### PR TITLE
fix: surface block reasons in failures and reply in shared Discord channel

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -60,6 +61,25 @@ class Settings(BaseSettings):
 
     # Wait strategy for Selenium operations (fixed, event_driven, hybrid)
     wait_mode: WaitMode = WaitMode.FIXED
+
+    @field_validator("discord_channel_id")
+    @classmethod
+    def _validate_discord_channel_id(cls, v: str) -> str:
+        """Reject a non-numeric DISCORD_CHANNEL_ID at load time.
+
+        The value is interpolated straight into /channels/{id}/messages, so a
+        channel *name* like "#general" would only fail later at send time. Trim
+        whitespace and require a numeric snowflake; empty stays valid and means
+        "fall back to DMs".
+        """
+        v = v.strip()
+        if v and not v.isdigit():
+            raise ValueError(
+                "DISCORD_CHANNEL_ID must be a numeric Discord channel ID (snowflake); "
+                f"got {v!r}. In Discord, enable Developer Mode, then right-click the "
+                "channel and choose Copy Channel ID. Leave it unset to use DMs."
+            )
+        return v
 
     class Config:
         env_file = ".env"

--- a/app/config.py
+++ b/app/config.py
@@ -25,6 +25,11 @@ class Settings(BaseSettings):
 
     discord_bot_token: str = ""
     discord_user_id: str = ""  # Snowflake ID of the (single) user allowed to DM the bot
+    # Snowflake ID of a shared channel (e.g. #general) to post outbound
+    # notifications into. When set, booking confirmations/failures go to this
+    # channel (mentioning the user) instead of a private DM, so the whole
+    # conversation stays in one place. Leave empty to fall back to DMs.
+    discord_channel_id: str = ""
     messaging_channel: str = "twilio"  # "twilio" or "discord"
 
     gemini_api_key: str = ""

--- a/app/providers/discord_provider.py
+++ b/app/providers/discord_provider.py
@@ -93,9 +93,18 @@ class DiscordProvider(SMSProvider):
         user_id = self.resolve_user_id(to_number)
         if not user_id:
             return SMSResult(success=False, error_message="No Discord user ID configured")
+
+        # When a shared channel is configured, post there (mentioning the user)
+        # so async notifications land in the same place the request was made,
+        # instead of splitting the conversation into a private DM.
+        shared_channel_id = settings.discord_channel_id.strip()
         try:
             async with self._client() as client:
-                channel_id = await self._get_dm_channel(client, user_id)
+                if shared_channel_id:
+                    channel_id = shared_channel_id
+                    message = f"<@{user_id}> {message}" if user_id.isdigit() else message
+                else:
+                    channel_id = await self._get_dm_channel(client, user_id)
                 last_message_id: str | None = None
                 for chunk in split_message(message):
                     resp = await client.post(

--- a/app/providers/walden_dom_schema.py
+++ b/app/providers/walden_dom_schema.py
@@ -371,6 +371,25 @@ class SlotBlockedSelectors:
 
 
 @dataclass(frozen=True)
+class DisabledSlotSelectors:
+    """Selectors for slots the club has disabled with a stated reason.
+
+    Unbookable slots (aerification, weather delay, frost delay, etc.) render a
+    disabled block that shows the reason as a heading (e.g. "Aerification")
+    above the generic "Cannot be reserved" subheading, in place of a Reserve
+    button. Reading the heading lets us tell the user *why* nothing in their
+    requested window could be booked.
+    """
+
+    # The disabled block heading that holds the human-readable reason text
+    reason_heading: str = ".custom-disabled-heading"
+    # The slot's time label (e.g. "07:30 AM") within a disabled block
+    time_label: str = ".custom-time-label"
+    # Generic subheading text confirming a slot is unbookable
+    cannot_reserve_text: str = "cannot be reserved"
+
+
+@dataclass(frozen=True)
 class ErrorMessageSelectors:
     """Selectors for error/alert message containers."""
 
@@ -465,6 +484,7 @@ class WaldenDOMSchema:
     TBD_GUESTS: TBDGuestSelectors = TBDGuestSelectors()
     BOOKING_COMPLETION: BookingCompletionSelectors = BookingCompletionSelectors()
     SLOT_BLOCKED: SlotBlockedSelectors = SlotBlockedSelectors()
+    DISABLED_SLOT: DisabledSlotSelectors = DisabledSlotSelectors()
     ERROR_MESSAGES: ErrorMessageSelectors = ErrorMessageSelectors()
     CANCELLATION: CancellationSelectors = CancellationSelectors()
     COURSE_FILTERING: CourseFilteringSelectors = CourseFilteringSelectors()

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -4216,9 +4216,7 @@ class WaldenGolfProvider(ReservationProvider):
 
                     # Restrict to the requested window when we can read the time.
                     slot_time = None
-                    labels = slot_item.find_elements(
-                        By.CSS_SELECTOR, DOM.DISABLED_SLOT.time_label
-                    )
+                    labels = slot_item.find_elements(By.CSS_SELECTOR, DOM.DISABLED_SLOT.time_label)
                     for label in labels:
                         match = time_pattern.search(label.text.strip())
                         if match:
@@ -4303,9 +4301,7 @@ class WaldenGolfProvider(ReservationProvider):
             parts.append(event_message)
 
         blocked_message = self._format_blocked_slot_message(
-            self._extract_blocked_slot_reasons(
-                search_context, target_time, fallback_window_minutes
-            )
+            self._extract_blocked_slot_reasons(search_context, target_time, fallback_window_minutes)
         )
         if blocked_message:
             parts.append(blocked_message)

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -4184,7 +4184,10 @@ class WaldenGolfProvider(ReservationProvider):
         Only slots whose time falls within the target +/- fallback window are
         considered, so the reasons reflect the times the user actually asked
         for. Slots whose time cannot be parsed are still counted, so a fully
-        disabled sheet is not silently dropped.
+        disabled sheet is not silently dropped. When the search context is the
+        whole page (no dedicated Northgate section), slots belonging to another
+        course are skipped so a Walden reason never leaks into a Northgate
+        failure.
 
         Args:
             search_context: The WebDriver element (or driver) to search within
@@ -4213,6 +4216,15 @@ class WaldenGolfProvider(ReservationProvider):
                     )
                     if not headings:
                         continue  # Not a disabled slot
