### PR TITLE
feat: ultra-fast booking chain to win 6:30 AM race

### DIFF
--- a/app/providers/walden_dom_schema.py
+++ b/app/providers/walden_dom_schema.py
@@ -347,6 +347,30 @@ class BookingCompletionSelectors:
 
 
 @dataclass(frozen=True)
+class SlotBlockedSelectors:
+    """Selectors for the 'slot blocked by another user' popup.
+
+    When another user grabs a slot at exactly the same moment, the Walden site
+    shows a teeSheetValidationErrorPopup dialog instead of opening the booking
+    modal. Detecting this popup allows the booking flow to fail fast and retry
+    the next slot instead of timing out on stale element references.
+    """
+
+    # The popup container (hidden by default, shown on conflict)
+    popup_container: str = "div[id*='teeSheetValidationErrorPopup']"
+    # Popup visibility check (aria-hidden becomes 'false' when shown)
+    popup_visible: str = "div[id*='teeSheetValidationErrorPopup'][aria-hidden='false']"
+    # The OK button to dismiss the popup
+    ok_button: str = "a[id*='j_idt1076'], .dialogOKBtn"
+    # Error text patterns that indicate a blocked slot
+    blocked_text_patterns: tuple[str, ...] = (
+        "blocked by another user",
+        "slot is blocked",
+        "already reserved",
+    )
+
+
+@dataclass(frozen=True)
 class ErrorMessageSelectors:
     """Selectors for error/alert message containers."""
 
@@ -440,6 +464,7 @@ class WaldenDOMSchema:
     PLAYER_COUNT: PlayerCountSelectors = PlayerCountSelectors()
     TBD_GUESTS: TBDGuestSelectors = TBDGuestSelectors()
     BOOKING_COMPLETION: BookingCompletionSelectors = BookingCompletionSelectors()
+    SLOT_BLOCKED: SlotBlockedSelectors = SlotBlockedSelectors()
     ERROR_MESSAGES: ErrorMessageSelectors = ErrorMessageSelectors()
     CANCELLATION: CancellationSelectors = CancellationSelectors()
     COURSE_FILTERING: CourseFilteringSelectors = CourseFilteringSelectors()

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -2335,7 +2335,37 @@ class WaldenGolfProvider(ReservationProvider):
                     course_name=self.NORTHGATE_COURSE_NAME,
                 )
 
