### PR TITLE
Fix player count selection matching wrong element (Issue #105)

### DIFF
--- a/app/providers/wait_helper.py
+++ b/app/providers/wait_helper.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.chrome.webdriver import WebDriver
+from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -48,7 +49,7 @@ class WaitStrategy:
 
     def wait_for_element(
         self,
-        driver: WebDriver,
+        driver: WebDriver | WebElement,
         locator: tuple[str, str],
         fixed_duration: float,
         timeout: float = 10.0,
@@ -58,7 +59,9 @@ class WaitStrategy:
         Wait for an element based on the configured wait mode.
 
         Args:
-            driver: The WebDriver instance
+            driver: The WebDriver or WebElement instance to search within.
+                    WebDriverWait accepts WebElement at runtime (Selenium #13087)
+                    for scoped searches (e.g., within a modal).
             locator: Tuple of (By.*, selector) for the element
             fixed_duration: Duration to sleep in FIXED mode
             timeout: Maximum wait time for WebDriverWait in EVENT_DRIVEN/HYBRID modes

--- a/app/providers/walden_dom_schema.py
+++ b/app/providers/walden_dom_schema.py
@@ -216,8 +216,10 @@ class BookingModalSelectors:
     """
 
     # Modal/dialog container (wait for any of these after clicking Reserve)
+    # Narrowed to PrimeFaces-specific selectors to avoid false positives
     modal_container: str = (
-        ".modal, .dialog, [class*='popup'], form[class*='booking'], [class*='confirm']"
+        ".ui-dialog, .ui-overlay-panel, [class*='booking-dialog'], "
+        "form[class*='booking'], [class*='confirm']"
     )
 
 
@@ -325,10 +327,8 @@ class BookingCompletionSelectors:
 
     # Book Now button by ID (preferred, most specific)
     book_now_by_id: str = "a[id*='bookTeeTimeAction']"
-    # Book Now button wait selector (includes text-based fallback)
-    book_now_wait: str = (
-        "a[id*='bookTeeTimeAction'], a:contains('Book Now'), button:contains('Book')"
-    )
+    # Book Now button wait selector (ID-based only; text matching uses XPath fallbacks)
+    book_now_wait: str = "a[id*='bookTeeTimeAction']"
     # Book Now button XPath fallbacks
     book_now_xpaths: tuple[str, ...] = (
         "//a[contains(., 'Book Now')]",

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -23,6 +23,7 @@ from selenium.common.exceptions import (
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import Select, WebDriverWait
 from webdriver_manager.chrome import ChromeDriverManager
@@ -3440,10 +3441,10 @@ class WaldenGolfProvider(ReservationProvider):
             # on the underlying tee sheet page (e.g., the time period filter's
             # .ui-selectonebutton matching instead of the player count buttons).
             # See Issue #105.
-            booking_context = driver  # default: full page
+            booking_context: webdriver.Chrome | WebElement = driver  # default: full page
             try:
                 modal_element = wait.until(
-                    expected_conditions.presence_of_element_located(
+                    expected_conditions.visibility_of_element_located(
                         (By.CSS_SELECTOR, DOM.BOOKING_MODAL.modal_container)
                     )
                 )

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -1129,7 +1129,7 @@ class TestPlayerCountModalScoping:
 
         # Make the WebDriverWait return values for each .until() call:
         # 1. element_to_be_clickable (reserve button check)
-        # 2. presence_of_element_located (modal detection)
+        # 2. visibility_of_element_located (modal detection)
         # 3+ any remaining calls (Book Now wait, url_changes, success indicators, etc.)
         with patch("app.providers.walden_provider.WebDriverWait") as mock_wait_cls:
             mock_wait_instance = MagicMock()


### PR DESCRIPTION
Extract centralized DOM schema and fix modal context scoping so player count selection searches within the booking modal instead of the full page. The generic .ui-selectonebutton selector was matching the time period filter (ALL/MORNING/AFTERNOON/AVAILABLE) rather than the player count button group.

- Create walden_dom_schema.py with frozen dataclass selector groups
- Add search_context parameter to _select_player_count_sync and _add_tbd_registered_guests_sync for modal-scoped element search
- Capture modal element in _complete_booking_sync and pass downstream
- Replace major inline selectors with schema references
- Add tests for modal scoping and schema validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured internal element identification system for improved code maintainability and consistency across booking workflows.

* **Tests**
  * Added comprehensive test coverage for modal interactions and context-scoped element searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->