### PR TITLE
fix: parse failures must not invent bookings (Gemini model retired)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ MESSAGING_CHANNEL=twilio
 
 # Google Gemini API
 GEMINI_API_KEY=your_gemini_api_key
+# Model used to parse incoming messages. Defaults to the floating "latest" alias
+# so a model retirement can't take message parsing down; pin a version here to
+# override (check availability first - retired models return 404).
+GEMINI_MODEL=gemini-flash-latest
 
 # Walden Golf Club Credentials
 WALDEN_MEMBER_NUMBER=your_member_number

--- a/app/config.py
+++ b/app/config.py
@@ -28,6 +28,9 @@ class Settings(BaseSettings):
     messaging_channel: str = "twilio"  # "twilio" or "discord"
 
     gemini_api_key: str = ""
+    # Floating alias rather than a pinned version: a pinned model (gemini-2.0-flash)
+    # was retired out from under us and every message silently mis-parsed.
+    gemini_model: str = "gemini-flash-latest"
 
     walden_member_number: str = ""
     walden_password: str = ""

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -2234,18 +2234,40 @@ class WaldenGolfProvider(ReservationProvider):
             # Each button contains a radio input with value 1, 2, 3, or 4
             # The button div has class "ui-button" and we need to click the one with the correct value
 
-            # First try to find the button group (scoped to search_context)
+            # First try to find the button group (scoped to search_context).
+            # Prefer a group that actually offers the requested player count:
+            # when the search context is the full page, .ui-selectonebutton also
+            # matches the tee sheet's time period filter (ALL/MORNING/AFTERNOON/
+            # AVAILABLE), which comes first in the DOM. Taking that first match
+            # is how a live booking failed with "Could not find radio input".
             button_group = None
+            decoy_group = None
+            radio_selector = DOM.PLAYER_COUNT.radio_input_template.format(value=num_players)
             for selector in DOM.PLAYER_COUNT.button_group:
-                try:
-                    button_group = search_context.find_element(By.CSS_SELECTOR, selector)
-                    logger.info(
-                        f"BOOKING_DEBUG: Found player button group with selector: {selector}"
-                    )
-                    break
-                except NoSuchElementException:
+                candidates = search_context.find_elements(By.CSS_SELECTOR, selector)
+                if not candidates:
                     logger.debug(f"BOOKING_DEBUG: Button group not found with selector: {selector}")
                     continue
+                for candidate in candidates:
+                    if candidate.find_elements(By.CSS_SELECTOR, radio_selector):
+                        button_group = candidate
+                        logger.info(
+                            f"BOOKING_DEBUG: Found player button group with selector: {selector}"
+                        )
+                        break
+                if button_group is not None:
+                    break
+                if decoy_group is None:
+                    decoy_group = candidates[0]
+                    logger.debug(
+                        f"BOOKING_DEBUG: {len(candidates)} group(s) matched {selector}, none with a "
+                        f"radio input for {num_players} players"
+                    )
+
+            # No group offered the requested count - fall through to the label and
+            # dropdown strategies below with the best candidate we saw.
+            if button_group is None:
+                button_group = decoy_group
 
             if button_group:
                 # Find the button with the correct value
@@ -4588,12 +4610,16 @@ class WaldenGolfProvider(ReservationProvider):
             # See Issue #105.
             booking_context: webdriver.Chrome | WebElement = driver  # default: full page
             try:
