### PR TITLE
infra: Discord gateway deploy config + guild-channel support

### DIFF
--- a/app/services/discord_gateway.py
+++ b/app/services/discord_gateway.py
@@ -31,19 +31,19 @@ MessageHandler = Callable[[str, str], Awaitable[str]]
 def should_handle_message(
     author_id: str,
     author_is_bot: bool,
-    is_dm: bool,
     allowed_user_id: str,
 ) -> bool:
     """Decide whether an incoming Discord message should be processed.
 
-    Only direct messages from the single configured user are handled; everything
-    else (other users, guild channels, other bots, our own messages) is ignored.
-    An empty allowed_user_id means no one is authorized - fail closed.
+    Messages from the single configured user are handled wherever the bot can
+    see them (DMs or a shared server channel); everything else (other users,
+    other bots, our own messages) is ignored. An empty allowed_user_id means
+    no one is authorized - fail closed.
     """
-    if author_is_bot or not is_dm:
+    if author_is_bot:
         return False
     if not allowed_user_id:
-        logger.warning("DISCORD_USER_ID not configured; ignoring DM from %s", author_id)
+        logger.warning("DISCORD_USER_ID not configured; ignoring message from %s", author_id)
         return False
     return author_id == allowed_user_id
 
@@ -56,7 +56,9 @@ class DiscordGateway:
         self._task: asyncio.Task[None] | None = None
 
         intents = discord.Intents.none()
+        intents.guilds = True  # channel/guild state; silences discord.py state warnings
         intents.dm_messages = True
+        intents.guild_messages = True  # let the user talk to the bot in a server channel too
         intents.message_content = True
         self.client = discord.Client(intents=intents)
 
@@ -72,12 +74,24 @@ class DiscordGateway:
     async def _on_message(self, message: discord.Message) -> None:
         author_id = str(message.author.id)
         is_dm = message.guild is None
-        if not should_handle_message(
-            author_id, message.author.bot, is_dm, settings.discord_user_id
-        ):
+        if message.author.id == getattr(self.client.user, "id", None):
+            return  # our own outbound messages
+        logger.info(
+            f"Discord message event: author={author_id}, bot={message.author.bot}, "
+            f"dm={is_dm}, content_len={len(message.content or '')}"
+        )
+        if not should_handle_message(author_id, message.author.bot, settings.discord_user_id):
+            logger.info(
+                f"Ignoring Discord message from {author_id} "
+                f"(allowed user: {settings.discord_user_id or '<unset>'})"
+            )
             return
         content = message.content.strip()
         if not content:
+            logger.warning(
+                "Discord message from allowed user has empty content - "
+                "is the Message Content intent enabled in the Developer Portal?"
+            )
             return
         logger.info(f"Discord DM received from {author_id}: {content[:80]}")
         try:

--- a/app/services/discord_gateway.py
+++ b/app/services/discord_gateway.py
@@ -93,7 +93,8 @@ class DiscordGateway:
                 "is the Message Content intent enabled in the Developer Portal?"
             )
             return
-        logger.info(f"Discord DM received from {author_id}: {content[:80]}")
+        source = "DM" if is_dm else f"guild channel #{getattr(message.channel, 'name', '?')}"
+        logger.info(f"Discord message received from {author_id} via {source}: {content[:80]}")
         try:
             response = await self._message_handler(author_id, content)
         except Exception:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,7 +42,22 @@ locals {
     "WALDEN_PASSWORD",
     "SCHEDULER_API_KEY",
     "USER_PHONE_NUMBER",
+    "DISCORD_BOT_TOKEN",
+    "DISCORD_USER_ID",
   ]