+
+                    # Skip slots that positively belong to another course. The
+                    # course index is embedded in child element IDs
+                    # (teeTimeCourses:0 = Northgate, :1 = Walden). When the
+                    # index can't be read we keep the slot (best-effort).
+                    slot_html = slot_item.get_attribute("innerHTML") or ""
+                    course_index = self._get_course_index_from_element_id(slot_html)
+                    if course_index is not None and course_index != self.NORTHGATE_COURSE_INDEX:
+                        continue
 
                     # Restrict to the requested window when we can read the time.
                     slot_time = None

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -2767,13 +2767,19 @@ class WaldenGolfProvider(ReservationProvider):
                 )
 
             if slot_info is None:
+                error_message = (
+                    f"No time slots with {num_players} available spots within "
+                    f"{fallback_window_minutes} minutes of {target_time.strftime('%I:%M %p')}"
+                )
+                detail = self._build_unavailability_detail(
+                    driver, target_time, fallback_window_minutes
+                )
+                if detail:
+                    error_message += f". {detail}"
                 return BookingResult(
                     success=False,
                     course_name=self.NORTHGATE_COURSE_NAME,
-                    error_message=(
-                        f"No time slots with {num_players} available spots within "
-                        f"{fallback_window_minutes} minutes of {target_time.strftime('%I:%M %p')}"
-                    ),
+                    error_message=error_message,
                 )
 
             booked_time = time(slot_info["hours"], slot_info["minutes"])
@@ -2926,6 +2932,14 @@ class WaldenGolfProvider(ReservationProvider):
                 error_message = (
                     f"No time slots with {num_players} available spots found. {event_message}"
                 )