-            # Fast chain succeeded - verify and extract confirmation
+            # Fast chain succeeded - wait briefly for page to settle after Book Now click
+            # The JS chain clicked Book Now but the page may still be processing
+            try:
+                # Wait for either URL change or success indicators
+                wait = WebDriverWait(driver, 5)
+                try:
+                    # First check if URL changed (common for successful bookings)
+                    wait.until(
+                        lambda d: "confirmation" in d.current_url.lower()
+                        or "success" in d.current_url.lower()
+                        or "thank" in d.current_url.lower()
+                    )
+                except TimeoutException:
+                    # URL didn't change, try waiting for success text on page
+                    try:
+                        wait.until(
+                            expected_conditions.presence_of_element_located(
+                                (
+                                    By.XPATH,
+                                    "//*[contains(text(), 'success') or "
+                                    "contains(text(), 'confirm') or "
+                                    "contains(text(), 'thank')]",
+                                )
+                            )
+                        )
+                    except TimeoutException:
+                        # No explicit success indicator, proceed with verification
+                        pass
+            except Exception as e:
+                logger.debug(f"FAST_BOOKING: Post-chain wait exception (non-fatal): {e}")
+
             confirmation_number = self._extract_confirmation_number(driver)
             if self._verify_booking_success(driver):
                 return BookingResult(
@@ -2898,8 +2928,24 @@ class WaldenGolfProvider(ReservationProvider):
         );
 
         if (blockedPopup) {
-            result.blocked = true;
-            result.error = 'Slot blocked by another user';
+            // Check popup text against known blocked-slot patterns
+            var blockedPatterns = arguments[8];  // Array of substrings
+            var popupText = (blockedPopup.textContent || '').toLowerCase();
+            var isBlockedSlot = false;
+            for (var p = 0; p < blockedPatterns.length; p++) {
+                if (popupText.indexOf(blockedPatterns[p].toLowerCase()) !== -1) {
+                    isBlockedSlot = true;
+                    break;
+                }
+            }
+
+            if (isBlockedSlot) {
+                result.blocked = true;
+                result.error = 'Slot blocked by another user';
+            } else {
+                // Generic validation error, not specifically blocked
+                result.error = 'Validation error: ' + popupText.substring(0, 100);
+            }
             result.timing.blockedDetected = Date.now() - startTime;
             // Try to dismiss the popup
             var okBtn = blockedPopup.querySelector('a.dialogOKBtn, a[id*="j_idt1076"]');
@@ -2973,11 +3019,29 @@ class WaldenGolfProvider(ReservationProvider):
             result.timing.playerRowsFound = Date.now() - startTime;
 
             // Click TBD button on each guest row (skip first row = member)
-            for (var r = 1; r < playerRows.length && tbdClicked < numTbd; r++) {
-                var row = playerRows[r];
+            // Re-query rows on each iteration to avoid stale references after AJAX
+            while (tbdClicked < numTbd) {
+                // Fresh query for player rows each iteration
+                var currentRows = document.querySelectorAll('[id*="playersTable"] tbody tr[data-ri]');
+                if (currentRows.length === 0) {
+                    currentRows = document.querySelectorAll('table[id*="player"] tbody tr');
+                }
+                if (currentRows.length <= 1) {
+                    result.error = 'Player rows disappeared while clicking TBD buttons';
+                    return result;
+                }
+
+                // Find the next guest row (skip member row at index 0)
+                var guestIndex = tbdClicked + 1;  // 1-indexed for guests
+                if (guestIndex >= currentRows.length) {
+                    result.error = 'Not enough player rows for TBD guests';
+                    return result;
+                }
+
+                var row = currentRows[guestIndex];
                 var tbd = row.querySelector('a[id*="tbd"], span[id*="tbd"], a.ui-commandlink');
                 if (!tbd) {
-                    // Try XPath-style search
+                    // Try text-based search
                     var links = row.querySelectorAll('a');
                     for (var l = 0; l < links.length; l++) {
                         if (links[l].textContent && links[l].textContent.toUpperCase().indexOf('TBD') !== -1) {
@@ -2989,9 +3053,13 @@ class WaldenGolfProvider(ReservationProvider):
                 if (tbd) {
                     tbd.click();
                     tbdClicked++;
-                    // Brief wait for AJAX
+                    // Brief wait for AJAX to update DOM
                     var waitUntil = Date.now() + 200;
                     while (Date.now() < waitUntil) { /* spin */ }
+                } else {
+                    // TBD button not found on this row, might already be filled
+                    result.error = 'TBD button not found on guest row ' + guestIndex;
+                    return result;
                 }
             }
 
@@ -3052,12 +3120,16 @@ class WaldenGolfProvider(ReservationProvider):
             f"{num_players} players"
         )
 
+        # Convert blocked patterns tuple to list for JSON serialization
+        blocked_patterns = list(DOM.SLOT_BLOCKED.blocked_text_patterns)
+
         result: dict[str, Any] = driver.execute_script(
             js_fast_chain,
             slot_index,
             num_players,
             max_wait_ms,
             poll_interval_ms,
+            blocked_patterns,
         )
 
         timing = result.get("timing", {})
@@ -3077,30 +3149,46 @@ class WaldenGolfProvider(ReservationProvider):
         This is a fallback check used by the Python-based booking flow.
         The fast JS chain has its own inline check.
 
+        Only returns True if the popup text matches one of the known
+        blocked_text_patterns. Other validation errors are logged but
+        not treated as blocked slots.
+
         Args:
             driver: The WebDriver instance
 
         Returns:
-            True if the blocked popup is visible, False otherwise
+            True if the blocked popup is visible AND contains blocked-slot text,
+            False otherwise
         """
         try:
             popup = driver.find_element(By.CSS_SELECTOR, DOM.SLOT_BLOCKED.popup_visible)
             if popup.is_displayed():
-                logger.warning("BOOKING_DEBUG: Slot blocked popup detected")
-                # Try to extract the error message
-                try:
-                    label = popup.find_element(By.TAG_NAME, "label")
-                    logger.warning(f"BOOKING_DEBUG: Blocked popup text: {label.text}")
-                except NoSuchElementException:
-                    pass
-                # Try to dismiss the popup
+                # Extract popup text
+                popup_text = popup.text.lower() if popup.text else ""
+                logger.warning(
+                    f"BOOKING_DEBUG: Validation popup detected, text: {popup_text[:100]}"
+                )
+
+                # Check if text matches blocked-slot patterns
+                is_blocked = any(
+                    pattern.lower() in popup_text
+                    for pattern in DOM.SLOT_BLOCKED.blocked_text_patterns
+                )
+
+                # Try to dismiss the popup regardless
                 try:
                     ok_btn = popup.find_element(By.CSS_SELECTOR, DOM.SLOT_BLOCKED.ok_button)
                     ok_btn.click()
-                    logger.debug("BOOKING_DEBUG: Dismissed blocked popup")
+                    logger.debug("BOOKING_DEBUG: Dismissed validation popup")
                 except NoSuchElementException:
                     pass
-                return True
+
+                if is_blocked:
+                    logger.warning("BOOKING_DEBUG: Popup matches blocked-slot pattern")
+                    return True
+                else:
+                    logger.warning("BOOKING_DEBUG: Popup is generic validation error, not blocked")
+                    return False
         except NoSuchElementException:
             pass
         return False

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -2297,13 +2297,6 @@ class WaldenGolfProvider(ReservationProvider):
             booked_time = time(slot_info["hours"], slot_info["minutes"])
             is_exact = slot_info["isExact"]
 
-            if not self._click_slot_by_index_js(driver, slot_info["index"]):
-                return BookingResult(
-                    success=False,
-                    error_message="Failed to click Reserve button via JavaScript",
-                    booked_time=booked_time,
-                )
-
             fallback_reason = None
             if not is_exact:
                 fallback_reason = (
@@ -2311,16 +2304,60 @@ class WaldenGolfProvider(ReservationProvider):
                     f"using {booked_time.strftime('%I:%M %p')}"
                 )
 
-            result = self._complete_booking_sync(
+            # === ULTRA-FAST PATH: Execute entire booking flow in rapid JS sequence ===
+            # This replaces: _click_slot_by_index_js + _complete_booking_sync
+            # with a single JS execution that does Reserve → player count → TBD → Book Now
+            # in under 2 seconds instead of 7-15 seconds.
+            chain_result = self._execute_fast_booking_chain_js(
                 driver,
-                None,
-                booked_time,
+                slot_info["index"],
                 num_players,
-                fallback_reason,
-                already_clicked=True,
             )
-            result.course_name = self.NORTHGATE_COURSE_NAME
-            return result
+
+            if chain_result.get("blocked"):
+                # Slot was grabbed by another user at the same moment
+                self._capture_diagnostic_info(driver, "slot_blocked_by_other_user")
+                return BookingResult(
+                    success=False,
+                    error_message="Slot blocked by another user",
+                    booked_time=booked_time,
+                    course_name=self.NORTHGATE_COURSE_NAME,
+                )
+
+            if not chain_result.get("success"):
+                phase = chain_result.get("phase", "unknown")
+                error = chain_result.get("error", "Unknown error in fast booking chain")
+                self._capture_diagnostic_info(driver, f"fast_chain_failed_{phase}")
+                return BookingResult(
+                    success=False,
+                    error_message=f"Fast booking failed at {phase}: {error}",
+                    booked_time=booked_time,
+                    course_name=self.NORTHGATE_COURSE_NAME,
+                )
+
+            # Fast chain succeeded - verify and extract confirmation
+            confirmation_number = self._extract_confirmation_number(driver)
+            if self._verify_booking_success(driver):
+                return BookingResult(
+                    success=True,
+                    booked_time=booked_time,
+                    confirmation_number=confirmation_number,
+                    fallback_reason=fallback_reason,
+                    course_name=self.NORTHGATE_COURSE_NAME,
+                )
+            else:
+                # Fast chain reported success but verification failed
+                self._capture_diagnostic_info(driver, "fast_chain_verify_failed")
+                error_details = self._extract_booking_error_message(driver)
+                return BookingResult(
+                    success=False,
+                    error_message=(
+                        f"Fast booking chain completed but verification failed"
+                        f"{': ' + error_details if error_details else ''}"
+                    ),
+                    booked_time=booked_time,
+                    course_name=self.NORTHGATE_COURSE_NAME,
+                )
 
         # === EXISTING SLOW PATH (Python-based Selenium iteration) ===
 
@@ -2752,6 +2789,321 @@ class WaldenGolfProvider(ReservationProvider):
         else:
             logger.warning(f"BOOKING_DEBUG: JS failed to click Reserve at slot index {slot_index}")
         return bool(result)
+
+    def _execute_fast_booking_chain_js(
+        self,
+        driver: webdriver.Chrome,
+        slot_index: int,
+        num_players: int,
+    ) -> dict[str, Any]:
+        """
+        Execute the entire booking flow in a single rapid JS sequence.
+
+        This is the speed-critical path for winning the 6:30 AM race. Instead of:
+            1. Click Reserve → wait for modal (up to 10s)
+            2. Find player selector → click it → wait
+            3. Find TBD buttons → click each → wait
+            4. Find Book Now → click it
+
+        We execute a tight JS loop that:
+            1. Clicks Reserve
+            2. Polls for modal/player selector (sub-100ms intervals)
+            3. Clicks player count immediately when found
+            4. Polls for and clicks TBD buttons
+            5. Polls for and clicks Book Now
+
+        The entire sequence should complete in under 2 seconds if the slot
+        is available, vs 7-15 seconds with the Python-based flow.
+
+        Args:
+            driver: The WebDriver instance
+            slot_index: Index of the slot in the li.ui-datascroller-item NodeList
+            num_players: Number of players (1-4)
+
+        Returns:
+            Dict with result info:
+            - success: bool
+            - error: str (if failed)
+            - blocked: bool (if slot was grabbed by another user)
+            - phase: str (which phase completed/failed)
+        """
+        js_fast_chain = """
+        var slotIndex = arguments[0];
+        var numPlayers = arguments[1];
+        var maxWaitMs = arguments[2];
+        var pollIntervalMs = arguments[3];
+
+        var result = {
+            success: false,
+            error: null,
+            blocked: false,
+            phase: 'init',
+            timing: {}
+        };
+        var startTime = Date.now();
+
+        // Helper: poll for element with timeout
+        function pollFor(selectorOrFn, timeoutMs, desc) {
+            var deadline = Date.now() + timeoutMs;
+            while (Date.now() < deadline) {
+                var el = typeof selectorOrFn === 'function'
+                    ? selectorOrFn()
+                    : document.querySelector(selectorOrFn);
+                if (el) return el;
+                // Busy-wait with minimal delay (can't use setTimeout in sync JS)
+                var waitUntil = Date.now() + pollIntervalMs;
+                while (Date.now() < waitUntil) { /* spin */ }
+            }
+            return null;
+        }
+
+        // Phase 1: Click Reserve button
+        result.phase = 'reserve_click';
+        result.timing.reserveStart = Date.now() - startTime;
+
+        var items = document.querySelectorAll('li.ui-datascroller-item');
+        var item = items[slotIndex];
+        if (!item) {
+            result.error = 'Slot item not found at index ' + slotIndex;
+            return result;
+        }
+
+        var reserveBtn = item.querySelector("a[id*='reserve_button']");
+        if (!reserveBtn) {
+            var spans = item.querySelectorAll('span.custom-free-slot-span');
+            reserveBtn = spans.length > 0 ? spans[0] : null;
+        }
+        if (!reserveBtn) reserveBtn = item.querySelector("a.slot-link");
+        if (!reserveBtn) {
+            result.error = 'Reserve button not found in slot';
+            return result;
+        }
+
+        reserveBtn.scrollIntoView({block: 'center'});
+        reserveBtn.click();
+        result.timing.reserveClicked = Date.now() - startTime;
+
+        // Phase 2: Check for blocked-slot popup (fast check before waiting for modal)
+        result.phase = 'blocked_check';
+        var blockedPopup = pollFor(
+            function() {
+                var popup = document.querySelector("div[id*='teeSheetValidationErrorPopup']");
+                if (popup && popup.getAttribute('aria-hidden') === 'false') {
+                    return popup;
+                }
+                return null;
+            },
+            300,  // Only wait 300ms for blocked popup
+            'blocked popup'
+        );
+
+        if (blockedPopup) {
+            result.blocked = true;
+            result.error = 'Slot blocked by another user';
+            result.timing.blockedDetected = Date.now() - startTime;
+            // Try to dismiss the popup
+            var okBtn = blockedPopup.querySelector('a.dialogOKBtn, a[id*="j_idt1076"]');
+            if (okBtn) okBtn.click();
+            return result;
+        }
+
+        // Phase 3: Wait for player count selector to appear
+        result.phase = 'player_count_wait';
+        var playerSelector = pollFor(
+            function() {
+                // Look for the player count button group
+                // It has radio inputs with values 1,2,3,4 (not 0,1,2,3 like the time filter)
+                var groups = document.querySelectorAll('.ui-selectonebutton');
+                for (var i = 0; i < groups.length; i++) {
+                    var radio = groups[i].querySelector('input[type="radio"][value="' + numPlayers + '"]');
+                    if (radio) {
+                        // Verify this isn't the time filter (which has value="0")
+                        var hasValue0 = groups[i].querySelector('input[type="radio"][value="0"]');
+                        if (!hasValue0) {
+                            return {group: groups[i], radio: radio};
+                        }
+                    }
+                }
+                return null;
+            },
+            maxWaitMs,
+            'player selector'
+        );
+
+        if (!playerSelector) {
+            result.error = 'Player count selector not found within ' + maxWaitMs + 'ms';
+            result.timing.playerSelectorTimeout = Date.now() - startTime;
+            return result;
+        }
+        result.timing.playerSelectorFound = Date.now() - startTime;
+
+        // Phase 4: Click player count button
+        result.phase = 'player_count_click';
+        var playerButton = playerSelector.radio.parentElement;
+        if (playerButton.classList.contains('ui-state-disabled')) {
+            result.error = 'Player count ' + numPlayers + ' button is disabled';
+            return result;
+        }
+        playerButton.click();
+        result.timing.playerCountClicked = Date.now() - startTime;
+
+        // Phase 5: Add TBD Registered Guests (if numPlayers > 1)
+        if (numPlayers > 1) {
+            result.phase = 'tbd_guests';
+            var numTbd = numPlayers - 1;
+            var tbdClicked = 0;
+
+            // Wait for player rows to appear
+            var playerRows = pollFor(
+                function() {
+                    var rows = document.querySelectorAll('[id*="playersTable"] tbody tr[data-ri]');
+                    if (rows.length >= numPlayers) return rows;
+                    rows = document.querySelectorAll('table[id*="player"] tbody tr');
+                    if (rows.length >= numPlayers) return rows;
+                    return null;
+                },
+                3000,
+                'player rows'
+            );
+
+            if (!playerRows) {
+                result.error = 'Player rows did not appear after selecting ' + numPlayers + ' players';
+                return result;
+            }
+            result.timing.playerRowsFound = Date.now() - startTime;
+
+            // Click TBD button on each guest row (skip first row = member)
+            for (var r = 1; r < playerRows.length && tbdClicked < numTbd; r++) {
+                var row = playerRows[r];
+                var tbd = row.querySelector('a[id*="tbd"], span[id*="tbd"], a.ui-commandlink');
+                if (!tbd) {
+                    // Try XPath-style search
+                    var links = row.querySelectorAll('a');
+                    for (var l = 0; l < links.length; l++) {
+                        if (links[l].textContent && links[l].textContent.toUpperCase().indexOf('TBD') !== -1) {
+                            tbd = links[l];
+                            break;
+                        }
+                    }
+                }
+                if (tbd) {
+                    tbd.click();
+                    tbdClicked++;
+                    // Brief wait for AJAX
+                    var waitUntil = Date.now() + 200;
+                    while (Date.now() < waitUntil) { /* spin */ }
+                }
+            }
+
+            if (tbdClicked < numTbd) {
+                result.error = 'Only clicked ' + tbdClicked + ' of ' + numTbd + ' TBD buttons';
+                return result;
+            }
+            result.timing.tbdGuestsAdded = Date.now() - startTime;
+        }
+
+        // Phase 6: Click Book Now button
+        result.phase = 'book_now';
+        var bookNow = pollFor(
+            function() {
+                // Primary: by ID
+                var btn = document.querySelector('a[id*="bookTeeTimeAction"]');
+                if (btn) return btn;
+                // Fallback: by text
+                var links = document.querySelectorAll('a');
+                for (var i = 0; i < links.length; i++) {
+                    var txt = links[i].textContent || '';
+                    if (txt.indexOf('Book Now') !== -1 || txt.indexOf('Book') !== -1) {
+                        return links[i];
+                    }
+                }
+                return null;
+            },
+            5000,
+            'Book Now button'
+        );
+
+        if (!bookNow) {
+            result.error = 'Book Now button not found';
+            result.timing.bookNowTimeout = Date.now() - startTime;
+            return result;
+        }
+        result.timing.bookNowFound = Date.now() - startTime;
+
+        bookNow.scrollIntoView({block: 'center'});
+        bookNow.click();
+        result.timing.bookNowClicked = Date.now() - startTime;
+
+        result.phase = 'complete';
+        result.success = true;
+        result.timing.totalMs = Date.now() - startTime;
+
+        return result;
+        """
+
+        # Execute the fast chain with configurable timeouts
+        # maxWaitMs: how long to wait for player selector (the critical race window)
+        # pollIntervalMs: how often to check for elements (lower = faster but more CPU)
+        max_wait_ms = 5000  # 5 seconds max for player selector
+        poll_interval_ms = 10  # 10ms polling interval
+
+        logger.info(
+            f"FAST_BOOKING: Starting rapid JS chain for slot {slot_index}, "
+            f"{num_players} players"
+        )
+
+        result: dict[str, Any] = driver.execute_script(
+            js_fast_chain,
+            slot_index,
+            num_players,
+            max_wait_ms,
+            poll_interval_ms,
+        )
+
+        timing = result.get("timing", {})
+        logger.info(
+            f"FAST_BOOKING: Chain completed in {timing.get('totalMs', 'N/A')}ms - "
+            f"phase={result.get('phase')}, success={result.get('success')}, "
+            f"blocked={result.get('blocked')}, error={result.get('error')}"
+        )
+        logger.debug(f"FAST_BOOKING: Timing breakdown: {timing}")
+
+        return result
+
+    def _check_slot_blocked_popup(self, driver: webdriver.Chrome) -> bool:
+        """
+        Check if the 'slot blocked by another user' popup is visible.
+
+        This is a fallback check used by the Python-based booking flow.
+        The fast JS chain has its own inline check.
+
+        Args:
+            driver: The WebDriver instance
+
+        Returns:
+            True if the blocked popup is visible, False otherwise
+        """
+        try:
+            popup = driver.find_element(By.CSS_SELECTOR, DOM.SLOT_BLOCKED.popup_visible)
+            if popup.is_displayed():
+                logger.warning("BOOKING_DEBUG: Slot blocked popup detected")
+                # Try to extract the error message
+                try:
+                    label = popup.find_element(By.TAG_NAME, "label")
+                    logger.warning(f"BOOKING_DEBUG: Blocked popup text: {label.text}")
+                except NoSuchElementException:
+                    pass
+                # Try to dismiss the popup
+                try:
+                    ok_btn = popup.find_element(By.CSS_SELECTOR, DOM.SLOT_BLOCKED.ok_button)
+                    ok_btn.click()
+                    logger.debug("BOOKING_DEBUG: Dismissed blocked popup")
+                except NoSuchElementException:
+                    pass
+                return True
+        except NoSuchElementException:
+            pass
+        return False
 
     def _precision_wait_until(self, execute_at: datetime) -> None:
         """
@@ -3811,6 +4163,17 @@ class WaldenGolfProvider(ReservationProvider):
                 # Use JavaScript click to bypass any overlay issues
                 driver.execute_script("arguments[0].click();", reserve_element)
                 logger.debug("BOOKING_DEBUG: Clicked Reserve button")
+
+            # Check for blocked-slot popup BEFORE waiting for modal
+            # This happens when another user grabs the slot at the same moment
+            self.wait_strategy.simple_wait(fixed_duration=0.3, event_driven_duration=0.1)
+            if self._check_slot_blocked_popup(driver):
+                self._capture_diagnostic_info(driver, "slot_blocked_by_other_user")
+                return BookingResult(
+                    success=False,
+                    error_message="Slot blocked by another user",
+                    booked_time=booked_time,
+                )
 
             # Attempt to detect the booking modal/dialog. If found, scope all
             # subsequent element searches to the modal to avoid matching elements

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -1703,6 +1703,9 @@ class TestFindAndBookFastJS:
             5,
             4,  # driver, slot_index, num_players
         )
+        # Verify confirmation extraction and verification were called
+        provider._extract_confirmation_number.assert_called_once_with(mock_driver)
+        provider._verify_booking_success.assert_called_once_with(mock_driver)
 
     def test_fast_js_returns_failure_when_no_slot(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
@@ -1773,6 +1776,10 @@ class TestFindAndBookFastJS:
 
         assert result.success is False
         assert "blocked" in result.error_message.lower()
+        # Verify diagnostic capture was called with correct key
+        provider._capture_diagnostic_info.assert_called_once_with(
+            mock_driver, "slot_blocked_by_other_user"
+        )
 
     def test_fast_js_returns_failure_when_chain_fails(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
@@ -1823,6 +1830,10 @@ class TestFindAndBookFastJS:
 
         assert result.success is False
         assert "player_count_wait" in result.error_message
+        # Verify diagnostic capture was called with correct key
+        provider._capture_diagnostic_info.assert_called_once_with(
+            mock_driver, "fast_chain_failed_player_count_wait"
+        )
 
 
 class TestBatchBookingPreparation:

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -1160,10 +1160,14 @@ class TestPlayerCountModalScoping:
             ) as mock_select:
                 provider.wait_strategy = MagicMock()
                 # Also mock _capture_diagnostic_info to avoid side effects
+                # Mock _check_slot_blocked_popup to return False (no blocked popup)
                 with patch.object(provider, "_capture_diagnostic_info"):
-                    result = provider._complete_booking_sync(
-                        mock_driver, mock_reserve_element, time(8, 26), 4
-                    )
+                    with patch.object(
+                        provider, "_check_slot_blocked_popup", return_value=False
+                    ):
+                        result = provider._complete_booking_sync(
+                            mock_driver, mock_reserve_element, time(8, 26), 4
+                        )
 
                 # Player count selection was called (it returns False, so booking fails)
                 assert result.success is False
@@ -1643,7 +1647,7 @@ class TestFindAndBookFastJS:
     def test_fast_js_finds_and_books_exact_match(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test that fast JS path finds slot, clicks it, and completes booking."""
+        """Test that fast JS path finds slot and executes fast booking chain."""
         mock_driver = MagicMock()
 
         # Mock JS slot finder
@@ -1663,21 +1667,25 @@ class TestFindAndBookFastJS:
             ),
         )
 
-        # Mock JS click
-        monkeypatch.setattr(provider, "_click_slot_by_index_js", MagicMock(return_value=True))
-
-        # Mock complete booking
+        # Mock fast booking chain - returns success
         monkeypatch.setattr(
             provider,
-            "_complete_booking_sync",
+            "_execute_fast_booking_chain_js",
             MagicMock(
-                return_value=SimpleNamespace(
-                    success=True,
-                    booked_time=time(8, 42),
-                    confirmation_number="ABC123",
-                    course_name=None,
-                )
+                return_value={
+                    "success": True,
+                    "blocked": False,
+                    "phase": "complete",
+                    "error": None,
+                    "timing": {"totalMs": 1500},
+                }
             ),
+        )
+
+        # Mock verification and confirmation extraction
+        monkeypatch.setattr(provider, "_verify_booking_success", MagicMock(return_value=True))
+        monkeypatch.setattr(
+            provider, "_extract_confirmation_number", MagicMock(return_value="ABC123")
         )
 
         result = provider._find_and_book_time_slot_sync(
@@ -1690,9 +1698,11 @@ class TestFindAndBookFastJS:
         )
 
         assert result.success is True
-        # Verify _complete_booking_sync was called with already_clicked=True
-        call_kwargs = provider._complete_booking_sync.call_args[1]
-        assert call_kwargs["already_clicked"] is True
+        assert result.confirmation_number == "ABC123"
+        # Verify _execute_fast_booking_chain_js was called with correct args
+        provider._execute_fast_booking_chain_js.assert_called_once_with(
+            mock_driver, 5, 4  # driver, slot_index, num_players
+        )
 
     def test_fast_js_returns_failure_when_no_slot(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
@@ -1714,10 +1724,10 @@ class TestFindAndBookFastJS:
         assert result.success is False
         assert "No time slots" in result.error_message
 
-    def test_fast_js_returns_failure_when_click_fails(
+    def test_fast_js_returns_failure_when_slot_blocked(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test that fast JS path returns failure when click fails."""
+        """Test that fast JS path returns failure when slot is blocked by another user."""
         mock_driver = MagicMock()
 
         monkeypatch.setattr(
@@ -1736,7 +1746,21 @@ class TestFindAndBookFastJS:
             ),
         )
 
-        monkeypatch.setattr(provider, "_click_slot_by_index_js", MagicMock(return_value=False))
+        # Mock fast booking chain - returns blocked
+        monkeypatch.setattr(
+            provider,
+            "_execute_fast_booking_chain_js",
+            MagicMock(
+                return_value={
+                    "success": False,
+                    "blocked": True,
+                    "phase": "blocked_check",
+                    "error": "Slot blocked by another user",
+                    "timing": {"blockedDetected": 300},
+                }
+            ),
+        )
+        monkeypatch.setattr(provider, "_capture_diagnostic_info", MagicMock())
 
         result = provider._find_and_book_time_slot_sync(
             mock_driver,
@@ -1748,7 +1772,57 @@ class TestFindAndBookFastJS:
         )
 
         assert result.success is False
-        assert "Failed to click Reserve" in result.error_message
+        assert "blocked" in result.error_message.lower()
+
+    def test_fast_js_returns_failure_when_chain_fails(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that fast JS path returns failure when booking chain fails."""
+        mock_driver = MagicMock()
+
+        monkeypatch.setattr(
+            provider,
+            "_find_target_slot_js",
+            MagicMock(
+                return_value={
+                    "timeStr": "8:42",
+                    "hours": 8,
+                    "minutes": 42,
+                    "index": 5,
+                    "diff": 0,
+                    "available": 4,
+                    "isExact": True,
+                }
+            ),
+        )
+
+        # Mock fast booking chain - returns failure at player_count phase
+        monkeypatch.setattr(
+            provider,
+            "_execute_fast_booking_chain_js",
+            MagicMock(
+                return_value={
+                    "success": False,
+                    "blocked": False,
+                    "phase": "player_count_wait",
+                    "error": "Player count selector not found within 5000ms",
+                    "timing": {"playerSelectorTimeout": 5000},
+                }
+            ),
+        )
+        monkeypatch.setattr(provider, "_capture_diagnostic_info", MagicMock())
+
+        result = provider._find_and_book_time_slot_sync(
+            mock_driver,
+            target_time=time(8, 42),
+            num_players=4,
+            fallback_window_minutes=32,
+            skip_scroll=True,
+            use_fast_js=True,
+        )
+
+        assert result.success is False
+        assert "player_count_wait" in result.error_message
 
 
 class TestBatchBookingPreparation:

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -1162,9 +1162,7 @@ class TestPlayerCountModalScoping:
                 # Also mock _capture_diagnostic_info to avoid side effects
                 # Mock _check_slot_blocked_popup to return False (no blocked popup)
                 with patch.object(provider, "_capture_diagnostic_info"):
-                    with patch.object(
-                        provider, "_check_slot_blocked_popup", return_value=False
-                    ):
+                    with patch.object(provider, "_check_slot_blocked_popup", return_value=False):
                         result = provider._complete_booking_sync(
                             mock_driver, mock_reserve_element, time(8, 26), 4
                         )
@@ -1701,7 +1699,9 @@ class TestFindAndBookFastJS:
         assert result.confirmation_number == "ABC123"
         # Verify _execute_fast_booking_chain_js was called with correct args
         provider._execute_fast_booking_chain_js.assert_called_once_with(
-            mock_driver, 5, 4  # driver, slot_index, num_players
+            mock_driver,
+            5,
+            4,  # driver, slot_index, num_players
         )
 
     def test_fast_js_returns_failure_when_no_slot(


### PR DESCRIPTION
## Problem
At 6:30 AM when the booking window opens, multiple users click Reserve simultaneously. Our current flow takes 7-15 seconds:
1. Click Reserve → wait for modal (up to 10s)
2. Find player selector → click it → wait
3. Find TBD buttons → click each → wait
4. Find Book Now → click it

The stale element errors this morning happened because someone else booked the slot during our 7-second wait.

## Solution
Add `_execute_fast_booking_chain_js()` that runs the entire booking flow in a single rapid JavaScript execution:
- Reserve click → 10ms polling for player selector → click → TBD clicks → Book Now
- **Target: under 2 seconds total** instead of 7-15 seconds

Also add slot-blocked detection:
- When another user grabs a slot first, Walden shows a popup: "This slot is blocked by another user"
- New `_check_slot_blocked_popup()` detects this and fails fast
- Returns clear error message instead of timing out on stale elements

## Changes
- `walden_dom_schema.py`: Add `SlotBlockedSelectors` dataclass
- `walden_provider.py`: Add `_execute_fast_booking_chain_js()` with inline blocked-popup detection and rapid element polling
- `walden_provider.py`: Add `_check_slot_blocked_popup()` for Python path
- `walden_provider.py`: Update `_find_and_book_time_slot_sync()` fast path to use new chain
- `walden_provider.py`: Add blocked-popup check to `_complete_booking_sync()` for fallback/slow path
- Tests: Update `TestFindAndBookFastJS` to test new chain behavior

## Timing Breakdown (Expected)
| Phase | Old Flow | New Flow |
|-------|----------|----------|
| Reserve click | 0ms | 0ms |
| Wait for modal | 3-10s | 100-500ms (polling) |
| Player count click | 1s | 10ms |
| TBD guest clicks | 2s | 400ms |
| Book Now click | 1s | 10ms |
| **Total** | **7-15s** | **<2s** |

## Testing
- All 472 tests pass
- Ruff: clean
- Mypy: clean
- New tests for blocked-slot detection and fast chain failures

## Debug Screenshot from This Morning
The debug HTML showed the `teeSheetValidationErrorPopup` with "This slot is blocked by another user" — this is now detected and handled gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added UI popup detection for "slot blocked by another user" and immediate handling to surface that state.
* **Bug Fixes**
  * Improved detection and handling when a slot is blocked, with clearer, specific error messages.
  * Fast booking path now reports precise outcomes (success, blocked, phase, error) and returns reliable, phase-specific failure info for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->