-                modal_element = wait.until(
-                    expected_conditions.visibility_of_element_located(
+                # visibility_of_element_located only ever inspects the FIRST match,
+                # and the tee sheet ships a permanently hidden golfEventDetailPopup
+                # ahead of any real dialog - so the wait timed out even when the
+                # booking modal was open. Check every match for visibility instead.
+                visible_modals = wait.until(
+                    expected_conditions.visibility_of_any_elements_located(
                         (By.CSS_SELECTOR, DOM.BOOKING_MODAL.modal_container)
                     )
                 )
-                booking_context = modal_element
+                booking_context = visible_modals[0]
                 logger.debug(
                     "BOOKING_DEBUG: Booking dialog/modal appeared, scoping searches to modal"
                 )

--- a/app/services/discord_gateway.py
+++ b/app/services/discord_gateway.py
@@ -16,6 +16,7 @@ with min-instances=1 when the Discord channel is enabled.
 
 import asyncio
 import logging
+import re
 from collections.abc import Awaitable, Callable
 
 import discord
@@ -46,6 +47,18 @@ def should_handle_message(
         logger.warning("DISCORD_USER_ID not configured; ignoring message from %s", author_id)
         return False
     return author_id == allowed_user_id
+
+
+def strip_bot_mention(content: str, bot_user_id: int | str | None) -> str:
+    """Remove mentions of the bot from message content.
+
+    In a server channel the user has to @-mention the bot, so the raw content
+    arrives as "<@1533170206082339016> book 8/2 at 5:06p". The snowflake is
+    noise the LLM parser has to see past - strip it before dispatching.
+    """
+    if bot_user_id is None:
+        return content.strip()
+    return re.sub(rf"<@!?{bot_user_id}>", " ", content).strip()
 
 
 class DiscordGateway:
@@ -86,12 +99,15 @@ class DiscordGateway:
                 f"(allowed user: {settings.discord_user_id or '<unset>'})"
             )
             return
-        content = message.content.strip()
-        if not content:
+        if not message.content.strip():
             logger.warning(
                 "Discord message from allowed user has empty content - "
                 "is the Message Content intent enabled in the Developer Portal?"
             )
+            return
+        content = strip_bot_mention(message.content, getattr(self.client.user, "id", None))
+        if not content:
+            logger.info("Discord message was only a bot mention; nothing to parse")
             return
         source = "DM" if is_dm else f"guild channel #{getattr(message.channel, 'name', '?')}"
         logger.info(f"Discord message received from {author_id} via {source}: {content[:80]}")

--- a/app/services/gemini_service.py
+++ b/app/services/gemini_service.py
@@ -252,6 +252,17 @@ class GeminiService:
 
     async def parse_message(self, message: str, context: str | None = None) -> ParsedIntent:
         if not self.model:
+            # Distinct from the API-error path below: this only fires when
+            # GEMINI_API_KEY itself is unset (the local-dev-without-a-key case).
+            # In deployed environments the key is a required Secret Manager
+            # mount, so reaching here means that's missing - log loudly so a
+            # misconfiguration doesn't silently guess bookings the way the
+            # dead-model fallback used to.
+            logger.warning(
+                "GEMINI_API_KEY not configured; using _mock_parse (guessed dates/times) "
+                "for message: %r",
+                message,
+            )
             return self._mock_parse(message)
 
         try:

--- a/app/services/gemini_service.py
+++ b/app/services/gemini_service.py
@@ -140,7 +140,7 @@ class GeminiService:
             if settings.gemini_api_key:
                 genai.configure(api_key=settings.gemini_api_key)  # type: ignore[attr-defined]
                 self._model = genai.GenerativeModel(  # type: ignore[attr-defined]
-                    model_name="gemini-2.0-flash",
+                    model_name=settings.gemini_model,
                     system_instruction=SYSTEM_PROMPT,
                     tools=[{"function_declarations": FUNCTION_DECLARATIONS}],
                 )
@@ -293,7 +293,19 @@ class GeminiService:
 
         except Exception as e:
             logger.exception(f"Gemini API error for message '{message}': {e}")
-            return self._mock_parse(message)
+            # Do NOT fall back to _mock_parse here. The mock ignores the date and
+            # time in the message and defaults to "7 days out at 8:00 AM", so a
+            # dead model turned "book 8/2 at 5:06p" into a confident confirmation
+            # of a booking the user never asked for. Failing loudly is the only
+            # safe answer when we cannot understand the request.
+            return ParsedIntent(
+                intent="unclear",
+                raw_message=message,
+                response_message=(
+                    "I couldn't understand that - my language model is unavailable "
+                    "right now, so nothing was booked. Please try again in a minute."
+                ),
+            )
 
     def _build_parsed_intent(
         self, args: dict[str, Any], raw_message: str | None = None

--- a/tests/test_discord_provider.py
+++ b/tests/test_discord_provider.py
@@ -236,19 +236,24 @@ class TestGatewayOnMessage:
         handler.assert_not_awaited()
         message.channel.send.assert_not_awaited()
 
-    async def test_bot_mention_stripped_before_dispatch(self, gateway) -> None:  # type: ignore[no-untyped-def]
+    @pytest.mark.parametrize("mention_fmt", ["<@{id}>", "<@!{id}>"])
+    async def test_bot_mention_stripped_before_dispatch(self, gateway, mention_fmt: str) -> None:  # type: ignore[no-untyped-def]
         """In a server channel the user @-mentions the bot; the raw snowflake
-        must not reach the parser."""
+        must not reach the parser. Discord sends the nickname form <@!id> when
+        the mentioned user has a per-server nickname, and the plain <@id> form
+        otherwise - both must be stripped."""
         gw, handler = gateway
-        message = make_message(content=f"<@{BOT_ID}> book 8/2 at 5:06p", in_guild=True)
+        mention = mention_fmt.format(id=BOT_ID)
+        message = make_message(content=f"{mention} book 8/2 at 5:06p", in_guild=True)
 
         await gw._on_message(message)
 
         handler.assert_awaited_once_with(ALLOWED_ID, "book 8/2 at 5:06p")
 
-    async def test_mention_only_message_ignored(self, gateway) -> None:  # type: ignore[no-untyped-def]
+    @pytest.mark.parametrize("mention_fmt", ["<@{id}>", "<@!{id}>"])
+    async def test_mention_only_message_ignored(self, gateway, mention_fmt: str) -> None:  # type: ignore[no-untyped-def]
         gw, handler = gateway
-        message = make_message(content=f"<@{BOT_ID}>", in_guild=True)
+        message = make_message(content=mention_fmt.format(id=BOT_ID), in_guild=True)
 
         await gw._on_message(message)
 

--- a/tests/test_discord_provider.py
+++ b/tests/test_discord_provider.py
@@ -236,6 +236,25 @@ class TestGatewayOnMessage:
         handler.assert_not_awaited()
         message.channel.send.assert_not_awaited()
 
+    async def test_bot_mention_stripped_before_dispatch(self, gateway) -> None:  # type: ignore[no-untyped-def]
+        """In a server channel the user @-mentions the bot; the raw snowflake
+        must not reach the parser."""
+        gw, handler = gateway
+        message = make_message(content=f"<@{BOT_ID}> book 8/2 at 5:06p", in_guild=True)
+
+        await gw._on_message(message)
+
+        handler.assert_awaited_once_with(ALLOWED_ID, "book 8/2 at 5:06p")
+
+    async def test_mention_only_message_ignored(self, gateway) -> None:  # type: ignore[no-untyped-def]
+        gw, handler = gateway
+        message = make_message(content=f"<@{BOT_ID}>", in_guild=True)
+
+        await gw._on_message(message)
+
+        handler.assert_not_awaited()
+        message.channel.send.assert_not_awaited()
+
     async def test_handler_error_reported_to_user(self, gateway) -> None:  # type: ignore[no-untyped-def]
         gw, handler = gateway
         handler.side_effect = RuntimeError("gemini exploded")

--- a/tests/test_gemini_service.py
+++ b/tests/test_gemini_service.py
@@ -525,14 +525,34 @@ class TestGeminiServiceParseMessage:
         assert result is not None
 
     @pytest.mark.asyncio
-    async def test_parse_message_api_error_fallback(self, gemini_service: GeminiService) -> None:
-        """Test that parse_message falls back to mock on API error."""
+    async def test_parse_message_api_error_reports_failure(
+        self, gemini_service: GeminiService
+    ) -> None:
+        """An API error must surface, never a guessed booking.
+
+        The mock parser ignores the date/time in the message and defaults to
+        "7 days out at 8:00 AM", so falling back to it on an API error confirms
+        a booking the user never asked for (what a retired model did in prod).
+        """
         with patch.object(gemini_service, "_model", MagicMock()):
             gemini_service._model.generate_content = MagicMock(side_effect=Exception("API Error"))
 
-            result = await gemini_service.parse_message("Book Saturday")
+            result = await gemini_service.parse_message("Book 8/2 at 5:06p")
 
-            assert result.intent == "book"
+            assert result.intent == "unclear"
+            assert result.tee_time_request is None
+            assert result.tee_time_requests is None
+            assert "nothing was booked" in result.response_message
+
+    def test_model_name_comes_from_settings(self, gemini_service: GeminiService) -> None:
+        """The model is configurable so a retirement can be worked around by env."""
+        with patch("app.services.gemini_service.settings") as mock_settings:
+            mock_settings.gemini_api_key = "test-key"
+            mock_settings.gemini_model = "gemini-test-model"
+            with patch("app.services.gemini_service.genai") as mock_genai:
+                _ = gemini_service.model
+
+            assert mock_genai.GenerativeModel.call_args.kwargs["model_name"] == "gemini-test-model"
 
     @pytest.mark.asyncio
     async def test_parse_message_successful_api_response(

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -1069,23 +1069,26 @@ class TestWaldenDOMSchema:
 class TestPlayerCountModalScoping:
     """Tests for Issue #105 fix: player count selection scoped to booking modal."""
 
+    @staticmethod
+    def _make_button_group(*, has_radio: bool) -> MagicMock:
+        """A .ui-selectonebutton group that does or doesn't offer the player count."""
+        group = MagicMock()
+        radio = MagicMock()
+        button_div = MagicMock()
+        button_div.get_attribute.return_value = "ui-button"
+        radio.find_element.return_value = button_div  # parent div (XPATH call)
+
+        group.find_elements.return_value = [radio] if has_radio else []
+        group.find_element.return_value = radio
+        return group
+
     def test_select_player_count_uses_search_context(self, provider: WaldenGolfProvider) -> None:
-        """When search_context is provided, find_element is called on it, not driver."""
+        """When search_context is provided, the search runs on it, not the driver."""
         mock_driver = MagicMock()
         mock_modal = MagicMock()
 
-        # Set up the mock modal to return a button group with a valid radio input
-        mock_button_group = MagicMock()
-        mock_radio = MagicMock()
-        mock_button_div = MagicMock()
-        mock_button_div.get_attribute.return_value = "ui-button"
-
-        # Make the modal find the button group with the first selector
-        mock_modal.find_element.return_value = mock_button_group
-        mock_button_group.find_element.side_effect = [
-            mock_radio,  # radio input
-            mock_button_div,  # parent div (XPATH call)
-        ]
+        mock_button_group = self._make_button_group(has_radio=True)
+        mock_modal.find_elements.return_value = [mock_button_group]
 
         # Mock wait_strategy to be a no-op
         provider.wait_strategy = MagicMock()
@@ -1095,8 +1098,9 @@ class TestPlayerCountModalScoping:
             result = provider._select_player_count_sync(mock_driver, 4, search_context=mock_modal)
 
         assert result is True
-        # The critical assertion: find_element was called on the MODAL, not the driver
-        mock_modal.find_element.assert_called()
+        # The critical assertion: the search ran on the MODAL, not the driver
+        mock_modal.find_elements.assert_called()
+        mock_driver.find_elements.assert_not_called()
         # execute_script should still use driver (not modal)
         mock_driver.execute_script.assert_called()
 
@@ -1104,17 +1108,8 @@ class TestPlayerCountModalScoping:
         """When no search_context is provided, defaults to using driver."""
         mock_driver = MagicMock()
 
-        # Set up the mock driver to return a button group with a valid radio input
-        mock_button_group = MagicMock()
-        mock_radio = MagicMock()
-        mock_button_div = MagicMock()
-        mock_button_div.get_attribute.return_value = "ui-button"
-
-        mock_driver.find_element.return_value = mock_button_group
-        mock_button_group.find_element.side_effect = [
-            mock_radio,  # radio input
-            mock_button_div,  # parent div
-        ]
+        mock_button_group = self._make_button_group(has_radio=True)
+        mock_driver.find_elements.return_value = [mock_button_group]
 
         provider.wait_strategy = MagicMock()
 
@@ -1122,8 +1117,26 @@ class TestPlayerCountModalScoping:
             result = provider._select_player_count_sync(mock_driver, 4)
 
         assert result is True
-        # find_element called on the driver (default search_context)
-        mock_driver.find_element.assert_called()
+        # search ran on the driver (default search_context)
+        mock_driver.find_elements.assert_called()
+
+    def test_select_player_count_skips_decoy_group(self, provider: WaldenGolfProvider) -> None:
+        """The tee sheet's time period filter shares .ui-selectonebutton and comes
+        first in the DOM; the group carrying the player count must win."""
+        mock_driver = MagicMock()
+
+        time_period_filter = self._make_button_group(has_radio=False)  # ALL/MORNING/...
+        player_count_group = self._make_button_group(has_radio=True)
+        mock_driver.find_elements.return_value = [time_period_filter, player_count_group]
+
+        provider.wait_strategy = MagicMock()
+
+        with patch.object(provider, "_verify_player_rows_appeared", return_value=True):
+            result = provider._select_player_count_sync(mock_driver, 4)
+
+        assert result is True
+        player_count_group.find_element.assert_called()
+        time_period_filter.find_element.assert_not_called()
 
     def test_complete_booking_passes_modal_as_context(self, provider: WaldenGolfProvider) -> None:
         """_complete_booking_sync captures modal element and passes it to player count selection."""
@@ -1135,7 +1148,7 @@ class TestPlayerCountModalScoping:
 
         # Make the WebDriverWait return values for each .until() call:
         # 1. element_to_be_clickable (reserve button check)
-        # 2. visibility_of_element_located (modal detection)
+        # 2. visibility_of_any_elements_located (modal detection - returns a list)
         # 3+ any remaining calls (Book Now wait, url_changes, success indicators, etc.)
         with patch("app.providers.walden_provider.WebDriverWait") as mock_wait_cls:
             mock_wait_instance = MagicMock()
@@ -1148,7 +1161,7 @@ class TestPlayerCountModalScoping:
                 if call_count[0] == 1:
                     return mock_reserve_element  # clickable check
                 elif call_count[0] == 2:
-                    return mock_modal  # modal detection
+                    return [mock_modal]  # modal detection (visible matches)
                 else:
                     return mock_confirm_button  # all subsequent calls
 

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -11,7 +11,9 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from selenium.webdriver.common.by import By
 
+from app.providers.walden_dom_schema import DOM
 from app.providers.walden_provider import WaldenGolfProvider
 from app.utils.timezone import CTDateTime
 
@@ -1150,17 +1152,28 @@ class TestPlayerCountModalScoping:
         # 1. element_to_be_clickable (reserve button check)
         # 2. visibility_of_any_elements_located (modal detection - returns a list)
         # 3+ any remaining calls (Book Now wait, url_changes, success indicators, etc.)
-        with patch("app.providers.walden_provider.WebDriverWait") as mock_wait_cls:
+        with (
+            patch("app.providers.walden_provider.WebDriverWait") as mock_wait_cls,
+            patch(
+                "app.providers.walden_provider.expected_conditions.visibility_of_any_elements_located"
+            ) as mock_visibility_any,
+        ):
             mock_wait_instance = MagicMock()
             mock_wait_cls.return_value = mock_wait_instance
-            # Use a default return for .until() but make the second call return the modal
+            modal_condition = mock_visibility_any.return_value
+
+            # Use a default return for .until() but make the second call return the modal.
+            # Asserting on the condition object (not just call order) is what catches a
+            # regression back to visibility_of_element_located, which silently passes
+            # since this mock doesn't otherwise care which predicate it was given.
             call_count = [0]
 
-            def until_side_effect(*args, **kwargs):
+            def until_side_effect(condition, *args, **kwargs):
                 call_count[0] += 1
                 if call_count[0] == 1:
                     return mock_reserve_element  # clickable check
                 elif call_count[0] == 2:
+                    assert condition == modal_condition
                     return [mock_modal]  # modal detection (visible matches)
                 else:
                     return mock_confirm_button  # all subsequent calls
@@ -1188,6 +1201,13 @@ class TestPlayerCountModalScoping:
                 mock_select.assert_called_once()
                 call_kwargs = mock_select.call_args
                 assert call_kwargs.kwargs.get("search_context") is mock_modal
+
+                # Modal detection used the any-elements predicate (checks every
+                # match for visibility) with the booking modal locator, not just
+                # the first element in the DOM
+                mock_visibility_any.assert_called_once_with(
+                    (By.CSS_SELECTOR, DOM.BOOKING_MODAL.modal_container)
+                )
 
 
 class TestWaldenProviderExtractEventBlocks:


### PR DESCRIPTION
## What happened

First real Discord request after #117 deployed:

> **Dax:** @Teetime book 8/2 at 5:06p
> **Teetime:** I'll book a tee time for **Saturday, August 08 at 08:00 AM** for 4 players. Reply 'yes' to confirm.

Cloud Logging shows why:

```
gemini_service - ERROR - Gemini API error for message '<@1533...> book 8/2 at 5:06p':
404 This model models/gemini-2.0-flash is no longer available.
```

`parse_message` caught that and fell back to `_mock_parse`, which ignores the date and time in the message and defaults to "7 days out at 08:00 for 4 players" — Aug 8, 8:00 AM. So a dead model produced a confident confirmation of a booking the user never asked for, and the bot then went and tried to book it.

## Fixes

- **Model is configurable** (`GEMINI_MODEL`), defaulting to the floating `gemini-flash-latest` alias so the next retirement can't take parsing down. Verified against the live API with this repo's function-calling schema: `gemini-flash-latest` and `gemini-3.6-flash` both return `{date: 2026-08-02, time: 17:06, players: 4}`; `gemini-2.0-flash` and `gemini-2.5-flash` return 404.
- **No silent guessing.** On an API error the user gets "my language model is unavailable right now, so nothing was booked" instead of a fabricated booking. `_mock_parse` stays only for the no-API-key local dev path.
- **Strip the bot @-mention** from Discord content before parsing (guild messages arrive as `<@1533...> book 8/2 at 5:06p`).

## Two DOM bugs the failed attempt exposed downstream

The booking then failed with `Failed to select 4 players`, and the debug artifact shows it had grabbed the tee sheet's time-period filter (ALL/MORNING/AFTERNOON/AVAILABLE) as the player-count group:

- `visibility_of_element_located` only inspects the **first** match, and the tee sheet ships a permanently hidden `golfEventDetailPopup` ahead of any real dialog — so modal detection could never succeed and every booking ran unscoped against the full page. Now uses `visibility_of_any_elements_located`.
- Player-count selection took the first `.ui-selectonebutton` on the page. Now it picks the group that actually contains a radio input for the requested count (the Issue #105 decoy, covered by a new regression test).

Note: in the failed run the Reserve click itself never opened anything — the captured page is the unchanged tee sheet. These two fixes are necessary but may not be sufficient; the next live attempt will tell.

## Testing

500 passed, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Gemini model selection, defaulting to the latest Gemini Flash model.
* **Bug Fixes**
  * Improved booking workflows by selecting the correct player-count controls and detecting visible booking dialogs reliably.
  * Discord messages containing only a bot mention are now ignored.
  * Gemini API failures now clearly indicate that no booking was made instead of using fallback data.
* **Tests**
  * Expanded coverage for Discord message handling, Gemini configuration and errors, and booking selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->