+}
+
+# The Discord secrets were created (with versions) via gcloud before this
+# config landed, so the Cloud Run revision could reference them on its first
+# deploy. These blocks adopt them into state; they are no-ops afterwards.
+import {
+  to = google_secret_manager_secret.secrets["DISCORD_BOT_TOKEN"]
+  id = "projects/gen-lang-client-0822973627/secrets/DISCORD_BOT_TOKEN"
+}
+
+import {
+  to = google_secret_manager_secret.secrets["DISCORD_USER_ID"]
+  id = "projects/gen-lang-client-0822973627/secrets/DISCORD_USER_ID"
 }
 
 data "google_project" "project" {
@@ -112,6 +127,10 @@ resource "google_cloud_run_v2_service" "teetime" {
           cpu    = var.cloud_run_cpu
           memory = var.cloud_run_memory
         }
+        # The Discord gateway holds a WebSocket outside of any HTTP request;
+        # with the default (cpu_idle = true) the instance is CPU-throttled
+        # between requests and the gateway connection starves.
+        cpu_idle = var.messaging_channel == "discord" ? false : true
       }
 
       env {
@@ -147,6 +166,11 @@ resource "google_cloud_run_v2_service" "teetime" {
       env {
         name  = "LOG_LEVEL"
         value = var.log_level
+      }
+
+      env {
+        name  = "MESSAGING_CHANNEL"
+        value = var.messaging_channel
       }
 
       env {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -33,7 +33,18 @@ locals {
     "iam.googleapis.com",
     "storage.googleapis.com",
   ]
-  secrets = [
+  discord_secrets = [
+    "DISCORD_BOT_TOKEN",
+    "DISCORD_USER_ID",
+  ]
+
+  # Every secret this project stores. Deliberately NOT scoped by
+  # messaging_channel: dropping a secret from this list would have Terraform
+  # delete it (and its versions) from Secret Manager, so flipping the channel
+  # would destroy stored credentials. Channel scoping is applied to the
+  # runtime env references and IAM grants below instead - that is where
+  # least-privilege actually matters.
+  secrets = concat([
     "TWILIO_ACCOUNT_SID",
     "TWILIO_AUTH_TOKEN",
     "TWILIO_PHONE_NUMBER",
@@ -42,22 +53,28 @@ locals {
     "WALDEN_PASSWORD",
     "SCHEDULER_API_KEY",
     "USER_PHONE_NUMBER",
-    "DISCORD_BOT_TOKEN",
-    "DISCORD_USER_ID",
-  ]
+  ], local.discord_secrets)
+
+  # Secrets the running container may read. The Discord credentials are only
+  # mounted (and only readable) when the Discord channel is active.
+  runtime_secrets = var.messaging_channel == "discord" ? toset(local.secrets) : setsubtract(
+    toset(local.secrets), toset(local.discord_secrets)
+  )
 }
 
 # The Discord secrets were created (with versions) via gcloud before this
 # config landed, so the Cloud Run revision could reference them on its first
-# deploy. These blocks adopt them into state; they are no-ops afterwards.
+# deploy. These blocks adopt them into state; Terraform ignores an import
+# block whose target is already in state, so they are no-ops afterwards and
+# can be deleted once this has applied successfully.
 import {
   to = google_secret_manager_secret.secrets["DISCORD_BOT_TOKEN"]
-  id = "projects/gen-lang-client-0822973627/secrets/DISCORD_BOT_TOKEN"
+  id = "projects/${var.project_id}/secrets/DISCORD_BOT_TOKEN"
 }
 
 import {
   to = google_secret_manager_secret.secrets["DISCORD_USER_ID"]
-  id = "projects/gen-lang-client-0822973627/secrets/DISCORD_USER_ID"
+  id = "projects/${var.project_id}/secrets/DISCORD_USER_ID"
 }
 
 data "google_project" "project" {
@@ -99,7 +116,7 @@ resource "google_service_account" "cloud_run" {
 }
 
 resource "google_secret_manager_secret_iam_member" "cloud_run_secret_access" {
-  for_each = toset(local.secrets)
+  for_each = toset(local.runtime_secrets)
 
   secret_id = google_secret_manager_secret.secrets[each.value].id
   role      = "roles/secretmanager.secretAccessor"
@@ -110,6 +127,25 @@ resource "google_cloud_run_v2_service" "teetime" {
   name     = local.service_name
   location = var.region
   ingress  = "INGRESS_TRAFFIC_ALL"
+
+  # Variable validation blocks cannot reference other variables on the
+  # Terraform version Cloud Build pins (1.6), so the cross-variable invariant
+  # is enforced here instead.
+  lifecycle {
+    precondition {
+      condition = (
+        var.messaging_channel != "discord" ||
+        (var.cloud_run_min_instances == 1 && var.cloud_run_max_instances == 1)
+      )
+      error_message = join(" ", [
+        "messaging_channel=\"discord\" requires cloud_run_min_instances and",
+        "cloud_run_max_instances to both be exactly 1: the gateway holds a",
+        "persistent WebSocket, so 0 instances drops the connection and >1",
+        "opens a second session that double-processes every message.",
+        "Got min=${var.cloud_run_min_instances}, max=${var.cloud_run_max_instances}.",
+      ])
+    }
+  }
 
   template {
     service_account = google_service_account.cloud_run.email
@@ -179,7 +215,7 @@ resource "google_cloud_run_v2_service" "teetime" {
       }
 
       dynamic "env" {
-        for_each = toset(local.secrets)
+        for_each = toset(local.runtime_secrets)
         content {
           name = env.value
           value_source {
@@ -371,8 +407,8 @@ resource "google_cloud_run_v2_service_iam_member" "scheduler_invoker" {
 }
 
 resource "google_cloud_scheduler_job" "execute_bookings" {
-  name             = "${local.service_name}-execute-bookings"
-  description      = "Execute due tee time bookings"
+  name        = "${local.service_name}-execute-bookings"
+  description = "Execute due tee time bookings"
   # Run 2 minutes early (6:28 AM CT) to allow login before booking window opens at 6:30 AM
   # The job queries for bookings due at 6:30 AM and waits until that time to book
   schedule         = "28 6 * * *"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -9,11 +9,18 @@ github_owner  = "alexenos"
 github_repo   = "teetime"
 github_branch = "main"
 
+# Messaging channel: "discord" (gateway runs in-process) or "twilio"
+messaging_channel = "discord"
+
 # Cloud Run settings
+# NOTE: with messaging_channel = "discord" both instance counts must be exactly
+# 1 (enforced by a precondition): the gateway holds a persistent WebSocket, so
+# 0 drops the connection and >1 double-processes every message. Switch to
+# twilio before relaxing these.
 cloud_run_memory        = "1Gi"
 cloud_run_cpu           = "1"
-cloud_run_max_instances = 10
-cloud_run_min_instances = 0
+cloud_run_max_instances = 1
+cloud_run_min_instances = 1
 
 # Application settings
 timezone           = "America/Chicago"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,15 +40,15 @@ variable "cloud_run_cpu" {
 }
 
 variable "cloud_run_max_instances" {
-  description = "Maximum number of Cloud Run instances"
+  description = "Maximum number of Cloud Run instances. Must be 1 while the Discord gateway runs in-process: a second instance would open a second gateway session and double-process every message."
   type        = number
-  default     = 10
+  default     = 1
 }
 
 variable "cloud_run_min_instances" {
-  description = "Minimum number of Cloud Run instances (0 allows scale to zero)"
+  description = "Minimum number of Cloud Run instances. Must be 1 while the Discord gateway runs in-process (a persistent WebSocket needs an always-on instance; with cpu_idle=false this bills roughly USD 50/month for 1 vCPU + 1GiB)."
   type        = number
-  default     = 0
+  default     = 1
 }
 
 variable "timezone" {
@@ -97,6 +97,12 @@ variable "container_image" {
   description = "Container image to deploy (passed from Cloud Build)"
   type        = string
   default     = ""
+}
+
+variable "messaging_channel" {
+  description = "User messaging channel: 'discord' (gateway in-process, requires min/max instances = 1 and always-on CPU) or 'twilio'"
+  type        = string
+  default     = "discord"
 }
 
 variable "log_level" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -103,6 +103,14 @@ variable "messaging_channel" {
   description = "User messaging channel: 'discord' (gateway in-process, requires min/max instances = 1 and always-on CPU) or 'twilio'"
   type        = string
   default     = "discord"
+
+  validation {
+    # Matched exactly (not case-folded) by both the cpu_idle expression here
+    # and settings.messaging_channel in the app, so a near-miss like "Discord"
+    # would silently run with no gateway at all.
+    condition     = contains(["discord", "twilio"], var.messaging_channel)
+    error_message = "messaging_channel must be exactly \"discord\" or \"twilio\" (lowercase)."
+  }
 }
 
 variable "log_level" {

--- a/tests/test_discord_provider.py
+++ b/tests/test_discord_provider.py
@@ -1,6 +1,7 @@
-"""Tests for the Discord messaging provider and gateway message filtering."""
+"""Tests for the Discord messaging provider and gateway message handling."""
 
 import json
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -11,7 +12,7 @@ from app.providers.discord_provider import (
     DiscordProvider,
     split_message,
 )
-from app.services.discord_gateway import should_handle_message
+from app.services.discord_gateway import DiscordGateway, should_handle_message
 
 
 class TestSplitMessage:
@@ -141,3 +142,115 @@ class TestShouldHandleMessage:
 
     def test_no_allowlist_fails_closed(self) -> None:
         assert not should_handle_message(self.ALLOWED, False, "")
+
+
+BOT_ID = 999000111
+ALLOWED_ID = "111222333444555666"
+
+
+def make_message(
+    *,
+    author_id: str = ALLOWED_ID,
+    content: str = "book saturday 8am",
+    is_bot: bool = False,
+    in_guild: bool = False,
+) -> MagicMock:
+    """Build a stand-in for discord.Message with a spy on channel.send."""
+    message = MagicMock()
+    message.author.id = int(author_id)
+    message.author.bot = is_bot
+    message.content = content
+    message.guild = MagicMock() if in_guild else None
+    message.channel.name = "tee-times"
+    message.channel.send = AsyncMock()
+    return message
+
+
+@pytest.fixture
+def gateway(monkeypatch: pytest.MonkeyPatch) -> tuple[DiscordGateway, AsyncMock]:
+    """A gateway whose discord.Client is replaced by a stub bot identity."""
+    monkeypatch.setattr(settings, "discord_user_id", ALLOWED_ID)
+    handler = AsyncMock(return_value="ok")
+    gw = DiscordGateway(handler)
+    gw.client = MagicMock()  # type: ignore[assignment]
+    gw.client.user.id = BOT_ID
+    return gw, handler
+
+
+class TestGatewayOnMessage:
+    async def test_dm_from_allowed_user_dispatched(self, gateway) -> None:  # type: ignore[no-untyped-def]
+        gw, handler = gateway
+        message = make_message()
+
+        await gw._on_message(message)
+
+        handler.assert_awaited_once_with(ALLOWED_ID, "book saturday 8am")
+        message.channel.send.assert_awaited_once_with("ok")
+
+    async def test_guild_message_from_allowed_user_dispatched(self, gateway) -> None:  # type: ignore[no-untyped-def]
+        """Server-channel messages must work, not just DMs."""
+        gw, handler = gateway
+        message = make_message(in_guild=True)
+
+        await gw._on_message(message)
+
+        handler.assert_awaited_once_with(ALLOWED_ID, "book saturday 8am")
+        message.channel.send.assert_awaited_once_with("ok")
+
+    async def test_own_message_suppressed(
+        self,
+        gateway,  # type: ignore[no-untyped-def]
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The bot must not react to its own outbound messages.
+
+        The allowlist is deliberately pointed at the bot's own ID so this
+        exercises the self-check rather than passing for the incidental
+        reason that the bot isn't the allowed user.
+        """
+        gw, handler = gateway
+        monkeypatch.setattr(settings, "discord_user_id", str(BOT_ID))
+        message = make_message(author_id=str(BOT_ID), is_bot=False)
+
+        await gw._on_message(message)
+
+        handler.assert_not_awaited()
+        message.channel.send.assert_not_awaited()
+
+    async def test_other_user_ignored(self, gateway) -> None:  # type: ignore[no-untyped-def]
+        gw, handler = gateway
+        message = make_message(author_id="424242424242")
+
+        await gw._on_message(message)
+
+        handler.assert_not_awaited()
+        message.channel.send.assert_not_awaited()
+
+    async def test_empty_content_ignored(self, gateway) -> None:  # type: ignore[no-untyped-def]
+        """Empty content signals a missing Message Content intent."""
+        gw, handler = gateway
+        message = make_message(content="   ")
+
+        await gw._on_message(message)
+
+        handler.assert_not_awaited()
+        message.channel.send.assert_not_awaited()
+
+    async def test_handler_error_reported_to_user(self, gateway) -> None:  # type: ignore[no-untyped-def]
+        gw, handler = gateway
+        handler.side_effect = RuntimeError("gemini exploded")
+        message = make_message()
+
+        await gw._on_message(message)
+
+        message.channel.send.assert_awaited_once()
+        assert "went wrong" in message.channel.send.await_args.args[0]
+
+    async def test_long_response_sent_in_chunks(self, gateway) -> None:  # type: ignore[no-untyped-def]
+        gw, handler = gateway
+        handler.return_value = "z" * (MAX_MESSAGE_LEN + 10)
+        message = make_message()
+
+        await gw._on_message(message)
+
+        assert message.channel.send.await_count == 2

--- a/tests/test_discord_provider.py
+++ b/tests/test_discord_provider.py
@@ -130,17 +130,14 @@ class TestSendSms:
 class TestShouldHandleMessage:
     ALLOWED = "111222333444555666"
 
-    def test_dm_from_allowed_user(self) -> None:
-        assert should_handle_message(self.ALLOWED, False, True, self.ALLOWED)
+    def test_message_from_allowed_user(self) -> None:
+        assert should_handle_message(self.ALLOWED, False, self.ALLOWED)
 
-    def test_dm_from_other_user_ignored(self) -> None:
-        assert not should_handle_message("999", False, True, self.ALLOWED)
-
-    def test_guild_message_ignored(self) -> None:
-        assert not should_handle_message(self.ALLOWED, False, False, self.ALLOWED)
+    def test_message_from_other_user_ignored(self) -> None:
+        assert not should_handle_message("999", False, self.ALLOWED)
 
     def test_bot_message_ignored(self) -> None:
-        assert not should_handle_message(self.ALLOWED, True, True, self.ALLOWED)
+        assert not should_handle_message(self.ALLOWED, True, self.ALLOWED)
 
     def test_no_allowlist_fails_closed(self) -> None:
-        assert not should_handle_message(self.ALLOWED, False, True, "")
+        assert not should_handle_message(self.ALLOWED, False, "")


### PR DESCRIPTION
Follow-up to #115 — these two commits were pushed to the feature branch after it was merged, so they missed main:

- **Gateway improvements**: accept the allowed user's messages in shared server channels (not just DMs), log every received/ignored message event so silent drops are diagnosable, warn on empty content (Message Content intent misconfiguration)
- **Terraform deploy config**: DISCORD_BOT_TOKEN / DISCORD_USER_ID added to the Secret Manager set (already pre-created with versions via gcloud; import blocks adopt them), MESSAGING_CHANNEL env (default discord), min/max instances = 1 (gateway must be an always-on singleton), cpu_idle=false so the WebSocket isn't CPU-starved between requests (~USD 50/month for the always-on 1 vCPU instance)

Without this, the deployed service runs in Twilio mode and the gateway never starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord messaging now supports messages from the configured user in both direct messages and shared server channels.
  * Added messaging-channel configuration, defaulting to Discord, with support for alternative channels.
  * Discord deployments now remain continuously available for reliable message handling.

* **Bug Fixes**
  * Prevented the bot from processing its own outbound messages.
  * Improved handling and warnings for ignored or empty messages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->