+
+            blocked_message = self._format_blocked_slot_message(
+                self._extract_blocked_slot_reasons(
+                    search_context, target_time, fallback_window_minutes
+                )
+            )
+            if blocked_message:
+                error_message += f" {blocked_message}"
 
             return BookingResult(
                 success=False,
@@ -3093,6 +3107,14 @@ class WaldenGolfProvider(ReservationProvider):
             event_message = self._format_event_block_message(event_blocks)
             if event_message:
                 error_message += f". {event_message}"
+
+            blocked_message = self._format_blocked_slot_message(
+                self._extract_blocked_slot_reasons(
+                    search_context, target_time, fallback_window_minutes
+                )
+            )
+            if blocked_message:
+                error_message += f" {blocked_message}"
 
             return BookingResult(
                 success=False,
@@ -4141,6 +4163,154 @@ class WaldenGolfProvider(ReservationProvider):
             )
 
         return event_names
+
+    def _extract_blocked_slot_reasons(
+        self,
+        search_context: Any,
+        target_time: time,
+        fallback_window_minutes: int,
+    ) -> list[str]:
+        """
+        Extract the reasons individual tee-time slots are disabled/unbookable.
+
+        Beyond tournament time-range blocks (see _extract_event_blocks), the
+        Walden Golf tee sheet renders individually disabled slots that show the
+        slot time (e.g. "07:30 AM") alongside a reason heading such as
+        "Aerification" or "Weather delay" and the subheading "Cannot be
+        reserved". When nothing is bookable this tells the user *why* (e.g. the
+        course is closed for aerification) rather than only that no open times
+        were found.
+
+        Only slots whose time falls within the target +/- fallback window are
+        considered, so the reasons reflect the times the user actually asked
+        for. Slots whose time cannot be parsed are still counted, so a fully
+        disabled sheet is not silently dropped.
+
+        Args:
+            search_context: The WebDriver element (or driver) to search within
+            target_time: The target tee time being searched for
+            fallback_window_minutes: The fallback window in minutes
+
+        Returns:
+            List of distinct reason strings, ordered by first appearance.
+        """
+        reasons: list[str] = []
+        target_minutes = target_time.hour * 60 + target_time.minute
+        min_time_minutes = max(0, target_minutes - fallback_window_minutes)
+        max_time_minutes = min(24 * 60 - 1, target_minutes + fallback_window_minutes)
+
+        time_pattern = re.compile(r"(\d{1,2}):(\d{2})\s*([AaPp][Mm])")
+
+        try:
+            slot_items = search_context.find_elements(
+                By.CSS_SELECTOR, DOM.SLOT_DISCOVERY.slot_items
+            )
+
+            for slot_item in slot_items:
+                try:
+                    headings = slot_item.find_elements(
+                        By.CSS_SELECTOR, DOM.DISABLED_SLOT.reason_heading
+                    )
+                    if not headings:
+                        continue  # Not a disabled slot
+
+                    # Restrict to the requested window when we can read the time.
+                    slot_time = None
+                    labels = slot_item.find_elements(
+                        By.CSS_SELECTOR, DOM.DISABLED_SLOT.time_label
+                    )
+                    for label in labels:
+                        match = time_pattern.search(label.text.strip())
+                        if match:
+                            hour = int(match.group(1))
+                            minute = int(match.group(2))
+                            ampm = match.group(3).upper()
+                            if ampm == "PM" and hour != 12:
+                                hour += 12
+                            if ampm == "AM" and hour == 12:
+                                hour = 0
+                            slot_time = time(hour, minute)
+                            break
+
+                    if slot_time is not None:
+                        slot_minutes = slot_time.hour * 60 + slot_time.minute
+                        if not (min_time_minutes <= slot_minutes <= max_time_minutes):
+                            continue
+
+                    reason = " ".join(headings[0].text.split())
+                    if not reason or reason.lower() == DOM.DISABLED_SLOT.cannot_reserve_text:
+                        continue
+                    if reason not in reasons:
+                        logger.debug(f"Found blocked slot reason: '{reason}'")
+                        reasons.append(reason)
+
+                except Exception as e:
+                    logger.debug(f"Error processing slot item for blocked reason: {e}")
+                    continue
+
+        except Exception as e:
+            logger.debug(f"Error extracting blocked slot reasons: {e}")
+
+        if reasons:
+            logger.info(
+                f"Found {len(reasons)} blocked-slot reason(s) in requested window: {reasons}"
+            )
+
+        return reasons
+
+    def _format_blocked_slot_message(self, reasons: list[str]) -> str | None:
+        """
+        Format disabled-slot reasons into a human-readable message suffix.
+
+        Args:
+            reasons: List of reason headings (e.g. ["Aerification"]) that make
+                nearby slots unbookable.
+
+        Returns:
+            Formatted message string, or None if there are no reasons.
+        """
+        if not reasons:
+            return None
+
+        if len(reasons) == 1:
+            return f"Nearby tee times are unavailable: {reasons[0]} (cannot be reserved)."
+
+        reason_list = ", ".join(reasons[:3])
+        if len(reasons) > 3:
+            reason_list += f" and {len(reasons) - 3} more"
+        return f"Nearby tee times are unavailable: {reason_list} (cannot be reserved)."
+
+    def _build_unavailability_detail(
+        self,
+        search_context: Any,
+        target_time: time,
+        fallback_window_minutes: int,
+    ) -> str | None:
+        """
+        Build a combined explanation of why nothing in the window was bookable.
+
+        Merges tournament/event time-range blocks (_extract_event_blocks) with
+        individually disabled slot reasons (_extract_blocked_slot_reasons) into
+        a single suffix for the failure message. Returns None when neither
+        source has anything to report.
+        """
+        parts: list[str] = []
+
+        event_message = self._format_event_block_message(
+            self._extract_event_blocks(search_context, target_time, fallback_window_minutes)
+        )
+        if event_message:
+            parts.append(event_message)
+
+        blocked_message = self._format_blocked_slot_message(
+            self._extract_blocked_slot_reasons(
+                search_context, target_time, fallback_window_minutes
+            )
+        )
+        if blocked_message:
+            parts.append(blocked_message)
+
+        return " ".join(parts) if parts else None
 
     @with_retry(max_attempts=3, backoff_base=0.5)
     def _find_available_slots(self, search_context: Any) -> list[tuple[time, Any]]:

--- a/docs/discord-setup.md
+++ b/docs/discord-setup.md
@@ -35,17 +35,30 @@ Discord gateway (a persistent WebSocket), so the service must run with
    This goes in `DISCORD_USER_ID` and is the allowlist — the bot ignores
    everyone else.
 
+7. **(Optional) Get a channel ID for shared replies**: with Developer Mode on,
+   right-click the channel you want the bot to talk in (e.g. `#general`) →
+   **Copy Channel ID**. Put it in `DISCORD_CHANNEL_ID`. When set, the bot posts
+   booking confirmations and failures into that channel (mentioning you)
+   instead of a private DM, so the whole conversation stays in one place. Make
+   sure the bot has **Send Messages** and **View Channels** permission there.
+
 ## App configuration
 
 ```
 MESSAGING_CHANNEL=discord
 DISCORD_BOT_TOKEN=<token from step 3>
 DISCORD_USER_ID=<id from step 6>
+DISCORD_CHANNEL_ID=<id from step 7, optional>
 ```
 
 Locally: put these in `.env` and run the server; the gateway starts inside
 the FastAPI process (log line: `Discord gateway connected as TeeTime#...`).
-Send the bot a DM — message flow is identical to the old SMS flow.
+Message the bot — message flow is identical to the old SMS flow. Talk to it in
+your shared channel by @-mentioning it, or send a DM.
+
+By default, async notifications (the booking result at 6:30 AM when the window
+opens) are sent as a DM. Set `DISCORD_CHANNEL_ID` to have those replies posted
+in your shared channel instead, matching where you asked for the booking.
 
 For Cloud Run, add the two secrets and set
 `--min-instances=1` so the gateway stays connected.

--- a/docs/discord-setup.md
+++ b/docs/discord-setup.md
@@ -44,7 +44,7 @@ Discord gateway (a persistent WebSocket), so the service must run with
 
 ## App configuration
 
-```
+```dotenv
 MESSAGING_CHANNEL=discord
 DISCORD_BOT_TOKEN=<token from step 3>
 DISCORD_USER_ID=<id from step 6>

--- a/tests/test_discord_provider.py
+++ b/tests/test_discord_provider.py
@@ -123,6 +123,50 @@ class TestSendSms:
         result = await provider.send_sms("", "hello")
         assert not result.success
 
+    async def test_posts_to_shared_channel_when_configured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With DISCORD_CHANNEL_ID set, send to that channel (mentioning the user),
+        not a private DM."""
+        monkeypatch.setattr(settings, "discord_channel_id", "9001")
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(200, json={"id": "msg-1"})
+
+        provider = make_provider(handler)
+        result = await provider.send_sms("123456789012345678", "tee time confirmed")
+
+        assert result.success
+        # No DM channel was opened; the message went straight to the channel.
+        assert all(not r.url.path.endswith("/users/@me/channels") for r in requests)
+        assert requests[0].url.path.endswith("/channels/9001/messages")
+        assert json.loads(requests[0].content) == {
+            "content": "<@123456789012345678> tee time confirmed"
+        }
+
+    async def test_shared_channel_unset_falls_back_to_dm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "discord_channel_id", "")
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            if request.url.path.endswith("/users/@me/channels"):
+                return httpx.Response(200, json={"id": "555"})
+            return httpx.Response(200, json={"id": "msg-1"})
+
+        provider = make_provider(handler)
+        result = await provider.send_sms("123456789012345678", "hi")
+
+        assert result.success
+        # A DM channel was opened and used.
+        assert requests[0].url.path.endswith("/users/@me/channels")
+        assert requests[1].url.path.endswith("/channels/555/messages")
+        assert json.loads(requests[1].content) == {"content": "hi"}
+
     def test_validate_request_always_true(self) -> None:
         provider = DiscordProvider()
         assert provider.validate_request("http://x", {}, None)

--- a/tests/test_discord_provider.py
+++ b/tests/test_discord_provider.py
@@ -5,8 +5,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
+from pydantic import ValidationError
 
-from app.config import settings
+from app.config import Settings, settings
 from app.providers.discord_provider import (
     MAX_MESSAGE_LEN,
     DiscordProvider,
@@ -149,6 +150,7 @@ class TestSendSms:
     async def test_shared_channel_unset_falls_back_to_dm(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """With no DISCORD_CHANNEL_ID, delivery opens and uses a private DM."""
         monkeypatch.setattr(settings, "discord_channel_id", "")
         requests: list[httpx.Request] = []
 
@@ -170,6 +172,25 @@ class TestSendSms:
     def test_validate_request_always_true(self) -> None:
         provider = DiscordProvider()
         assert provider.validate_request("http://x", {}, None)
+
+
+class TestDiscordChannelIdValidation:
+    """DISCORD_CHANNEL_ID must be a numeric snowflake, or empty (DM fallback)."""
+
+    def test_empty_is_allowed(self) -> None:
+        """An unset channel ID is valid and means 'use DMs'."""
+        assert Settings(discord_channel_id="").discord_channel_id == ""
+
+    def test_valid_snowflake_is_accepted_and_trimmed(self) -> None:
+        """A numeric ID (with surrounding whitespace) is accepted and trimmed."""
+        assert Settings(discord_channel_id="  123456789012345678  ").discord_channel_id == (
+            "123456789012345678"
+        )
+
+    def test_channel_name_is_rejected(self) -> None:
+        """A channel name like '#general' is rejected at load time."""
+        with pytest.raises(ValidationError):
+            Settings(discord_channel_id="#general")
 
 
 class TestShouldHandleMessage:

--- a/tests/test_dom_parsing.py
+++ b/tests/test_dom_parsing.py
@@ -127,9 +127,7 @@ class TestDisabledSlotSelectors:
     (e.g. aerification, weather delay) instead of only reporting no openings.
     """
 
-    def test_disabled_headings_present_with_reason_text(
-        self, tee_time_page_html: BeautifulSoup
-    ):
+    def test_disabled_headings_present_with_reason_text(self, tee_time_page_html: BeautifulSoup):
         """Disabled slots expose a reason heading (e.g. 'Weather delay')."""
         headings = tee_time_page_html.select(".custom-disabled-heading")
         assert len(headings) >= 1, "No disabled-slot reason headings found"
@@ -139,15 +137,11 @@ class TestDisabledSlotSelectors:
         # The captured fixture is a frost/weather-delayed morning.
         assert "Weather delay" in reasons
 
-    def test_disabled_slot_marked_cannot_be_reserved(
-        self, tee_time_page_html: BeautifulSoup
-    ):
+    def test_disabled_slot_marked_cannot_be_reserved(self, tee_time_page_html: BeautifulSoup):
         """Disabled slots carry the generic 'Cannot be reserved' subheading."""
         subheadings = tee_time_page_html.select(".custom-disabled-subheading-txt")
         assert len(subheadings) >= 1
-        assert any(
-            "cannot be reserved" in s.get_text(strip=True).lower() for s in subheadings
-        )
+        assert any("cannot be reserved" in s.get_text(strip=True).lower() for s in subheadings)
 
     def test_disabled_slot_has_time_label(self, tee_time_page_html: BeautifulSoup):
         """A disabled slot still shows its tee time via the time label."""

--- a/tests/test_dom_parsing.py
+++ b/tests/test_dom_parsing.py
@@ -120,6 +120,47 @@ class TestTeeTimeSlotSelectors:
             assert "Reserve" in el.get_text(), f"Button doesn't say Reserve: {el.get_text()}"
 
 
+class TestDisabledSlotSelectors:
+    """Tests validating the disabled-slot reason selectors against real HTML.
+
+    These selectors let the provider explain *why* a window is unbookable
+    (e.g. aerification, weather delay) instead of only reporting no openings.
+    """
+
+    def test_disabled_headings_present_with_reason_text(
+        self, tee_time_page_html: BeautifulSoup
+    ):
+        """Disabled slots expose a reason heading (e.g. 'Weather delay')."""
+        headings = tee_time_page_html.select(".custom-disabled-heading")
+        assert len(headings) >= 1, "No disabled-slot reason headings found"
+
+        reasons = {h.get_text(strip=True) for h in headings}
+        assert any(r for r in reasons), "Disabled headings had no reason text"
+        # The captured fixture is a frost/weather-delayed morning.
+        assert "Weather delay" in reasons
+
+    def test_disabled_slot_marked_cannot_be_reserved(
+        self, tee_time_page_html: BeautifulSoup
+    ):
+        """Disabled slots carry the generic 'Cannot be reserved' subheading."""
+        subheadings = tee_time_page_html.select(".custom-disabled-subheading-txt")
+        assert len(subheadings) >= 1
+        assert any(
+            "cannot be reserved" in s.get_text(strip=True).lower() for s in subheadings
+        )
+
+    def test_disabled_slot_has_time_label(self, tee_time_page_html: BeautifulSoup):
+        """A disabled slot still shows its tee time via the time label."""
+        li_items = tee_time_page_html.select("li.ui-datascroller-item")
+        disabled_items = [li for li in li_items if li.select_one(".custom-disabled-heading")]
+        assert len(disabled_items) >= 1
+
+        time_pattern = re.compile(r"\d{1,2}:\d{2}\s*(AM|PM)", re.IGNORECASE)
+        label = disabled_items[0].select_one(".custom-time-label")
+        assert label is not None
+        assert time_pattern.match(label.get_text(strip=True))
+
+
 class TestCourseIdentification:
     """Tests for identifying which course a slot belongs to."""
 

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -1379,11 +1379,15 @@ class TestWaldenProviderFormatEventBlockMessage:
         assert result == "Times blocked by events: Event A, Event B, Event C and 2 more"
 
 
-def _make_disabled_slot(reason: str | None, time_text: str | None) -> MagicMock:
+def _make_disabled_slot(
+    reason: str | None, time_text: str | None, course_index: str = "0"
+) -> MagicMock:
     """Build a mock datascroller slot item for _extract_blocked_slot_reasons.
 
     Passing reason=None simulates a normal (bookable) slot with no disabled
     heading; time_text=None simulates a disabled slot whose time can't be read.
+    course_index tags the slot's course via the teeTimeCourses:<n> element-ID
+    pattern ("0" = Northgate, "1" = Walden on Lake Conroe).
     """
     slot = MagicMock()
 
@@ -1407,6 +1411,9 @@ def _make_disabled_slot(reason: str | None, time_text: str | None) -> MagicMock:
         return []
 
     slot.find_elements.side_effect = find_elements
+    slot.get_attribute.return_value = (
+        f"<div id='...teeTimeCourses:{course_index}:teeTimeSlots:0:slotTee:0:slotTeeDIV'></div>"
+    )
     return slot
 
 
@@ -1414,6 +1421,7 @@ class TestWaldenProviderExtractBlockedSlotReasons:
     """Tests for the _extract_blocked_slot_reasons method."""
 
     def test_extracts_single_reason_in_window(self, provider: WaldenGolfProvider) -> None:
+        """A single disabled slot in the window yields its reason."""
         search_context = MagicMock()
         search_context.find_elements.return_value = [
             _make_disabled_slot("Aerification", "05:07 PM")
@@ -1426,6 +1434,7 @@ class TestWaldenProviderExtractBlockedSlotReasons:
         assert result == ["Aerification"]
 
     def test_deduplicates_repeated_reason(self, provider: WaldenGolfProvider) -> None:
+        """A reason shared by many blocked slots is reported once."""
         search_context = MagicMock()
         search_context.find_elements.return_value = [
             _make_disabled_slot("Aerification", "05:07 PM"),
@@ -1440,6 +1449,7 @@ class TestWaldenProviderExtractBlockedSlotReasons:
         assert result == ["Aerification"]
 
     def test_collects_distinct_reasons_in_order(self, provider: WaldenGolfProvider) -> None:
+        """Distinct reasons are collected in first-seen order."""
         search_context = MagicMock()
         search_context.find_elements.return_value = [
             _make_disabled_slot("Weather delay", "07:30 AM"),
@@ -1453,6 +1463,7 @@ class TestWaldenProviderExtractBlockedSlotReasons:
         assert result == ["Weather delay", "Aerification"]
 
     def test_ignores_reasons_outside_window(self, provider: WaldenGolfProvider) -> None:
+        """Blocked slots outside the target +/- window are ignored."""
         search_context = MagicMock()
         search_context.find_elements.return_value = [
             _make_disabled_slot("Aerification", "07:30 AM")
@@ -1466,6 +1477,7 @@ class TestWaldenProviderExtractBlockedSlotReasons:
         assert result == []
 
     def test_ignores_bookable_slots(self, provider: WaldenGolfProvider) -> None:
+        """Normal (non-disabled) slots contribute no reason."""
         search_context = MagicMock()
         # No disabled heading -> a normal, bookable slot.
         search_context.find_elements.return_value = [_make_disabled_slot(None, "05:07 PM")]
@@ -1475,6 +1487,25 @@ class TestWaldenProviderExtractBlockedSlotReasons:
         )
 
         assert result == []
+
+    def test_excludes_non_northgate_course(self, provider: WaldenGolfProvider) -> None:
+        """A disabled slot from another course (Walden) is not reported.
+
+        When no dedicated Northgate section exists the search spans the whole
+        page, so Walden-on-Lake-Conroe disabled slots must be filtered out by
+        course index rather than surfaced in a Northgate failure message.
+        """
+        search_context = MagicMock()
+        search_context.find_elements.return_value = [
+            _make_disabled_slot("Aerification", "05:07 PM", course_index="1"),  # Walden
+            _make_disabled_slot("Weather delay", "05:15 PM", course_index="0"),  # Northgate
+        ]
+
+        result = provider._extract_blocked_slot_reasons(
+            search_context, target_time=time(17, 7), fallback_window_minutes=32
+        )
+
+        assert result == ["Weather delay"]
 
     def test_includes_reason_when_time_unreadable(self, provider: WaldenGolfProvider) -> None:
         """A disabled slot with no parseable time is still surfaced."""
@@ -1488,6 +1519,7 @@ class TestWaldenProviderExtractBlockedSlotReasons:
         assert result == ["Aerification"]
 
     def test_skips_generic_cannot_be_reserved_heading(self, provider: WaldenGolfProvider) -> None:
+        """The generic 'Cannot be reserved' text is not treated as a reason."""
         search_context = MagicMock()
         search_context.find_elements.return_value = [
             _make_disabled_slot("Cannot be reserved", "05:07 PM")
@@ -1500,6 +1532,7 @@ class TestWaldenProviderExtractBlockedSlotReasons:
         assert result == []
 
     def test_handles_empty_search_context(self, provider: WaldenGolfProvider) -> None:
+        """An empty tee sheet yields no reasons and does not error."""
         search_context = MagicMock()
         search_context.find_elements.return_value = []
 
@@ -1514,19 +1547,23 @@ class TestWaldenProviderFormatBlockedSlotMessage:
     """Tests for the _format_blocked_slot_message helper method."""
 
     def test_returns_none_for_empty_list(self, provider: WaldenGolfProvider) -> None:
+        """No reasons produces no message suffix."""
         assert provider._format_blocked_slot_message([]) is None
 
     def test_formats_single_reason(self, provider: WaldenGolfProvider) -> None:
+        """A single reason renders as a one-item sentence."""
         result = provider._format_blocked_slot_message(["Aerification"])
         assert result == "Nearby tee times are unavailable: Aerification (cannot be reserved)."
 
     def test_formats_multiple_reasons(self, provider: WaldenGolfProvider) -> None:
+        """Multiple reasons are comma-joined."""
         result = provider._format_blocked_slot_message(["Aerification", "Weather delay"])
         assert result == (
             "Nearby tee times are unavailable: Aerification, Weather delay (cannot be reserved)."
         )
 
     def test_truncates_more_than_three_reasons(self, provider: WaldenGolfProvider) -> None:
+        """More than three reasons are truncated with an 'and N more' tail."""
         result = provider._format_blocked_slot_message(["A", "B", "C", "D", "E"])
         assert (
             result == "Nearby tee times are unavailable: A, B, C and 2 more (cannot be reserved)."

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -1379,6 +1379,158 @@ class TestWaldenProviderFormatEventBlockMessage:
         assert result == "Times blocked by events: Event A, Event B, Event C and 2 more"
 
 
+def _make_disabled_slot(reason: str | None, time_text: str | None) -> MagicMock:
+    """Build a mock datascroller slot item for _extract_blocked_slot_reasons.
+
+    Passing reason=None simulates a normal (bookable) slot with no disabled
+    heading; time_text=None simulates a disabled slot whose time can't be read.
+    """
+    slot = MagicMock()
+
+    heading_els = []
+    if reason is not None:
+        heading = MagicMock()
+        heading.text = reason
+        heading_els = [heading]
+
+    label_els = []
+    if time_text is not None:
+        label = MagicMock()
+        label.text = time_text
+        label_els = [label]
+
+    def find_elements(_by: str, selector: str) -> list[MagicMock]:
+        if selector == DOM.DISABLED_SLOT.reason_heading:
+            return heading_els
+        if selector == DOM.DISABLED_SLOT.time_label:
+            return label_els
+        return []
+
+    slot.find_elements.side_effect = find_elements
+    return slot
+
+
+class TestWaldenProviderExtractBlockedSlotReasons:
+    """Tests for the _extract_blocked_slot_reasons method."""
+
+    def test_extracts_single_reason_in_window(self, provider: WaldenGolfProvider) -> None:
+        search_context = MagicMock()
+        search_context.find_elements.return_value = [
+            _make_disabled_slot("Aerification", "05:07 PM")
+        ]
+
+        result = provider._extract_blocked_slot_reasons(
+            search_context, target_time=time(17, 7), fallback_window_minutes=32
+        )
+
+        assert result == ["Aerification"]
+
+    def test_deduplicates_repeated_reason(self, provider: WaldenGolfProvider) -> None:
+        search_context = MagicMock()
+        search_context.find_elements.return_value = [
+            _make_disabled_slot("Aerification", "05:07 PM"),
+            _make_disabled_slot("Aerification", "05:15 PM"),
+            _make_disabled_slot("Aerification", "05:23 PM"),
+        ]
+
+        result = provider._extract_blocked_slot_reasons(
+            search_context, target_time=time(17, 15), fallback_window_minutes=32
+        )
+
+        assert result == ["Aerification"]
+
+    def test_collects_distinct_reasons_in_order(self, provider: WaldenGolfProvider) -> None:
+        search_context = MagicMock()
+        search_context.find_elements.return_value = [
+            _make_disabled_slot("Weather delay", "07:30 AM"),
+            _make_disabled_slot("Aerification", "07:38 AM"),
+        ]
+
+        result = provider._extract_blocked_slot_reasons(
+            search_context, target_time=time(7, 34), fallback_window_minutes=32
+        )
+
+        assert result == ["Weather delay", "Aerification"]
+
+    def test_ignores_reasons_outside_window(self, provider: WaldenGolfProvider) -> None:
+        search_context = MagicMock()
+        search_context.find_elements.return_value = [
+            _make_disabled_slot("Aerification", "07:30 AM")
+        ]
+
+        # Target 5pm; the 7:30am block is well outside the window.
+        result = provider._extract_blocked_slot_reasons(
+            search_context, target_time=time(17, 0), fallback_window_minutes=32
+        )
+
+        assert result == []
+
+    def test_ignores_bookable_slots(self, provider: WaldenGolfProvider) -> None:
+        search_context = MagicMock()
+        # No disabled heading -> a normal, bookable slot.
+        search_context.find_elements.return_value = [_make_disabled_slot(None, "05:07 PM")]
+
+        result = provider._extract_blocked_slot_reasons(
+            search_context, target_time=time(17, 7), fallback_window_minutes=32
+        )
+
+        assert result == []
+
+    def test_includes_reason_when_time_unreadable(self, provider: WaldenGolfProvider) -> None:
+        """A disabled slot with no parseable time is still surfaced."""
+        search_context = MagicMock()
+        search_context.find_elements.return_value = [_make_disabled_slot("Aerification", None)]
+
+        result = provider._extract_blocked_slot_reasons(
+            search_context, target_time=time(17, 7), fallback_window_minutes=32
+        )
+
+        assert result == ["Aerification"]
+
+    def test_skips_generic_cannot_be_reserved_heading(self, provider: WaldenGolfProvider) -> None:
+        search_context = MagicMock()
+        search_context.find_elements.return_value = [
+            _make_disabled_slot("Cannot be reserved", "05:07 PM")
+        ]
+
+        result = provider._extract_blocked_slot_reasons(
+            search_context, target_time=time(17, 7), fallback_window_minutes=32
+        )
+
+        assert result == []
+
+    def test_handles_empty_search_context(self, provider: WaldenGolfProvider) -> None:
+        search_context = MagicMock()
+        search_context.find_elements.return_value = []
+
+        result = provider._extract_blocked_slot_reasons(
+            search_context, target_time=time(17, 7), fallback_window_minutes=32
+        )
+
+        assert result == []
+
+
+class TestWaldenProviderFormatBlockedSlotMessage:
+    """Tests for the _format_blocked_slot_message helper method."""
+
+    def test_returns_none_for_empty_list(self, provider: WaldenGolfProvider) -> None:
+        assert provider._format_blocked_slot_message([]) is None
+
+    def test_formats_single_reason(self, provider: WaldenGolfProvider) -> None:
+        result = provider._format_blocked_slot_message(["Aerification"])
+        assert result == "Nearby tee times are unavailable: Aerification (cannot be reserved)."
+
+    def test_formats_multiple_reasons(self, provider: WaldenGolfProvider) -> None:
+        result = provider._format_blocked_slot_message(["Aerification", "Weather delay"])
+        assert result == (
+            "Nearby tee times are unavailable: Aerification, Weather delay (cannot be reserved)."
+        )
+
+    def test_truncates_more_than_three_reasons(self, provider: WaldenGolfProvider) -> None:
+        result = provider._format_blocked_slot_message(["A", "B", "C", "D", "E"])
+        assert result == "Nearby tee times are unavailable: A, B, C and 2 more (cannot be reserved)."
+
+
 class TestWaldenProviderEnhancedErrorMessages:
     """Tests for enhanced error messages with event information."""
 
@@ -1453,6 +1605,32 @@ class TestWaldenProviderEnhancedErrorMessages:
         assert result.success is False
         assert "No time slots with 4 available spots found" in result.error_message
         assert "blocked by event" not in result.error_message
+
+    def test_error_message_includes_blocked_slot_reason(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Failure message names the disabled-slot reason (e.g. Aerification)."""
+        mock_driver = MagicMock()
+
+        monkeypatch.setattr(provider, "_scroll_to_load_all_slots", MagicMock())
+        monkeypatch.setattr(provider, "_find_empty_slots", MagicMock(return_value=[]))
+        monkeypatch.setattr(provider, "_extract_event_blocks", MagicMock(return_value=[]))
+        monkeypatch.setattr(
+            provider,
+            "_extract_blocked_slot_reasons",
+            MagicMock(return_value=["Aerification"]),
+        )
+
+        result = provider._find_and_book_time_slot_sync(
+            mock_driver,
+            target_time=time(17, 7),
+            num_players=4,
+            fallback_window_minutes=32,
+        )
+
+        assert result.success is False
+        assert "Aerification" in result.error_message
+        assert "cannot be reserved" in result.error_message.lower()
 
     def test_fallback_failure_includes_event_info(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -1528,7 +1528,9 @@ class TestWaldenProviderFormatBlockedSlotMessage:
 
     def test_truncates_more_than_three_reasons(self, provider: WaldenGolfProvider) -> None:
         result = provider._format_blocked_slot_message(["A", "B", "C", "D", "E"])
-        assert result == "Nearby tee times are unavailable: A, B, C and 2 more (cannot be reserved)."
+        assert (
+            result == "Nearby tee times are unavailable: A, B, C and 2 more (cannot be reserved)."
+        )
 
 
 class TestWaldenProviderEnhancedErrorMessages:


### PR DESCRIPTION
## Summary

Two fixes to how the tee-time agent reports booking outcomes, both driven by the reported behavior in the screenshots (an afternoon fully blocked by **Aerification**, and result details arriving as a separate DM).

### 1. Tell the user *why* nothing was bookable

Previously a failed booking only said something like "No time slots with 4 available spots." When the real cause was that the nearby slots are individually disabled — aerification, weather delay, frost delay, etc. (the "Cannot be reserved" blocks on the tee sheet) — that reason was dropped.

- New `_extract_blocked_slot_reasons` reads the disabled-slot reason heading (e.g. `Aerification`, `Weather delay`) for slots within the requested time window.
- New `_format_blocked_slot_message` renders it as `Nearby tee times are unavailable: Aerification (cannot be reserved).`
- `_build_unavailability_detail` combines this with the existing tournament event-block extraction, so failure messages carry both when relevant.
- The **fast JS booking path** — which previously returned a bare "no slots" message — now includes this detail too. This is the path that runs in production at 6:30 AM, so it's the one the user actually sees.

The enriched `error_message` already flows through both the single-booking path (`execute_booking`) and the batch job (`jobs.py`) to the user notification, so no changes were needed there.

### 2. Reply in the shared channel, not a private DM

Async booking results (sent when the booking window opens) went out as a Discord DM even when the request was made in a shared channel, splitting the conversation. Added a `DISCORD_CHANNEL_ID` setting: when set, `DiscordProvider` posts confirmations/failures into that channel and `@`-mentions the user, instead of opening a DM. Falls back to DM when unset, so existing single-user DM deployments are unaffected.

Immediate replies were already going to the originating channel (via the gateway), so only the async provider path needed the change.

## Testing

- `_extract_blocked_slot_reasons` / `_format_blocked_slot_message`: window filtering, dedup, distinct-reason ordering, unreadable-time fallback, generic-heading skip.
- Real-fixture DOM test confirms the disabled-slot selectors (`.custom-disabled-heading`, `.custom-time-label`, `Cannot be reserved`) match the captured Walden HTML.
- Slow-path failure message includes the blocked reason end-to-end.
- `DiscordProvider`: posts to the configured channel with an `@`-mention when `DISCORD_CHANNEL_ID` is set; falls back to DM when unset.
- Full suite: 520 passed, 10 skipped. `ruff` and `mypy` clean.

## Config / rollout

Set `DISCORD_CHANNEL_ID` (channel snowflake, Developer Mode → Copy Channel ID) to route notifications into your shared channel; the bot needs Send Messages + View Channels there. Documented in `docs/discord-setup.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSY1o79Mw4o1wzvGmg2pSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSY1o79Mw4o1wzvGmg2pSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional shared Discord channel delivery for booking notifications, with private messages remaining the fallback.
  * Booking availability errors now include specific reasons for unavailable tee times, such as weather delays or reservation restrictions.

* **Documentation**
  * Added setup guidance for configuring shared Discord channel notifications.

* **Tests**
  * Added coverage for shared-channel messaging and detailed unavailable-slot explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->