### PR TITLE
refactor: centralize timezone handling in app/utils/timezone.py

### DIFF
--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -10,7 +10,6 @@ import asyncio
 import logging
 from datetime import date, datetime, time
 from enum import Enum
-from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from google.auth import exceptions as google_auth_exceptions
@@ -21,6 +20,7 @@ from pydantic import BaseModel
 from app.config import settings
 from app.services.booking_service import booking_service
 from app.services.sms_service import sms_service
+from app.utils.timezone import CTDateTime
 
 logger = logging.getLogger(__name__)
 
@@ -169,8 +169,7 @@ async def execute_due_bookings(
     Idempotency: Bookings are transitioned to IN_PROGRESS before execution,
     so retries will not re-execute already-started bookings.
     """
-    tz = ZoneInfo(settings.timezone)
-    now = datetime.now(tz)
+    now = CTDateTime.now()
 
     # Calculate the booking window open time (6:30am CT)
     # We query for bookings due at this time, not "now", because the scheduler
@@ -200,7 +199,7 @@ async def execute_due_bookings(
     booking_map = {b.id: b for b in due_bookings if b.id is not None}
 
     # Strip timezone for passing to batch booking (expects naive datetime in CT)
-    booking_open_time_naive = booking_open_time.replace(tzinfo=None)
+    booking_open_time_naive = CTDateTime.to_naive_ct(booking_open_time)
 
     logger.info(
         f"BATCH_JOB: Booking window opens at {booking_open_time.strftime('%H:%M:%S')}, "

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -7,7 +7,6 @@ import time as time_module
 from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from typing import Any, TypeVar
-from zoneinfo import ZoneInfo
 
 import google.auth
 import httpx
@@ -38,6 +37,7 @@ from app.providers.base import (
 )
 from app.providers.wait_helper import WaitStrategy
 from app.providers.walden_dom_schema import DOM
+from app.utils.timezone import CTDateTime
 
 logger = logging.getLogger(__name__)
 
@@ -2764,11 +2764,9 @@ class WaldenGolfProvider(ReservationProvider):
             execute_at: Datetime in CT timezone to wait until. May be naive
                 (assumed CT) or timezone-aware (converted to naive CT).
         """
-        ct_tz = ZoneInfo(settings.timezone)
         # Normalize: convert aware datetimes to naive CT so comparisons are consistent
-        if execute_at.tzinfo is not None:
-            execute_at = execute_at.astimezone(ct_tz).replace(tzinfo=None)
-        now_ct = datetime.now(ct_tz).replace(tzinfo=None)
+        execute_at = CTDateTime.to_naive_ct(execute_at)
+        now_ct = CTDateTime.to_naive_ct(CTDateTime.now())
         if now_ct >= execute_at:
             logger.warning(
                 f"BATCH_BOOKING: Already past execute_at "
@@ -2788,7 +2786,7 @@ class WaldenGolfProvider(ReservationProvider):
 
         # Precision busy-wait for the final ~200ms
         # Sub-millisecond sleep reduces CPU pressure with negligible precision loss
-        while datetime.now(ct_tz).replace(tzinfo=None) < execute_at:
+        while CTDateTime.to_naive_ct(CTDateTime.now()) < execute_at:
             time_module.sleep(0.0001)
 
         logger.info("BATCH_BOOKING: Precision wait complete - GO!")

--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -7,7 +7,6 @@ processing booking requests, and executing reservations at the scheduled time.
 
 import uuid
 from datetime import UTC, date, datetime, timedelta
-from zoneinfo import ZoneInfo
 
 from app.config import settings
 from app.models.schemas import (
@@ -22,6 +21,7 @@ from app.providers.base import BatchBookingRequest, BookingResult, ReservationPr
 from app.services.database_service import database_service
 from app.services.gemini_service import gemini_service
 from app.services.sms_service import sms_service
+from app.utils.timezone import CTDateTime
 
 
 class BookingService:
@@ -558,12 +558,11 @@ class BookingService:
         """
         # Check 48-hour restriction for multi-player bookings
         if request.num_players > 1:
-            tz = ZoneInfo(settings.timezone)
-            now_ct = datetime.now(tz)
+            now_ct = CTDateTime.now()
 
-            # Combine requested date and time into a timezone-aware datetime
+            # Combine requested date and time into a timezone-aware CT datetime
             tee_time_naive = datetime.combine(request.requested_date, request.requested_time)
-            tee_time_ct = tee_time_naive.replace(tzinfo=tz)
+            tee_time_ct = CTDateTime.from_naive_ct(tee_time_naive)
 
             hours_until_tee_time = (tee_time_ct - now_ct).total_seconds() / 3600
 
@@ -591,14 +590,9 @@ class BookingService:
 
         # Compare in timezone-aware space for robustness.
         # execution_time is naive (CT wall-clock), so we localize it.
-        # This approach is safe even if _calculate_execution_time() is later
-        # changed to return an aware datetime.
-        tz = ZoneInfo(settings.timezone)
-        now_ct = datetime.now(tz)
-        if execution_time.tzinfo is None:
-            exec_ct = execution_time.replace(tzinfo=tz)
-        else:
-            exec_ct = execution_time.astimezone(tz)
+        # normalize_to_ct handles both naive and aware inputs safely.
+        now_ct = CTDateTime.now()
+        exec_ct = CTDateTime.normalize_to_ct(execution_time)
 
         if exec_ct <= now_ct:
             booking_id_opt: str | None = created_booking.id
@@ -677,8 +671,6 @@ class BookingService:
         The timezone is used for DST-correct calculation but stripped
         before returning to match the database schema (timestamp without timezone).
         """
-        tz = ZoneInfo(settings.timezone)
-
         booking_open_date = target_date - timedelta(days=settings.days_in_advance)
 
         execution_time = datetime.combine(
@@ -688,11 +680,11 @@ class BookingService:
                 minute=settings.booking_open_minute,
                 second=0,
             ),
-        ).replace(tzinfo=tz)
+        ).replace(tzinfo=CTDateTime.CT_TZ)
 
         # Return naive datetime (strip timezone) for database storage
         # The value represents CT wall-clock time
-        return execution_time.replace(tzinfo=None)
+        return CTDateTime.to_naive_ct(execution_time)
 
     def _get_help_message(self) -> str:
         """Return a help message explaining how to use the booking service."""

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,0 +1,1 @@
+# app/utils package

--- a/app/utils/timezone.py
+++ b/app/utils/timezone.py
@@ -1,0 +1,143 @@
+"""
+Centralized timezone utility for Central Time (America/Chicago) operations.
+
+All timezone conversions in the application should go through CTDateTime to
+ensure consistency and avoid the class of bugs caused by scattered ZoneInfo
+lookups and naive/aware datetime mismatches.
+
+Design notes:
+- Database stores naive datetimes representing CT wall-clock time.
+- In-memory comparisons use timezone-aware CT datetimes.
+- Naive datetimes passed into CTDateTime are always assumed to be CT.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+_CT_TZ = ZoneInfo("America/Chicago")
+
+# Booking window: Cloud Scheduler triggers at 6:28am so the system can log in
+# before the reservation page opens at 6:30am. The window is considered "open"
+# from 6:28am until 6:35am to give a small buffer for retries.
+_BOOKING_WINDOW_START_HOUR = 6
+_BOOKING_WINDOW_START_MINUTE = 28
+_BOOKING_WINDOW_END_HOUR = 6
+_BOOKING_WINDOW_END_MINUTE = 35
+
+
+class CTDateTime:
+    """
+    Utility class for Central Time datetime operations.
+
+    All methods are class methods so this class can be used without
+    instantiation. The CT timezone is fixed to 'America/Chicago' and
+    handles DST transitions automatically via the zoneinfo stdlib module.
+    """
+
+    CT_TZ: ZoneInfo = _CT_TZ
+
+    @classmethod
+    def now(cls) -> datetime:
+        """
+        Return the current moment as a timezone-aware datetime in Central Time.
+
+        Returns:
+            A timezone-aware datetime in the America/Chicago timezone.
+        """
+        return datetime.now(cls.CT_TZ)
+
+    @classmethod
+    def to_naive_ct(cls, dt: datetime) -> datetime:
+        """
+        Convert any datetime to a naive CT datetime for database storage.
+
+        The database schema stores scheduled_execution_time as a timestamp
+        without timezone (naive). This method canonicalises any datetime
+        into that form by first converting aware datetimes to CT and then
+        stripping the tzinfo.
+
+        Args:
+            dt: A timezone-aware or naive datetime. If naive, it is assumed
+                to already represent CT wall-clock time and is returned
+                unchanged (only tzinfo is stripped if somehow present).
+
+        Returns:
+            A naive datetime whose value represents CT wall-clock time.
+        """
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(cls.CT_TZ)
+        return dt.replace(tzinfo=None)
+
+    @classmethod
+    def from_naive_ct(cls, dt: datetime) -> datetime:
+        """
+        Convert a naive CT datetime to a timezone-aware CT datetime.
+
+        Use this when retrieving naive datetimes from the database that are
+        known to represent CT wall-clock time and need to participate in
+        timezone-aware arithmetic or comparisons.
+
+        Args:
+            dt: A naive datetime whose value represents CT wall-clock time.
+
+        Returns:
+            A timezone-aware datetime in the America/Chicago timezone.
+
+        Raises:
+            ValueError: If ``dt`` is already timezone-aware.
+        """
+        if dt.tzinfo is not None:
+            raise ValueError(
+                f"from_naive_ct expects a naive datetime, got tzinfo={dt.tzinfo!r}"
+            )
+        return dt.replace(tzinfo=cls.CT_TZ)
+
+    @classmethod
+    def normalize_to_ct(cls, dt: datetime) -> datetime:
+        """
+        Return a timezone-aware CT datetime regardless of the input's tzinfo.
+
+        This is the safe "always works" conversion: if ``dt`` is already
+        timezone-aware it is converted to CT; if it is naive it is treated
+        as CT and has tzinfo attached.
+
+        Args:
+            dt: A timezone-aware or naive datetime.
+
+        Returns:
+            A timezone-aware datetime in the America/Chicago timezone.
+        """
+        if dt.tzinfo is not None:
+            return dt.astimezone(cls.CT_TZ)
+        return dt.replace(tzinfo=cls.CT_TZ)
+
+    @classmethod
+    def is_booking_window(cls, dt: datetime) -> bool:
+        """
+        Return True if ``dt`` falls within the 6:28–6:35 AM CT booking window.
+
+        The booking window begins at 6:28 AM (when Cloud Scheduler triggers)
+        and ends at 6:35 AM (a small buffer past the 6:30 AM reservation open
+        time). Both endpoints are inclusive.
+
+        Args:
+            dt: A timezone-aware or naive datetime to check. Naive datetimes
+                are treated as CT.
+
+        Returns:
+            True if the time component of ``dt`` (in CT) is in [6:28, 6:35].
+        """
+        ct_dt = cls.normalize_to_ct(dt)
+        window_start = ct_dt.replace(
+            hour=_BOOKING_WINDOW_START_HOUR,
+            minute=_BOOKING_WINDOW_START_MINUTE,
+            second=0,
+            microsecond=0,
+        )
+        window_end = ct_dt.replace(
+            hour=_BOOKING_WINDOW_END_HOUR,
+            minute=_BOOKING_WINDOW_END_MINUTE,
+            second=0,
+            microsecond=0,
+        )
+        return window_start <= ct_dt <= window_end

--- a/app/utils/timezone.py
+++ b/app/utils/timezone.py
@@ -87,9 +87,7 @@ class CTDateTime:
             ValueError: If ``dt`` is already timezone-aware.
         """
         if dt.tzinfo is not None:
-            raise ValueError(
-                f"from_naive_ct expects a naive datetime, got tzinfo={dt.tzinfo!r}"
-            )
+            raise ValueError(f"from_naive_ct expects a naive datetime, got tzinfo={dt.tzinfo!r}")
         return dt.replace(tzinfo=cls.CT_TZ)
 
     @classmethod

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -20,6 +20,7 @@ from app.models.schemas import (
 )
 from app.providers.base import BookingResult
 from app.services.booking_service import BookingService
+from app.utils.timezone import CTDateTime
 
 
 @pytest.fixture
@@ -117,12 +118,10 @@ class TestBookingServiceBookings:
 
             mock_db.create_booking = AsyncMock(side_effect=create_booking_side_effect)
 
-            with patch("app.services.booking_service.datetime") as mock_datetime:
+            with patch.object(CTDateTime, "now") as mock_ct_now:
                 tz = pytz.timezone("America/Chicago")
-                mock_now = datetime(2025, 12, 22, 10, 0)
-                mock_datetime.now.return_value = tz.localize(mock_now)
-                mock_datetime.combine = datetime.combine
-                mock_datetime.min = datetime.min
+                mock_now_value = datetime(2025, 12, 22, 10, 0)
+                mock_ct_now.return_value = tz.localize(mock_now_value)
 
                 booking = await booking_service.create_booking("+15551234567", future_request)
 
@@ -385,14 +384,12 @@ class TestBookingServiceImmediateExecution:
             with patch("app.services.booking_service.sms_service") as mock_sms:
                 mock_sms.send_booking_confirmation = AsyncMock()
 
-                with patch("app.services.booking_service.datetime") as mock_datetime:
+                with patch.object(CTDateTime, "now") as mock_ct_now:
                     tz = pytz.timezone("America/Chicago")
                     # Now is Dec 22 at 10:00 AM CT, execution time (6:30 AM) is in the past
                     # Tee time is Dec 29 at 8:00 AM CT, which is ~7 days away (over 48 hours)
-                    mock_now = datetime(2025, 12, 22, 10, 0)
-                    mock_datetime.now.return_value = tz.localize(mock_now)
-                    mock_datetime.combine = datetime.combine
-                    mock_datetime.min = datetime.min
+                    mock_now_value = datetime(2025, 12, 22, 10, 0)
+                    mock_ct_now.return_value = tz.localize(mock_now_value)
 
                     result = await booking_service.create_booking("+15551234567", past_request)
 
@@ -424,12 +421,10 @@ class TestBookingServiceImmediateExecution:
             mock_provider.book_tee_time = AsyncMock()
             booking_service.set_reservation_provider(mock_provider)
 
-            with patch("app.services.booking_service.datetime") as mock_datetime:
+            with patch.object(CTDateTime, "now") as mock_ct_now:
                 tz = pytz.timezone("America/Chicago")
-                mock_now = datetime(2025, 12, 20, 10, 0)
-                mock_datetime.now.return_value = tz.localize(mock_now)
-                mock_datetime.combine = datetime.combine
-                mock_datetime.min = datetime.min
+                mock_now_value = datetime(2025, 12, 20, 10, 0)
+                mock_ct_now.return_value = tz.localize(mock_now_value)
 
                 result = await booking_service.create_booking("+15551234567", future_request)
 
@@ -490,12 +485,10 @@ class TestBookingServiceImmediateExecution:
             with patch("app.services.booking_service.sms_service") as mock_sms:
                 mock_sms.send_booking_confirmation = AsyncMock()
 
-                with patch("app.services.booking_service.datetime") as mock_datetime:
+                with patch.object(CTDateTime, "now") as mock_ct_now:
                     tz = pytz.timezone("America/Chicago")
-                    mock_now = datetime(2025, 12, 22, 6, 30)
-                    mock_datetime.now.return_value = tz.localize(mock_now)
-                    mock_datetime.combine = datetime.combine
-                    mock_datetime.min = datetime.min
+                    mock_now_value = datetime(2025, 12, 22, 6, 30)
+                    mock_ct_now.return_value = tz.localize(mock_now_value)
 
                     result = await booking_service.create_booking("+15551234567", request)
 
@@ -668,12 +661,10 @@ class TestBookingServiceIntentHandling:
 
             mock_db.create_booking = AsyncMock(side_effect=create_booking_side_effect)
 
-            with patch("app.services.booking_service.datetime") as mock_datetime:
+            with patch.object(CTDateTime, "now") as mock_ct_now:
                 tz = pytz.timezone("America/Chicago")
-                mock_now = datetime(2025, 12, 22, 10, 0)
-                mock_datetime.now.return_value = tz.localize(mock_now)
-                mock_datetime.combine = datetime.combine
-                mock_datetime.min = datetime.min
+                mock_now_value = datetime(2025, 12, 22, 10, 0)
+                mock_ct_now.return_value = tz.localize(mock_now_value)
 
                 response = await booking_service._handle_confirm_intent(session)
 
@@ -1398,7 +1389,7 @@ class TestBookingService48HourRestriction:
 
         tz = pytz.timezone("America/Chicago")
         # Current time: Dec 23, 2025 at 10:00 AM CT
-        mock_now = tz.localize(datetime(2025, 12, 23, 10, 0))
+        mock_now_value = tz.localize(datetime(2025, 12, 23, 10, 0))
 
         # Request for Dec 24, 2025 at 8:00 AM CT (22 hours away - within 48 hours)
         request = TeeTimeRequest(
@@ -1408,9 +1399,8 @@ class TestBookingService48HourRestriction:
             fallback_window_minutes=30,
         )
 
-        with patch("app.services.booking_service.datetime") as mock_datetime:
-            mock_datetime.now.return_value = mock_now
-            mock_datetime.combine = datetime.combine
+        with patch.object(CTDateTime, "now") as mock_ct_now:
+            mock_ct_now.return_value = mock_now_value
 
             with pytest.raises(ValueError) as exc_info:
                 await booking_service.create_booking("+15551234567", request)
@@ -1429,7 +1419,7 @@ class TestBookingService48HourRestriction:
         # Current time: Dec 16, 2025 at 10:00 AM CT
         # Execution time for Dec 23 booking is Dec 16 at 6:30 AM CT (in the past)
         # But we mock "now" to be Dec 16 at 6:00 AM CT so execution is in the future
-        mock_now = tz.localize(datetime(2025, 12, 16, 6, 0))
+        mock_now_value = tz.localize(datetime(2025, 12, 16, 6, 0))
 
         # Request for Dec 17, 2025 at 8:00 AM CT (26 hours away - within 48 hours)
         # Execution time is Dec 10 at 6:30 AM CT (in the past relative to Dec 16)
@@ -1456,10 +1446,8 @@ class TestBookingService48HourRestriction:
 
             mock_db.create_booking = AsyncMock(side_effect=create_booking_side_effect)
 
-            with patch("app.services.booking_service.datetime") as mock_datetime:
-                mock_datetime.now.return_value = mock_now
-                mock_datetime.combine = datetime.combine
-                mock_datetime.min = datetime.min
+            with patch.object(CTDateTime, "now") as mock_ct_now:
+                mock_ct_now.return_value = mock_now_value
 
                 # Should not raise - single player is always allowed
                 booking = await booking_service.create_booking("+15551234567", request)
@@ -1475,7 +1463,7 @@ class TestBookingService48HourRestriction:
         tz = pytz.timezone("America/Chicago")
         # Current time: Dec 16, 2025 at 6:00 AM CT
         # This is before the execution time of Dec 16 at 6:30 AM CT
-        mock_now = tz.localize(datetime(2025, 12, 16, 6, 0))
+        mock_now_value = tz.localize(datetime(2025, 12, 16, 6, 0))
 
         # Request for Dec 23, 2025 at 8:00 AM CT (7+ days away, well over 48 hours)
         # Execution time is Dec 16 at 6:30 AM CT (30 min in future, so scheduled)
@@ -1493,10 +1481,8 @@ class TestBookingService48HourRestriction:
 
             mock_db.create_booking = AsyncMock(side_effect=create_booking_side_effect)
 
-            with patch("app.services.booking_service.datetime") as mock_datetime:
-                mock_datetime.now.return_value = mock_now
-                mock_datetime.combine = datetime.combine
-                mock_datetime.min = datetime.min
+            with patch.object(CTDateTime, "now") as mock_ct_now:
+                mock_ct_now.return_value = mock_now_value
 
                 # Should not raise - more than 48 hours away
                 booking = await booking_service.create_booking("+15551234567", request)
@@ -1510,7 +1496,7 @@ class TestBookingService48HourRestriction:
         import pytz
 
         tz = pytz.timezone("America/Chicago")
-        mock_now = tz.localize(datetime(2025, 12, 23, 10, 0))
+        mock_now_value = tz.localize(datetime(2025, 12, 23, 10, 0))
 
         # Request for Dec 24, 2025 at 8:00 AM CT (within 48 hours)
         request = TeeTimeRequest(
@@ -1520,9 +1506,8 @@ class TestBookingService48HourRestriction:
             fallback_window_minutes=30,
         )
 
-        with patch("app.services.booking_service.datetime") as mock_datetime:
-            mock_datetime.now.return_value = mock_now
-            mock_datetime.combine = datetime.combine
+        with patch.object(CTDateTime, "now") as mock_ct_now:
+            mock_ct_now.return_value = mock_now_value
 
             with pytest.raises(ValueError) as exc_info:
                 await booking_service.create_booking("+15551234567", request)
@@ -1538,7 +1523,7 @@ class TestBookingService48HourRestriction:
         import pytz
 
         tz = pytz.timezone("America/Chicago")
-        mock_now = tz.localize(datetime(2025, 12, 23, 10, 0))
+        mock_now_value = tz.localize(datetime(2025, 12, 23, 10, 0))
 
         # Session with pending request within 48 hours
         request = TeeTimeRequest(
@@ -1556,9 +1541,8 @@ class TestBookingService48HourRestriction:
         with patch("app.services.booking_service.database_service") as mock_db:
             mock_db.update_session = AsyncMock(return_value=session)
 
-            with patch("app.services.booking_service.datetime") as mock_datetime:
-                mock_datetime.now.return_value = mock_now
-                mock_datetime.combine = datetime.combine
+            with patch.object(CTDateTime, "now") as mock_ct_now:
+                mock_ct_now.return_value = mock_now_value
 
                 response = await booking_service._handle_confirm_intent(session)
 

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -1412,30 +1412,45 @@ class TestBookingService48HourRestriction:
     async def test_single_player_booking_allowed_within_48_hours(
         self, booking_service: BookingService
     ) -> None:
-        """Test that single-player bookings are allowed within 48 hours of tee time."""
+        """Test that single-player bookings are allowed within 48 hours of tee time.
+
+        This verifies the single-player carve-out: multi-player bookings within
+        48 hours of tee time are rejected, but single-player bookings are always
+        allowed regardless of timing.
+
+        We use a date where execution time is in the future (so booking is scheduled,
+        not executed immediately) but verify the 48-hour check doesn't apply to
+        single-player requests by using the same timing that would fail for
+        multi-player.
+        """
         import pytz
 
         tz = pytz.timezone("America/Chicago")
-        # Current time: Dec 16, 2025 at 10:00 AM CT
-        # Execution time for Dec 23 booking is Dec 16 at 6:30 AM CT (in the past)
-        # But we mock "now" to be Dec 16 at 6:00 AM CT so execution is in the future
-        mock_now_value = tz.localize(datetime(2025, 12, 16, 6, 0))
+        # Current time: Dec 16, 2025 at 6:00 AM CT (before execution time)
+        # Tee time: Dec 17, 2025 at 8:00 AM CT (26 hours away - within 48 hours)
+        # Execution time: Dec 10, 2025 at 6:30 AM CT (past, but we test the check)
+        #
+        # The 48-hour check happens before execution time calculation, so we need
+        # mock_now to be close enough to tee_time to trigger the 48-hour path.
+        # But execution time is based on requested_date - 7 days, not now.
+        #
+        # For Dec 17 tee time: execution = Dec 10 at 6:30 AM
+        # If now = Dec 16 at 6:00 AM, execution is in the past → immediate exec
+        # So let's use Dec 23 tee time with now = Dec 22 at 10 AM:
+        # - Tee time Dec 23 8:00 AM is 22 hours away (within 48h)
+        # - Execution Dec 16 6:30 AM is in past → immediate exec
+        # - But single player should bypass the 48h check entirely
+        #
+        # Actually, the simplest test: same timing as multi_player_rejected test
+        # but with num_players=1 - should NOT raise.
+        mock_now_value = tz.localize(datetime(2025, 12, 23, 10, 0))
 
-        # Request for Dec 17, 2025 at 8:00 AM CT (26 hours away - within 48 hours)
-        # Execution time is Dec 10 at 6:30 AM CT (in the past relative to Dec 16)
-        # So this will trigger immediate execution - let's use a different approach
-        # Use a date where execution time is in the future
-        # Request for Dec 23, 2025 at 8:00 AM CT
-        # Execution time is Dec 16 at 6:30 AM CT
-        # If now is Dec 16 at 6:00 AM CT, execution is 30 min in the future (scheduled)
-        # Tee time is Dec 23 at 8:00 AM CT, which is ~7 days away (not within 48 hours)
-        # Let's adjust: we want tee time within 48 hours but execution in future
-        # That's impossible since execution is 7 days before tee time
-        # So let's just test that single player doesn't raise, using a far future date
+        # Request for Dec 24, 2025 at 8:00 AM CT - 22 hours away (within 48 hours)
+        # This is the SAME timing that raises ValueError for multi-player
         request = TeeTimeRequest(
-            requested_date=date(2025, 12, 23),
+            requested_date=date(2025, 12, 24),
             requested_time=time(8, 0),
-            num_players=1,
+            num_players=1,  # Single player - should bypass 48-hour restriction
             fallback_window_minutes=30,
         )
 
@@ -1445,11 +1460,15 @@ class TestBookingService48HourRestriction:
                 return booking
 
             mock_db.create_booking = AsyncMock(side_effect=create_booking_side_effect)
+            mock_db.get_booking = AsyncMock(return_value=None)  # For execute path
+            mock_db.update_booking = AsyncMock(side_effect=create_booking_side_effect)
 
             with patch.object(CTDateTime, "now") as mock_ct_now:
                 mock_ct_now.return_value = mock_now_value
 
-                # Should not raise - single player is always allowed
+                # Should not raise ValueError - single player bypasses 48-hour restriction
+                # even though tee time is only 22 hours away (same timing that fails
+                # for multi-player in test_multi_player_booking_rejected_within_48_hours)
                 booking = await booking_service.create_booking("+15551234567", request)
                 assert booking.request.num_players == 1
 

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,245 @@
+"""
+Comprehensive unit tests for app/utils/timezone.py (CTDateTime).
+
+Tests cover:
+- now() returns timezone-aware CT datetime
+- to_naive_ct() strips tzinfo and converts to CT
+- from_naive_ct() attaches CT tzinfo to naive datetimes
+- normalize_to_ct() handles both aware and naive inputs
+- is_booking_window() correctly identifies the 6:28–6:35 AM window
+- DST boundary correctness
+- Round-trip consistency
+"""
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.utils.timezone import CTDateTime
+
+CT_TZ = ZoneInfo("America/Chicago")
+UTC_TZ = UTC
+
+
+# ---------------------------------------------------------------------------
+# now()
+# ---------------------------------------------------------------------------
+
+
+class TestNow:
+    def test_returns_aware_datetime(self) -> None:
+        dt = CTDateTime.now()
+        assert dt.tzinfo is not None
+
+    def test_returns_ct_timezone(self) -> None:
+        dt = CTDateTime.now()
+        # Normalize: zoneinfo returns the canonical zone key
+        assert dt.tzinfo == CT_TZ or str(dt.tzinfo) == "America/Chicago"
+
+    def test_close_to_real_time(self) -> None:
+        """now() should be within 2 seconds of the actual current time."""
+        import time as _time
+
+        before = datetime.now(CT_TZ)
+        _time.sleep(0)
+        ct_now = CTDateTime.now()
+        after = datetime.now(CT_TZ)
+        assert before <= ct_now <= after + timedelta(seconds=2)
+
+
+# ---------------------------------------------------------------------------
+# to_naive_ct()
+# ---------------------------------------------------------------------------
+
+
+class TestToNaiveCt:
+    def test_aware_ct_becomes_naive(self) -> None:
+        aware = datetime(2026, 6, 15, 10, 30, 0, tzinfo=CT_TZ)
+        naive = CTDateTime.to_naive_ct(aware)
+        assert naive.tzinfo is None
+        assert naive == datetime(2026, 6, 15, 10, 30, 0)
+
+    def test_aware_utc_converts_to_ct(self) -> None:
+        # 2026-06-15 15:00 UTC == 2026-06-15 10:00 CDT (UTC-5)
+        aware_utc = datetime(2026, 6, 15, 15, 0, 0, tzinfo=UTC_TZ)
+        naive = CTDateTime.to_naive_ct(aware_utc)
+        assert naive.tzinfo is None
+        assert naive == datetime(2026, 6, 15, 10, 0, 0)
+
+    def test_aware_utc_winter_converts_to_cst(self) -> None:
+        # 2026-01-15 12:00 UTC == 2026-01-15 06:00 CST (UTC-6)
+        aware_utc = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC_TZ)
+        naive = CTDateTime.to_naive_ct(aware_utc)
+        assert naive.tzinfo is None
+        assert naive == datetime(2026, 1, 15, 6, 0, 0)
+
+    def test_naive_input_passthrough(self) -> None:
+        """Naive datetimes (assumed CT) are returned with tzinfo stripped (no-op)."""
+        naive_input = datetime(2026, 3, 10, 8, 0, 0)
+        result = CTDateTime.to_naive_ct(naive_input)
+        assert result.tzinfo is None
+        assert result == naive_input
+
+    def test_already_naive_no_change(self) -> None:
+        dt = datetime(2026, 7, 4, 6, 30, 0)
+        assert CTDateTime.to_naive_ct(dt) == dt
+
+
+# ---------------------------------------------------------------------------
+# from_naive_ct()
+# ---------------------------------------------------------------------------
+
+
+class TestFromNaiveCt:
+    def test_attaches_ct_tzinfo(self) -> None:
+        naive = datetime(2026, 6, 15, 10, 30, 0)
+        aware = CTDateTime.from_naive_ct(naive)
+        assert aware.tzinfo is not None
+        assert aware.tzinfo == CT_TZ or str(aware.tzinfo) == "America/Chicago"
+
+    def test_value_unchanged(self) -> None:
+        naive = datetime(2026, 6, 15, 10, 30, 0)
+        aware = CTDateTime.from_naive_ct(naive)
+        assert aware.replace(tzinfo=None) == naive
+
+    def test_raises_if_already_aware(self) -> None:
+        aware = datetime(2026, 6, 15, 10, 30, 0, tzinfo=CT_TZ)
+        with pytest.raises(ValueError, match="from_naive_ct expects a naive datetime"):
+            CTDateTime.from_naive_ct(aware)
+
+    def test_raises_for_utc_aware(self) -> None:
+        aware_utc = datetime(2026, 6, 15, 10, 30, 0, tzinfo=UTC_TZ)
+        with pytest.raises(ValueError):
+            CTDateTime.from_naive_ct(aware_utc)
+
+
+# ---------------------------------------------------------------------------
+# normalize_to_ct()
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeToCt:
+    def test_naive_gets_ct_attached(self) -> None:
+        naive = datetime(2026, 6, 15, 10, 30, 0)
+        result = CTDateTime.normalize_to_ct(naive)
+        assert result.tzinfo is not None
+        assert result.replace(tzinfo=None) == naive
+
+    def test_aware_ct_unchanged(self) -> None:
+        aware = datetime(2026, 6, 15, 10, 30, 0, tzinfo=CT_TZ)
+        result = CTDateTime.normalize_to_ct(aware)
+        assert result == aware
+
+    def test_aware_utc_converted_to_ct(self) -> None:
+        # 2026-06-15 15:00 UTC == 2026-06-15 10:00 CDT
+        aware_utc = datetime(2026, 6, 15, 15, 0, 0, tzinfo=UTC_TZ)
+        result = CTDateTime.normalize_to_ct(aware_utc)
+        assert result.tzinfo is not None
+        assert result.replace(tzinfo=None) == datetime(2026, 6, 15, 10, 0, 0)
+
+    def test_always_returns_aware(self) -> None:
+        for dt in [
+            datetime(2026, 1, 1, 0, 0, 0),
+            datetime(2026, 7, 1, 12, 0, 0, tzinfo=UTC_TZ),
+            datetime(2026, 12, 31, 23, 59, 59, tzinfo=CT_TZ),
+        ]:
+            result = CTDateTime.normalize_to_ct(dt)
+            assert result.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# is_booking_window()
+# ---------------------------------------------------------------------------
+
+
+class TestIsBookingWindow:
+    # Helper: build a naive CT datetime at a given H:M:S
+    @staticmethod
+    def _ct(hour: int, minute: int, second: int = 0) -> datetime:
+        return datetime(2026, 7, 4, hour, minute, second)
+
+    def test_before_window(self) -> None:
+        assert not CTDateTime.is_booking_window(self._ct(6, 27, 59))
+
+    def test_window_start_inclusive(self) -> None:
+        assert CTDateTime.is_booking_window(self._ct(6, 28, 0))
+
+    def test_inside_window(self) -> None:
+        assert CTDateTime.is_booking_window(self._ct(6, 30, 0))
+
+    def test_window_end_inclusive(self) -> None:
+        assert CTDateTime.is_booking_window(self._ct(6, 35, 0))
+
+    def test_after_window(self) -> None:
+        assert not CTDateTime.is_booking_window(self._ct(6, 35, 1))
+
+    def test_much_earlier(self) -> None:
+        assert not CTDateTime.is_booking_window(self._ct(0, 0, 0))
+
+    def test_much_later(self) -> None:
+        assert not CTDateTime.is_booking_window(self._ct(12, 0, 0))
+
+    def test_aware_ct_datetime(self) -> None:
+        aware = datetime(2026, 7, 4, 6, 30, 0, tzinfo=CT_TZ)
+        assert CTDateTime.is_booking_window(aware)
+
+    def test_aware_utc_in_window(self) -> None:
+        # 6:30 CDT == 11:30 UTC (summer, UTC-5)
+        aware_utc = datetime(2026, 7, 4, 11, 30, 0, tzinfo=UTC_TZ)
+        assert CTDateTime.is_booking_window(aware_utc)
+
+    def test_aware_utc_outside_window(self) -> None:
+        # 7:00 CDT == 12:00 UTC (summer, UTC-5) – outside [6:28, 6:35]
+        aware_utc = datetime(2026, 7, 4, 12, 0, 0, tzinfo=UTC_TZ)
+        assert not CTDateTime.is_booking_window(aware_utc)
+
+
+# ---------------------------------------------------------------------------
+# DST boundary tests
+# ---------------------------------------------------------------------------
+
+
+class TestDstBoundaries:
+    def test_spring_forward_2026(self) -> None:
+        """2026-03-08 02:00 clocks spring forward to 03:00 (CDT starts)."""
+        # 2026-03-08 08:00 UTC == 2026-03-08 02:00 CST before transition
+        # but actually at spring forward UTC-6->UTC-5
+        # 2026-03-08 12:00 UTC == 2026-03-08 07:00 CDT (after transition)
+        aware_utc = datetime(2026, 3, 8, 12, 0, 0, tzinfo=UTC_TZ)
+        naive = CTDateTime.to_naive_ct(aware_utc)
+        # CDT = UTC-5 so 12:00 UTC = 07:00 CDT
+        assert naive == datetime(2026, 3, 8, 7, 0, 0)
+
+    def test_fall_back_2026(self) -> None:
+        """2026-11-01 02:00 clocks fall back to 01:00 (CST starts)."""
+        # 2026-11-01 07:00 UTC == 2026-11-01 01:00 CST (UTC-6, after fallback)
+        aware_utc = datetime(2026, 11, 1, 7, 0, 0, tzinfo=UTC_TZ)
+        naive = CTDateTime.to_naive_ct(aware_utc)
+        # CST = UTC-6 so 07:00 UTC = 01:00 CST
+        assert naive == datetime(2026, 11, 1, 1, 0, 0)
+
+    def test_round_trip_naive_summer(self) -> None:
+        naive = datetime(2026, 7, 4, 6, 30, 0)
+        aware = CTDateTime.from_naive_ct(naive)
+        back = CTDateTime.to_naive_ct(aware)
+        assert back == naive
+
+    def test_round_trip_naive_winter(self) -> None:
+        naive = datetime(2026, 1, 15, 6, 30, 0)
+        aware = CTDateTime.from_naive_ct(naive)
+        back = CTDateTime.to_naive_ct(aware)
+        assert back == naive
+
+
+# ---------------------------------------------------------------------------
+# CT_TZ class attribute
+# ---------------------------------------------------------------------------
+
+
+class TestCtTzAttribute:
+    def test_is_america_chicago(self) -> None:
+        assert str(CTDateTime.CT_TZ) == "America/Chicago"
+
+    def test_is_zoneinfo_instance(self) -> None:
+        assert isinstance(CTDateTime.CT_TZ, ZoneInfo)

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -1589,11 +1589,10 @@ class TestPrecisionWait:
         # execute_at is 1 hour ago
         past_time = datetime(2026, 2, 12, 5, 30, 0)
 
-        with mock_patch("app.providers.walden_provider.datetime") as mock_datetime:
-            mock_datetime.now.return_value = datetime(
+        with mock_patch.object(CTDateTime, "now") as mock_ct_now:
+            mock_ct_now.return_value = datetime(
                 2026, 2, 12, 6, 30, 0, tzinfo=ZoneInfo("America/Chicago")
             )
-            mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
             # Should not raise or hang
             provider._precision_wait_until(past_time)
 

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.providers.walden_provider import WaldenGolfProvider
+from app.utils.timezone import CTDateTime
 
 
 @pytest.fixture
@@ -1624,10 +1625,8 @@ class TestPrecisionWait:
             # After sleep, return time past execute_at to exit busy-wait
             return real_datetime(2026, 2, 12, 6, 30, 0, 1000, tzinfo=ZoneInfo("America/Chicago"))
 
-        with mock_patch("app.providers.walden_provider.datetime") as mock_dt:
-            mock_dt.now = mock_now
-            # Route strftime and other calls through real datetime
-            mock_dt.side_effect = lambda *args, **kwargs: real_datetime(*args, **kwargs)
+        with mock_patch.object(CTDateTime, "now") as mock_ct_now:
+            mock_ct_now.side_effect = mock_now
 
             execute_at = real_datetime(2026, 2, 12, 6, 30, 0)
             provider._precision_wait_until(execute_at)


### PR DESCRIPTION
## Summary

Create `CTDateTime` utility class to centralize all timezone handling in Central Time (America/Chicago).

## Problem

The architecture review (docs/architecture-review-2026-02-01.md) identified scattered timezone handling as a recurring bug source (~25% of recent bugs). Timezone conversions were scattered across `booking_service.py`, `walden_provider.py`, and `jobs.py` with no single source of truth.

## Solution

New `app/utils/timezone.py` module with `CTDateTime` class providing:

- `now()` → timezone-aware datetime in CT
- `to_naive_ct()` → convert any datetime to naive CT for database storage
- `from_naive_ct()` → convert naive CT datetime to timezone-aware
- `normalize_to_ct()` → safely handle both naive and aware inputs
- `is_booking_window()` → check if time is in 6:28–6:35 AM booking window

All scattered timezone conversions migrated to use this utility.

## Testing

- 32 new unit tests for `CTDateTime` covering:
  - Basic functionality
  - DST boundary handling (spring forward, fall back 2026)
  - Round-trip consistency
  - Booking window detection
- All existing tests updated to mock `CTDateTime.now()` instead of `datetime.now()`
- Full test suite: **471 passed**, 3 skipped, 0 failures
- `ruff check`: clean
- `mypy`: no issues

## Changes

| File | Change |
|------|--------|
| `app/utils/timezone.py` | New module with `CTDateTime` utility |
| `app/utils/__init__.py` | Package init |
| `tests/test_timezone.py` | 32 unit tests |
| `app/services/booking_service.py` | Migrated to `CTDateTime` |
| `app/providers/walden_provider.py` | Migrated to `CTDateTime` |
| `tests/test_booking_service.py` | Updated mocks |
| `tests/test_walden_provider.py` | Updated mocks |

## Related

Addresses findings from docs/architecture-review-2026-02-01.md regarding timezone handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized Central Time handling across booking and scheduling for more reliable time comparisons and execution.
  * Introduced centralized CT datetime utilities for consistent timezone conversions.

* **Bug Fixes**
  * Improved accuracy of booking-window checks and 48-hour restriction timing to reduce timing-related booking errors.
  * Made scheduling precision checks more robust around execution boundaries.

* **Tests**
  * Added and updated tests validating Central Time behavior and scheduling precision.

* **Chores**
  * Enabled utils package imports with a package initializer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->