### PR TITLE
fix: reply in the channel the conversation started in

### DIFF
--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -299,7 +299,9 @@ async def execute_due_bookings(
                     f"{result.fallback_reason}"
                 )
 
-            await sms_service.send_booking_confirmation(original_booking.phone_number, details)
+            await sms_service.send_booking_confirmation(
+                original_booking.phone_number, details, original_booking.origin_channel_id
+            )
         else:
             failed += 1
             error_message = (
@@ -328,6 +330,7 @@ async def execute_due_bookings(
                 original_booking.phone_number,
                 error_message or "Unknown error",
                 booking_details=booking_details,
+                origin_channel_id=original_booking.origin_channel_id,
             )
 
     logger.info(

--- a/app/models/database.py
+++ b/app/models/database.py
@@ -52,6 +52,9 @@ class BookingRecord(Base):
             from requested_time if fallback was used).
         confirmation_number: Confirmation number from the club website.
         error_message: Details about why a booking failed.
+        origin_channel_id: Discord channel ID the booking was requested in, so
+            the result notification replies in that conversation rather than a
+            DM. NULL for SMS and REST API bookings.
         created_at: When this record was created.
         updated_at: When this record was last modified.
     """
@@ -70,6 +73,7 @@ class BookingRecord(Base):
     actual_booked_time = Column(Time, nullable=True)
     confirmation_number = Column(String(100), nullable=True)
     error_message = Column(Text, nullable=True)
+    origin_channel_id = Column(String(32), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
@@ -90,6 +94,8 @@ class SessionRecord(Base):
             through the conversation. NULL when state is IDLE.
         pending_cancellation_id: Booking ID awaiting cancellation confirmation.
             Set when user requests to cancel and we're waiting for confirmation.
+        origin_channel_id: Discord channel ID of the user's current conversation,
+            refreshed on each inbound message. NULL for SMS users.
         last_interaction: Timestamp of the user's last message.
     """
 
@@ -100,6 +106,7 @@ class SessionRecord(Base):
     state: Column[Any] = Column(Enum(ConversationState), default=ConversationState.IDLE)
     pending_request_json = Column(Text, nullable=True)
     pending_cancellation_id = Column(String(50), nullable=True)
+    origin_channel_id = Column(String(32), nullable=True)
     last_interaction = Column(DateTime, default=datetime.utcnow)
 
 
@@ -118,6 +125,16 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
+# Columns added after the initial deployment, as (table, column, SQL type).
+# create_all() only creates missing tables, so existing installs need these
+# backfilled explicitly. Append to this list when adding a nullable column.
+_ADDED_COLUMNS: list[tuple[str, str, str]] = [
+    ("sessions", "pending_cancellation_id", "VARCHAR(50)"),
+    ("sessions", "origin_channel_id", "VARCHAR(32)"),
+    ("bookings", "origin_channel_id", "VARCHAR(32)"),
+]
+
+
 async def _run_column_migrations(conn: Any) -> None:
     """
     Run idempotent schema migrations for columns added after initial deployment.
@@ -128,24 +145,22 @@ async def _run_column_migrations(conn: Any) -> None:
     is_postgres = settings.database_url.startswith("postgresql")
     is_sqlite = settings.database_url.startswith("sqlite")
 
-    if is_postgres:
-        await conn.execute(
-            text(
-                "ALTER TABLE sessions ADD COLUMN IF NOT EXISTS pending_cancellation_id VARCHAR(50)"
-            )
-        )
-        logger.info("Checked/added pending_cancellation_id column to sessions table")
-    elif is_sqlite:
-        try:
+    for table, column, sql_type in _ADDED_COLUMNS:
+        if is_postgres:
             await conn.execute(
-                text("ALTER TABLE sessions ADD COLUMN pending_cancellation_id VARCHAR(50)")
+                text(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {column} {sql_type}")
             )
-            logger.info("Added pending_cancellation_id column to sessions table")
-        except Exception as e:
-            if "duplicate column" in str(e).lower():
-                logger.debug("pending_cancellation_id column already exists")
-            else:
-                raise
+            logger.info(f"Checked/added {column} column to {table} table")
+        elif is_sqlite:
+            # SQLite has no ADD COLUMN IF NOT EXISTS; a duplicate is the no-op case.
+            try:
+                await conn.execute(text(f"ALTER TABLE {table} ADD COLUMN {column} {sql_type}"))
+                logger.info(f"Added {column} column to {table} table")
+            except Exception as e:
+                if "duplicate column" in str(e).lower():
+                    logger.debug(f"{column} column already exists on {table}")
+                else:
+                    raise
 
 
 async def _run_enum_migrations() -> None:

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -87,6 +87,10 @@ class TeeTimeBooking(BaseModel):
             populated on SUCCESS.
         error_message: Description of why the booking failed. Only populated
             on FAILED status.
+        origin_channel_id: Discord channel the booking was requested in, captured
+            when the booking is created so the result notification (sent days
+            later, at 6:30am) goes back to the same conversation instead of a DM.
+            None for bookings made over SMS or the REST API.
         created_at: When this booking record was created.
         updated_at: When this booking record was last modified.
     """
@@ -95,6 +99,7 @@ class TeeTimeBooking(BaseModel):
     phone_number: str
     request: TeeTimeRequest
     status: BookingStatus = BookingStatus.PENDING
+    origin_channel_id: str | None = None
     scheduled_execution_time: datetime | None = None
     actual_booked_time: time | None = None
     confirmation_number: str | None = None
@@ -147,6 +152,10 @@ class UserSession(BaseModel):
             None when IDLE.
         pending_cancellation_id: ID of a booking awaiting cancellation confirmation.
             Set when user requests to cancel and we're waiting for them to confirm.
+        origin_channel_id: Discord channel the user's current conversation is
+            happening in, refreshed on every inbound message. Bookings copy it at
+            creation time so their notifications reply in the same place. None for
+            SMS users, who have no channel concept.
         last_interaction: Timestamp of the user's last message. Used for
             session timeout logic.
     """
@@ -156,6 +165,7 @@ class UserSession(BaseModel):
     pending_request: TeeTimeRequest | None = None
     pending_requests: list[TeeTimeRequest] | None = None
     pending_cancellation_id: str | None = None
+    origin_channel_id: str | None = None
     last_interaction: datetime = Field(default_factory=datetime.utcnow)
 
 

--- a/app/providers/discord_provider.py
+++ b/app/providers/discord_provider.py
@@ -1,7 +1,8 @@
 """
 Discord implementation of the messaging provider interface.
 
-Outbound messages are sent as Discord DMs via the REST API (bot token auth).
+Outbound messages are sent via the REST API (bot token auth), into the channel
+the conversation started in when one was recorded, and as a DM otherwise.
 Inbound messages arrive over the gateway WebSocket (see
 app/services/discord_gateway.py), not HTTP webhooks, so there is no request
 signature to validate.
@@ -23,6 +24,12 @@ logger = logging.getLogger(__name__)
 DISCORD_API_BASE = "https://discord.com/api/v10"
 MAX_MESSAGE_LEN = 2000  # Discord's hard limit per message
 
+# Recorded as a conversation's origin when it started in a DM rather than a
+# guild channel. A DM channel has a real snowflake, but storing it would make
+# replies indistinguishable from a shared channel and add a spurious @-mention;
+# the sentinel just says "reply the way we always did".
+DM_ORIGIN = "dm"
+
 
 def split_message(message: str, limit: int = MAX_MESSAGE_LEN) -> list[str]:
     """Split a message into chunks under Discord's length limit, preferring newlines."""
@@ -42,12 +49,14 @@ def split_message(message: str, limit: int = MAX_MESSAGE_LEN) -> list[str]:
 
 
 class DiscordProvider(SMSProvider):
-    """Sends messages to a Discord user via bot DMs.
+    """Sends messages to a Discord user, in a shared channel or via bot DM.
 
     The ``to_number`` argument is a Discord user ID (snowflake string). If it
     is not numeric (e.g. a legacy phone number), the configured
     ``discord_user_id`` is used instead so notification paths written for SMS
     still reach the user.
+
+    ``origin_channel_id`` selects the destination - see ``resolve_channel_id``.
     """
 
     def __init__(self, transport: httpx.AsyncBaseTransport | None = None) -> None:
@@ -89,19 +98,47 @@ class DiscordProvider(SMSProvider):
         self._dm_channels[user_id] = channel_id
         return channel_id
 
-    async def send_sms(self, to_number: str, message: str) -> SMSResult:
+    @staticmethod
+    def resolve_channel_id(origin_channel_id: str | None) -> str | None:
+        """Pick the channel to post into, or None to fall back to a DM.
+
+        Async notifications (the 6:30am booking result) are sent days after the
+        request, so they carry the channel the conversation started in. Replying
+        there keeps the thread where the user asked instead of splitting it into a
+        private DM.
+
+        Precedence:
+        1. A guild channel ID from the originating conversation.
+        2. DM_ORIGIN, meaning the conversation started in a DM - reply in the DM
+           even when a shared channel is configured, since a DM is where the user
+           chose to talk.
+        3. No origin at all (REST API bookings, SMS, the weekly prompt, and
+           bookings created before origins were recorded): DISCORD_CHANNEL_ID if
+           set, else a DM.
+        """
+        candidate = (origin_channel_id or "").strip()
+        if candidate.isdigit():
+            return candidate
+        if candidate == DM_ORIGIN:
+            return None
+        if candidate:
+            logger.warning(f"Ignoring unrecognized Discord origin channel {candidate!r}")
+        return settings.discord_channel_id.strip() or None
+
+    async def send_sms(
+        self, to_number: str, message: str, origin_channel_id: str | None = None
+    ) -> SMSResult:
         user_id = self.resolve_user_id(to_number)
         if not user_id:
             return SMSResult(success=False, error_message="No Discord user ID configured")
 
-        # When a shared channel is configured, post there (mentioning the user)
-        # so async notifications land in the same place the request was made,
-        # instead of splitting the conversation into a private DM.
-        shared_channel_id = settings.discord_channel_id.strip()
+        target_channel_id = self.resolve_channel_id(origin_channel_id)
+        destination = f"channel {target_channel_id}" if target_channel_id else f"DM to {user_id}"
         try:
             async with self._client() as client:
-                if shared_channel_id:
-                    channel_id = shared_channel_id
+                if target_channel_id:
+                    # Shared channel: @-mention so the notification still pings.
+                    channel_id = target_channel_id
                     message = f"<@{user_id}> {message}" if user_id.isdigit() else message
                 else:
                     channel_id = await self._get_dm_channel(client, user_id)
@@ -115,8 +152,8 @@ class DiscordProvider(SMSProvider):
             return SMSResult(success=True, message_sid=last_message_id)
         except httpx.HTTPStatusError as exc:
             body = exc.response.text[:200]
-            logger.error(f"Discord API error sending DM to {user_id}: {exc} {body}")
+            logger.error(f"Discord API error sending to {destination}: {exc} {body}")
             return SMSResult(success=False, error_message=f"{exc.response.status_code}: {body}")
         except httpx.HTTPError as exc:
-            logger.error(f"Discord request failed sending DM to {user_id}: {exc}")
+            logger.error(f"Discord request failed sending to {destination}: {exc}")
             return SMSResult(success=False, error_message=str(exc))

--- a/app/providers/discord_provider.py
+++ b/app/providers/discord_provider.py
@@ -115,6 +115,11 @@ class DiscordProvider(SMSProvider):
         3. No origin at all (REST API bookings, SMS, the weekly prompt, and
            bookings created before origins were recorded): DISCORD_CHANNEL_ID if
            set, else a DM.
+
+        Whatever comes back is interpolated into ``/channels/{id}/messages``, so
+        both sources are checked here rather than trusted. Settings already
+        rejects a non-numeric DISCORD_CHANNEL_ID at load time; re-checking keeps
+        that invariant local to the place that depends on it.
         """
         candidate = (origin_channel_id or "").strip()
         if candidate.isdigit():
@@ -123,7 +128,13 @@ class DiscordProvider(SMSProvider):
             return None
         if candidate:
             logger.warning(f"Ignoring unrecognized Discord origin channel {candidate!r}")
-        return settings.discord_channel_id.strip() or None
+
+        configured = settings.discord_channel_id.strip()
+        if configured.isdigit():
+            return configured
+        if configured:
+            logger.warning(f"Ignoring non-numeric DISCORD_CHANNEL_ID {configured!r}")
+        return None
 
     async def send_sms(
         self, to_number: str, message: str, origin_channel_id: str | None = None

--- a/app/providers/sms_base.py
+++ b/app/providers/sms_base.py
@@ -28,23 +28,30 @@ class SMSProvider(ABC):
         pass
 
     @abstractmethod
-    async def send_sms(self, to_number: str, message: str) -> SMSResult:
+    async def send_sms(
+        self, to_number: str, message: str, origin_channel_id: str | None = None
+    ) -> SMSResult:
         """
         Send an SMS message.
 
         Args:
             to_number: The recipient's phone number.
             message: The message content.
+            origin_channel_id: Where the conversation this message belongs to
+                started, for providers that have a concept of channels. Discord
+                uses it to reply in that channel; SMS providers ignore it.
 
         Returns:
             SMSResult with success status and message SID or error.
         """
         pass
 
-    async def send_booking_confirmation(self, to_number: str, booking_details: str) -> SMSResult:
+    async def send_booking_confirmation(
+        self, to_number: str, booking_details: str, origin_channel_id: str | None = None
+    ) -> SMSResult:
         """Send a booking confirmation SMS."""
         message = f"Tee time booking confirmed! {booking_details}"
-        return await self.send_sms(to_number, message)
+        return await self.send_sms(to_number, message, origin_channel_id)
 
     async def send_booking_failure(
         self,
@@ -52,6 +59,7 @@ class SMSProvider(ABC):
         reason: str,
         alternatives: str | None = None,
         booking_details: str | None = None,
+        origin_channel_id: str | None = None,
     ) -> SMSResult:
         """Send a booking failure notification SMS.
 
@@ -61,6 +69,8 @@ class SMSProvider(ABC):
             alternatives: Optional alternative time slots available.
             booking_details: Optional details about the specific booking that failed
                            (e.g., "Sunday, February 01 at 08:58 AM for 4 players").
+            origin_channel_id: Channel the booking was requested in, so the
+                failure replies there instead of a DM.
         """
         if booking_details:
             message = f"Unable to book tee time for {booking_details}: {reason}"
@@ -68,12 +78,14 @@ class SMSProvider(ABC):
             message = f"Unable to book tee time: {reason}"
         if alternatives:
             message += f"\n\nAlternatives available: {alternatives}"
-        return await self.send_sms(to_number, message)
+        return await self.send_sms(to_number, message, origin_channel_id)
 
-    async def send_weekly_prompt(self, to_number: str) -> SMSResult:
+    async def send_weekly_prompt(
+        self, to_number: str, origin_channel_id: str | None = None
+    ) -> SMSResult:
         """Send a weekly tee time prompt SMS."""
         message = (
             "Hi! What tee times would you like this week? "
             "Reply with something like 'Saturday 8am, 4 players' or 'Same as last week'."
         )
-        return await self.send_sms(to_number, message)
+        return await self.send_sms(to_number, message, origin_channel_id)

--- a/app/providers/twilio_provider.py
+++ b/app/providers/twilio_provider.py
@@ -99,13 +99,16 @@ class TwilioSMSProvider(SMSProvider):
             return False
         return bool(self.validator.validate(url, params, signature))
 
-    async def send_sms(self, to_number: str, message: str) -> SMSResult:
+    async def send_sms(
+        self, to_number: str, message: str, origin_channel_id: str | None = None
+    ) -> SMSResult:
         """
         Send a message via Twilio (SMS or WhatsApp based on channel setting).
 
         Args:
             to_number: The recipient's phone number in E.164 format.
             message: The message content to send.
+            origin_channel_id: Unused; SMS has no channels, only a recipient.
 
         Returns:
             SMSResult with success status and message SID or error message.
@@ -151,7 +154,9 @@ class MockSMSProvider(SMSProvider):
         """Always return True for mock provider."""
         return True
 
-    async def send_sms(self, to_number: str, message: str) -> SMSResult:
+    async def send_sms(
+        self, to_number: str, message: str, origin_channel_id: str | None = None
+    ) -> SMSResult:
         """Record the message and return a mock success result."""
         self.sent_messages.append({"to": to_number, "message": message})
         logger.debug("[SMS Mock] To: %s, Message: %s", to_number, message)

--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -59,7 +59,9 @@ class BookingService:
         session.last_interaction = datetime.now(UTC).replace(tzinfo=None)
         await database_service.update_session(session)
 
-    async def handle_incoming_message(self, phone_number: str, message: str) -> str:
+    async def handle_incoming_message(
+        self, phone_number: str, message: str, origin_channel_id: str | None = None
+    ) -> str:
         """
         Process an incoming SMS message and return a response.
 
@@ -73,11 +75,17 @@ class BookingService:
         Args:
             phone_number: The sender's phone number.
             message: The text content of the SMS.
+            origin_channel_id: For Discord, the channel this message arrived in.
+                Stored on the session and copied onto any booking created from
+                this conversation, so the booking result days later replies in
+                the same place. None for SMS, which has no channels.
 
         Returns:
             The response message to send back to the user.
         """
         session = await self.get_session(phone_number)
+        if origin_channel_id:
+            session.origin_channel_id = origin_channel_id
 
         context = None
         if session.state != ConversationState.IDLE:
@@ -166,7 +174,9 @@ class BookingService:
             return "There's nothing to confirm. Would you like to book a tee time?"
 
         try:
-            booking = await self.create_booking(session.phone_number, session.pending_request)
+            booking = await self.create_booking(
+                session.phone_number, session.pending_request, session.origin_channel_id
+            )
         except ValueError as e:
             session.pending_request = None
             session.state = ConversationState.IDLE
@@ -225,7 +235,9 @@ class BookingService:
 
         for request in session.pending_requests:
             try:
-                booking = await self.create_booking(session.phone_number, request)
+                booking = await self.create_booking(
+                    session.phone_number, request, session.origin_channel_id
+                )
                 successful_bookings.append(booking)
             except ValueError as e:
                 failed_requests.append((request, str(e)))
@@ -531,7 +543,12 @@ class BookingService:
             await database_service.update_booking(booking)
             return False
 
-    async def create_booking(self, phone_number: str, request: TeeTimeRequest) -> TeeTimeBooking:
+    async def create_booking(
+        self,
+        phone_number: str,
+        request: TeeTimeRequest,
+        origin_channel_id: str | None = None,
+    ) -> TeeTimeBooking:
         """
         Create a new booking record and schedule it for execution.
 
@@ -549,6 +566,9 @@ class BookingService:
         Args:
             phone_number: The phone number to associate with the booking.
             request: The tee time request details.
+            origin_channel_id: Discord channel this booking was requested in, so
+                the success/failure notification replies there. None for SMS and
+                REST API callers.
 
         Returns:
             The created TeeTimeBooking record.
@@ -584,6 +604,7 @@ class BookingService:
             request=request,
             status=BookingStatus.SCHEDULED,
             scheduled_execution_time=execution_time,
+            origin_channel_id=origin_channel_id,
         )
 
         created_booking = await database_service.create_booking(booking)
@@ -733,6 +754,7 @@ class BookingService:
                 booking.phone_number,
                 "System not configured for booking",
                 booking_details=booking_details,
+                origin_channel_id=booking.origin_channel_id,
             )
             return False
 
@@ -764,7 +786,9 @@ class BookingService:
                 if result.fallback_reason:
                     details += f"\n\nNote: {result.fallback_reason}"
 
-                await sms_service.send_booking_confirmation(booking.phone_number, details)
+                await sms_service.send_booking_confirmation(
+                    booking.phone_number, details, booking.origin_channel_id
+                )
                 return True
             else:
                 booking.status = BookingStatus.FAILED
@@ -783,6 +807,7 @@ class BookingService:
                     result.error_message or "Unknown error",
                     result.alternatives,
                     booking_details,
+                    booking.origin_channel_id,
                 )
                 return False
 
@@ -797,7 +822,10 @@ class BookingService:
             booking_details = f"{date_str} at {time_str} for {booking.request.num_players} players"
 
             await sms_service.send_booking_failure(
-                booking.phone_number, str(e), booking_details=booking_details
+                booking.phone_number,
+                str(e),
+                booking_details=booking_details,
+                origin_channel_id=booking.origin_channel_id,
             )
             return False
 

--- a/app/services/database_service.py
+++ b/app/services/database_service.py
@@ -40,6 +40,7 @@ class DatabaseService:
             actual_booked_time=booking.actual_booked_time,
             confirmation_number=booking.confirmation_number,
             error_message=booking.error_message,
+            origin_channel_id=booking.origin_channel_id,
             created_at=booking.created_at,
             updated_at=booking.updated_at,
         )
@@ -61,6 +62,7 @@ class DatabaseService:
             actual_booked_time=record.actual_booked_time,  # type: ignore[arg-type]
             confirmation_number=record.confirmation_number,  # type: ignore[arg-type]
             error_message=record.error_message,  # type: ignore[arg-type]
+            origin_channel_id=record.origin_channel_id,  # type: ignore[arg-type]
             created_at=record.created_at,  # type: ignore[arg-type]
             updated_at=record.updated_at,  # type: ignore[arg-type]
         )
@@ -79,6 +81,7 @@ class DatabaseService:
             state=session.state,
             pending_request_json=pending_json,
             pending_cancellation_id=session.pending_cancellation_id,
+            origin_channel_id=session.origin_channel_id,
             last_interaction=session.last_interaction,
         )
 
@@ -105,6 +108,7 @@ class DatabaseService:
             pending_request=pending_request,
             pending_requests=pending_requests,
             pending_cancellation_id=record.pending_cancellation_id,  # type: ignore[arg-type]
+            origin_channel_id=record.origin_channel_id,  # type: ignore[arg-type]
             last_interaction=record.last_interaction,  # type: ignore[arg-type]
         )
 
@@ -206,6 +210,7 @@ class DatabaseService:
                 pending_json = session.pending_request.model_dump_json()
             record.pending_request_json = pending_json  # type: ignore[assignment]
             record.pending_cancellation_id = session.pending_cancellation_id  # type: ignore[assignment]
+            record.origin_channel_id = session.origin_channel_id  # type: ignore[assignment]
             record.last_interaction = session.last_interaction  # type: ignore[assignment]
 
             await db.commit()

--- a/app/services/discord_gateway.py
+++ b/app/services/discord_gateway.py
@@ -3,9 +3,11 @@ Discord gateway listener: the inbound half of the Discord messaging channel.
 
 Discord bots receive messages over a persistent WebSocket (the "gateway"),
 unlike Twilio's HTTP webhooks. This module runs a discord.py client as a
-background task inside the FastAPI process and routes DMs from the configured
-user into the same booking_service.handle_incoming_message() entry point the
-Twilio webhook uses.
+background task inside the FastAPI process and routes messages from the
+configured user - whether sent in a DM or a shared server channel - into the
+same booking_service.handle_incoming_message() entry point the Twilio webhook
+uses. It passes along the channel each message arrived in so that later
+notifications about the resulting booking reply in the same conversation.
 
 Requires the "Message Content Intent" to be enabled for the bot in the
 Discord Developer Portal, and DISCORD_BOT_TOKEN / DISCORD_USER_ID settings.
@@ -22,11 +24,12 @@ from collections.abc import Awaitable, Callable
 import discord
 
 from app.config import settings
-from app.providers.discord_provider import split_message
+from app.providers.discord_provider import DM_ORIGIN, split_message
 
 logger = logging.getLogger(__name__)
 
-MessageHandler = Callable[[str, str], Awaitable[str]]
+# (user_id, content, origin_channel_id) -> reply text
+MessageHandler = Callable[[str, str, str], Awaitable[str]]
 
 
 def should_handle_message(
@@ -111,8 +114,11 @@ class DiscordGateway:
             return
         source = "DM" if is_dm else f"guild channel #{getattr(message.channel, 'name', '?')}"
         logger.info(f"Discord message received from {author_id} via {source}: {content[:80]}")
+        # Record where this conversation is happening so async notifications
+        # (the 6:30am booking result) reply here rather than opening a DM.
+        origin_channel_id = DM_ORIGIN if is_dm else str(message.channel.id)
         try:
-            response = await self._message_handler(author_id, content)
+            response = await self._message_handler(author_id, content, origin_channel_id)
         except Exception:
             logger.exception("Error handling Discord message")
             response = "Sorry, something went wrong processing that message."

--- a/app/services/sms_service.py
+++ b/app/services/sms_service.py
@@ -54,23 +54,31 @@ class SMSService:
         """
         return self.provider.validate_request(url, params, signature)
 
-    async def send_sms(self, to_number: str, message: str) -> str | None:
+    async def send_sms(
+        self, to_number: str, message: str, origin_channel_id: str | None = None
+    ) -> str | None:
         """
         Send an SMS message.
 
         Args:
             to_number: The recipient's phone number.
             message: The message content.
+            origin_channel_id: Channel the conversation started in, for providers
+                that support channels (Discord). Ignored by SMS providers.
 
         Returns:
             The message SID if successful, None otherwise.
         """
-        result = await self.provider.send_sms(to_number, message)
+        result = await self.provider.send_sms(to_number, message, origin_channel_id)
         return result.message_sid if result.success else None
 
-    async def send_booking_confirmation(self, to_number: str, booking_details: str) -> str | None:
+    async def send_booking_confirmation(
+        self, to_number: str, booking_details: str, origin_channel_id: str | None = None
+    ) -> str | None:
         """Send a booking confirmation SMS."""
-        result = await self.provider.send_booking_confirmation(to_number, booking_details)
+        result = await self.provider.send_booking_confirmation(
+            to_number, booking_details, origin_channel_id
+        )
         return result.message_sid if result.success else None
 
     async def send_booking_failure(
@@ -79,6 +87,7 @@ class SMSService:
         reason: str,
         alternatives: str | None = None,
         booking_details: str | None = None,
+        origin_channel_id: str | None = None,
     ) -> str | None:
         """Send a booking failure notification SMS.
 
@@ -88,15 +97,19 @@ class SMSService:
             alternatives: Optional alternative time slots available.
             booking_details: Optional details about the specific booking that failed
                            (e.g., "Sunday, February 01 at 08:58 AM for 4 players").
+            origin_channel_id: Channel the booking was requested in, so the
+                failure replies there instead of a DM.
         """
         result = await self.provider.send_booking_failure(
-            to_number, reason, alternatives, booking_details
+            to_number, reason, alternatives, booking_details, origin_channel_id
         )
         return result.message_sid if result.success else None
 
-    async def send_weekly_prompt(self, to_number: str) -> str | None:
+    async def send_weekly_prompt(
+        self, to_number: str, origin_channel_id: str | None = None
+    ) -> str | None:
         """Send a weekly tee time prompt SMS."""
-        result = await self.provider.send_weekly_prompt(to_number)
+        result = await self.provider.send_weekly_prompt(to_number, origin_channel_id)
         return result.message_sid if result.success else None
 
 

--- a/docs/discord-setup.md
+++ b/docs/discord-setup.md
@@ -35,12 +35,13 @@ Discord gateway (a persistent WebSocket), so the service must run with
    This goes in `DISCORD_USER_ID` and is the allowlist — the bot ignores
    everyone else.
 
-7. **(Optional) Get a channel ID for shared replies**: with Developer Mode on,
-   right-click the channel you want the bot to talk in (e.g. `#general`) →
-   **Copy Channel ID**. Put it in `DISCORD_CHANNEL_ID`. When set, the bot posts
-   booking confirmations and failures into that channel (mentioning you)
-   instead of a private DM, so the whole conversation stays in one place. Make
-   sure the bot has **Send Messages** and **View Channels** permission there.
+7. **(Optional) Get a fallback channel ID**: with Developer Mode on, right-click
+   a channel → **Copy Channel ID** and put it in `DISCORD_CHANNEL_ID`. Replies
+   already follow the conversation on their own (see below), so this is only the
+   destination for notifications with no conversation behind them — bookings
+   made through the REST API, and any created before this behavior existed.
+   Make sure the bot has **Send Messages** and **View Channels** permission
+   wherever you talk to it.
 
 ## App configuration
 
@@ -56,9 +57,18 @@ the FastAPI process (log line: `Discord gateway connected as TeeTime#...`).
 Message the bot — message flow is identical to the old SMS flow. Talk to it in
 your shared channel by @-mentioning it, or send a DM.
 
-By default, async notifications (the booking result at 6:30 AM when the window
-opens) are sent as a DM. Set `DISCORD_CHANNEL_ID` to have those replies posted
-in your shared channel instead, matching where you asked for the booking.
+### Where replies go
+
+Replies land wherever the conversation started. Ask for a booking in
+`#general` and the result — including the 6:30 AM confirmation or failure that
+arrives days later — is posted in `#general`, mentioning you. Ask in a DM and
+everything stays in the DM.
+
+This works because the channel of each incoming message is recorded on your
+session and copied onto any booking it creates, so the notification can find
+its way back long after the request. Bookings with no channel recorded (the
+REST API, SMS, or bookings made before this existed) fall back to
+`DISCORD_CHANNEL_ID`, and to a DM if that is unset.
 
 For Cloud Run, add the two secrets and set
 `--min-instances=1` so the gateway stays connected.
@@ -66,10 +76,12 @@ For Cloud Run, add the two secrets and set
 ## How it maps onto the old SMS design
 
 - `app/providers/discord_provider.py` implements the same `SMSProvider`
-  interface Twilio used; outbound "SMS" become DMs via the Discord REST API.
-- `app/services/discord_gateway.py` replaces the Twilio inbound webhook; DMs
-  from `DISCORD_USER_ID` are routed into
-  `booking_service.handle_incoming_message()` unchanged.
+  interface Twilio used; outbound "SMS" become channel posts or DMs via the
+  Discord REST API.
+- `app/services/discord_gateway.py` replaces the Twilio inbound webhook;
+  messages from `DISCORD_USER_ID` are routed into
+  `booking_service.handle_incoming_message()` along with the channel they
+  arrived in.
 - The `phone_number` identifier field now carries your Discord user ID
   (a numeric snowflake, fits the existing schema). Twilio remains available
   by setting `MESSAGING_CHANNEL=twilio`.

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -1928,6 +1928,47 @@ class TestOriginChannelRouting:
         mock_create.assert_awaited_once_with("+15551234567", sample_request, "778899")
 
     @pytest.mark.asyncio
+    async def test_confirm_multiple_bookings_passes_session_origin_to_each(
+        self, booking_service: BookingService
+    ) -> None:
+        """Confirming several requests at once is a separate loop from the single
+        booking path; every booking it creates must carry the channel too."""
+        requests = [
+            TeeTimeRequest(
+                requested_date=date(2025, 12, 30), requested_time=time(8, 0), num_players=4
+            ),
+            TeeTimeRequest(
+                requested_date=date(2025, 12, 31), requested_time=time(9, 0), num_players=4
+            ),
+        ]
+        session = UserSession(
+            phone_number="+15551234567",
+            state=ConversationState.AWAITING_CONFIRMATION,
+            pending_requests=requests,
+            origin_channel_id="778899",
+        )
+
+        async def create_booking_side_effect(
+            phone_number: str, request: TeeTimeRequest, origin_channel_id: str | None = None
+        ) -> TeeTimeBooking:
+            return TeeTimeBooking(
+                id="test1234",
+                phone_number=phone_number,
+                request=request,
+                status=BookingStatus.SCHEDULED,
+                scheduled_execution_time=datetime(2025, 12, 23, 6, 30),
+                origin_channel_id=origin_channel_id,
+            )
+
+        with patch.object(
+            booking_service, "create_booking", side_effect=create_booking_side_effect
+        ) as mock_create:
+            await booking_service._handle_confirm_multiple_bookings(session)
+
+        assert len(mock_create.await_args_list) == len(requests)
+        assert all(call.args[2] == "778899" for call in mock_create.await_args_list)
+
+    @pytest.mark.asyncio
     async def test_execute_booking_success_notifies_origin_channel(
         self, booking_service: BookingService, sample_booking: TeeTimeBooking
     ) -> None:

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -1631,7 +1631,7 @@ class TestMultipleBookings:
         )
 
         async def create_booking_side_effect(
-            phone_number: str, request: TeeTimeRequest
+            phone_number: str, request: TeeTimeRequest, origin_channel_id: str | None = None
         ) -> TeeTimeBooking:
             return TeeTimeBooking(
                 id="test123",
@@ -1677,7 +1677,7 @@ class TestMultipleBookings:
         call_count = 0
 
         async def create_booking_side_effect(
-            phone_number: str, request: TeeTimeRequest
+            phone_number: str, request: TeeTimeRequest, origin_channel_id: str | None = None
         ) -> TeeTimeBooking:
             nonlocal call_count
             call_count += 1
@@ -1746,7 +1746,7 @@ class TestMultipleBookings:
         )
 
         async def create_booking_side_effect(
-            phone_number: str, request: TeeTimeRequest
+            phone_number: str, request: TeeTimeRequest, origin_channel_id: str | None = None
         ) -> TeeTimeBooking:
             raise ValueError("Multi-player bookings within 48 hours")
 
@@ -1823,3 +1823,152 @@ class TestMultipleBookings:
         assert "2 players" in response
         assert "4 players" in response
         assert sample_session.pending_requests == requests
+
+
+class TestOriginChannelRouting:
+    """A booking's notification must reply where its conversation started.
+
+    The 6:30am result arrives days after the request, so the originating channel
+    is captured on the session, copied onto the booking, and handed to the
+    messaging provider at notification time.
+    """
+
+    @pytest.mark.asyncio
+    async def test_incoming_message_records_origin_channel(
+        self, booking_service: BookingService, sample_session: UserSession
+    ) -> None:
+        """The channel an inbound message arrived in is stored on the session."""
+        with (
+            patch("app.services.booking_service.database_service") as mock_db,
+            patch("app.services.booking_service.gemini_service") as mock_gemini,
+        ):
+            mock_db.get_or_create_session = AsyncMock(return_value=sample_session)
+            mock_db.update_session = AsyncMock()
+            mock_gemini.parse_message = AsyncMock(return_value=ParsedIntent(intent="help"))
+
+            await booking_service.handle_incoming_message("+15551234567", "help", "778899")
+
+        assert sample_session.origin_channel_id == "778899"
+
+    @pytest.mark.asyncio
+    async def test_incoming_message_without_channel_keeps_existing(
+        self, booking_service: BookingService
+    ) -> None:
+        """An SMS message (no channel) must not erase a recorded Discord origin."""
+        session = UserSession(phone_number="+15551234567", origin_channel_id="778899")
+        with (
+            patch("app.services.booking_service.database_service") as mock_db,
+            patch("app.services.booking_service.gemini_service") as mock_gemini,
+        ):
+            mock_db.get_or_create_session = AsyncMock(return_value=session)
+            mock_db.update_session = AsyncMock()
+            mock_gemini.parse_message = AsyncMock(return_value=ParsedIntent(intent="help"))
+
+            await booking_service.handle_incoming_message("+15551234567", "help")
+
+        assert session.origin_channel_id == "778899"
+
+    @pytest.mark.asyncio
+    async def test_create_booking_stores_origin_channel(
+        self, booking_service: BookingService, sample_request: TeeTimeRequest
+    ) -> None:
+        """create_booking persists the channel so it survives until execution."""
+        import pytz
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+
+            async def create_booking_side_effect(booking: TeeTimeBooking) -> TeeTimeBooking:
+                return booking
+
+            mock_db.create_booking = AsyncMock(side_effect=create_booking_side_effect)
+
+            future_request = TeeTimeRequest(
+                requested_date=date(2025, 12, 29),
+                requested_time=time(8, 0),
+                num_players=4,
+            )
+            with patch.object(CTDateTime, "now") as mock_ct_now:
+                tz = pytz.timezone("America/Chicago")
+                mock_ct_now.return_value = tz.localize(datetime(2025, 12, 20, 10, 0))
+                result = await booking_service.create_booking(
+                    "+15551234567", future_request, "778899"
+                )
+
+        assert result.origin_channel_id == "778899"
+
+    @pytest.mark.asyncio
+    async def test_confirm_intent_passes_session_origin_to_booking(
+        self, booking_service: BookingService, sample_request: TeeTimeRequest
+    ) -> None:
+        """Confirming a pending request carries the session's channel onto the booking."""
+        session = UserSession(
+            phone_number="+15551234567",
+            state=ConversationState.AWAITING_CONFIRMATION,
+            pending_request=sample_request,
+            origin_channel_id="778899",
+        )
+
+        async def create_booking_side_effect(
+            phone_number: str, request: TeeTimeRequest, origin_channel_id: str | None = None
+        ) -> TeeTimeBooking:
+            return TeeTimeBooking(
+                id="test1234",
+                phone_number=phone_number,
+                request=request,
+                status=BookingStatus.SCHEDULED,
+                scheduled_execution_time=datetime(2025, 12, 13, 6, 30),
+                origin_channel_id=origin_channel_id,
+            )
+
+        with patch.object(
+            booking_service, "create_booking", side_effect=create_booking_side_effect
+        ) as mock_create:
+            await booking_service._handle_confirm_intent(session)
+
+        mock_create.assert_awaited_once_with("+15551234567", sample_request, "778899")
+
+    @pytest.mark.asyncio
+    async def test_execute_booking_success_notifies_origin_channel(
+        self, booking_service: BookingService, sample_booking: TeeTimeBooking
+    ) -> None:
+        """The confirmation is routed back to the booking's channel, not a DM."""
+        sample_booking.origin_channel_id = "778899"
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_booking = AsyncMock(return_value=sample_booking)
+            mock_db.update_booking = AsyncMock(side_effect=lambda b: b)
+
+            mock_provider = MagicMock()
+            mock_provider.book_tee_time = AsyncMock(
+                return_value=BookingResult(
+                    success=True, booked_time=time(8, 0), confirmation_number="CONF123"
+                )
+            )
+            booking_service.set_reservation_provider(mock_provider)
+
+            with patch("app.services.booking_service.sms_service") as mock_sms:
+                mock_sms.send_booking_confirmation = AsyncMock()
+                await booking_service.execute_booking(sample_booking.id)
+
+        assert mock_sms.send_booking_confirmation.await_args.args[2] == "778899"
+
+    @pytest.mark.asyncio
+    async def test_execute_booking_failure_notifies_origin_channel(
+        self, booking_service: BookingService, sample_booking: TeeTimeBooking
+    ) -> None:
+        """Failures follow the same route as confirmations."""
+        sample_booking.origin_channel_id = "778899"
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_booking = AsyncMock(return_value=sample_booking)
+            mock_db.update_booking = AsyncMock(side_effect=lambda b: b)
+
+            mock_provider = MagicMock()
+            mock_provider.book_tee_time = AsyncMock(
+                return_value=BookingResult(success=False, error_message="No slots")
+            )
+            booking_service.set_reservation_provider(mock_provider)
+
+            with patch("app.services.booking_service.sms_service") as mock_sms:
+                mock_sms.send_booking_failure = AsyncMock()
+                await booking_service.execute_booking(sample_booking.id)
+
+        assert mock_sms.send_booking_failure.await_args.args[4] == "778899"

--- a/tests/test_database_service.py
+++ b/tests/test_database_service.py
@@ -1023,3 +1023,67 @@ class TestGetDueBookings:
         result = await database_service.get_due_bookings(due_before)
 
         assert len(result) == 0
+
+
+class TestOriginChannelPersistence:
+    """The originating channel must survive the round trip to the database.
+
+    A booking is executed days after it is created, in a different process, so
+    the channel is only useful if it is actually stored and read back.
+    """
+
+    @pytest.mark.asyncio
+    async def test_booking_origin_channel_round_trips(
+        self, database_service: DatabaseService, sample_booking: TeeTimeBooking
+    ) -> None:
+        """A booking's channel is readable after being written and re-fetched."""
+        sample_booking.origin_channel_id = "778899001122334455"
+        await database_service.create_booking(sample_booking)
+
+        retrieved = await database_service.get_booking("test1234")
+
+        assert retrieved is not None
+        assert retrieved.origin_channel_id == "778899001122334455"
+
+    @pytest.mark.asyncio
+    async def test_booking_without_origin_channel_is_none(
+        self, database_service: DatabaseService, sample_booking: TeeTimeBooking
+    ) -> None:
+        """SMS and REST bookings store no channel, which reads back as None."""
+        await database_service.create_booking(sample_booking)
+
+        retrieved = await database_service.get_booking("test1234")
+
+        assert retrieved is not None
+        assert retrieved.origin_channel_id is None
+
+    @pytest.mark.asyncio
+    async def test_booking_origin_channel_survives_status_update(
+        self, database_service: DatabaseService, sample_booking: TeeTimeBooking
+    ) -> None:
+        """Marking the booking IN_PROGRESS at execution time must not drop the
+        channel the result notification depends on."""
+        sample_booking.origin_channel_id = "778899001122334455"
+        await database_service.create_booking(sample_booking)
+
+        sample_booking.status = BookingStatus.SUCCESS
+        updated = await database_service.update_booking(sample_booking)
+
+        assert updated.origin_channel_id == "778899001122334455"
+
+    @pytest.mark.asyncio
+    async def test_session_origin_channel_round_trips(
+        self, database_service: DatabaseService, sample_session: UserSession
+    ) -> None:
+        """A session's channel persists across updates, so a multi-turn
+        conversation still knows where it started when the user confirms."""
+        await database_service.create_session(sample_session)
+
+        sample_session.origin_channel_id = "778899001122334455"
+        sample_session.state = ConversationState.AWAITING_CONFIRMATION
+        await database_service.update_session(sample_session)
+
+        retrieved = await database_service.get_session("+15551234567")
+
+        assert retrieved is not None
+        assert retrieved.origin_channel_id == "778899001122334455"

--- a/tests/test_discord_provider.py
+++ b/tests/test_discord_provider.py
@@ -240,24 +240,39 @@ class TestResolveChannelId:
     """Destination precedence: origin channel, then DM sentinel, then config."""
 
     def test_numeric_origin_used_directly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The conversation's own channel outranks the configured one."""
         monkeypatch.setattr(settings, "discord_channel_id", "9001")
         assert DiscordProvider.resolve_channel_id("4242") == "4242"
 
     def test_origin_is_trimmed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stray whitespace around a stored ID does not break the API path."""
         monkeypatch.setattr(settings, "discord_channel_id", "")
         assert DiscordProvider.resolve_channel_id("  4242  ") == "4242"
 
     def test_dm_sentinel_means_dm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A DM conversation stays a DM even with a shared channel configured."""
         monkeypatch.setattr(settings, "discord_channel_id", "9001")
         assert DiscordProvider.resolve_channel_id(DM_ORIGIN) is None
 
     def test_no_origin_uses_configured_channel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Notifications with no conversation behind them use the fallback."""
         monkeypatch.setattr(settings, "discord_channel_id", "9001")
         assert DiscordProvider.resolve_channel_id(None) == "9001"
 
     def test_no_origin_and_no_config_means_dm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With nothing configured and no origin, delivery falls back to a DM."""
         monkeypatch.setattr(settings, "discord_channel_id", "")
         assert DiscordProvider.resolve_channel_id(None) is None
+
+    def test_non_numeric_configured_channel_falls_back_to_dm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Settings rejects a bad DISCORD_CHANNEL_ID at load, but the value is
+        interpolated into an API path, so a value that reached settings another
+        way (a direct assignment, bypassing validation) must not be used."""
+        monkeypatch.setattr(settings, "discord_channel_id", "../../users/@me")
+        assert DiscordProvider.resolve_channel_id(None) is None
+        assert DiscordProvider.resolve_channel_id(DM_ORIGIN) is None
 
 
 class TestDiscordChannelIdValidation:

--- a/tests/test_discord_provider.py
+++ b/tests/test_discord_provider.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from app.config import Settings, settings
 from app.providers.discord_provider import (
+    DM_ORIGIN,
     MAX_MESSAGE_LEN,
     DiscordProvider,
     split_message,
@@ -169,9 +170,94 @@ class TestSendSms:
         assert requests[1].url.path.endswith("/channels/555/messages")
         assert json.loads(requests[1].content) == {"content": "hi"}
 
+    async def test_origin_channel_wins_over_configured_channel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A notification replies in the channel its conversation started in,
+        even when a different shared channel is configured."""
+        monkeypatch.setattr(settings, "discord_channel_id", "9001")
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(200, json={"id": "msg-1"})
+
+        provider = make_provider(handler)
+        result = await provider.send_sms("123456789012345678", "booked", origin_channel_id="4242")
+
+        assert result.success
+        assert requests[0].url.path.endswith("/channels/4242/messages")
+        assert json.loads(requests[0].content) == {"content": "<@123456789012345678> booked"}
+
+    async def test_dm_origin_stays_a_dm_despite_configured_channel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A conversation started in a DM is answered in the DM, without a
+        mention, rather than being aired in the configured shared channel."""
+        monkeypatch.setattr(settings, "discord_channel_id", "9001")
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            if request.url.path.endswith("/users/@me/channels"):
+                return httpx.Response(200, json={"id": "555"})
+            return httpx.Response(200, json={"id": "msg-1"})
+
+        provider = make_provider(handler)
+        result = await provider.send_sms(
+            "123456789012345678", "booked", origin_channel_id=DM_ORIGIN
+        )
+
+        assert result.success
+        assert requests[0].url.path.endswith("/users/@me/channels")
+        assert requests[1].url.path.endswith("/channels/555/messages")
+        assert json.loads(requests[1].content) == {"content": "booked"}
+
+    async def test_unrecognized_origin_falls_back_to_configured_channel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A malformed stored origin must not be interpolated into the API path;
+        it falls back to the configured channel."""
+        monkeypatch.setattr(settings, "discord_channel_id", "9001")
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(200, json={"id": "msg-1"})
+
+        provider = make_provider(handler)
+        result = await provider.send_sms("123456789012345678", "hi", origin_channel_id="#general")
+
+        assert result.success
+        assert requests[0].url.path.endswith("/channels/9001/messages")
+
     def test_validate_request_always_true(self) -> None:
         provider = DiscordProvider()
         assert provider.validate_request("http://x", {}, None)
+
+
+class TestResolveChannelId:
+    """Destination precedence: origin channel, then DM sentinel, then config."""
+
+    def test_numeric_origin_used_directly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "discord_channel_id", "9001")
+        assert DiscordProvider.resolve_channel_id("4242") == "4242"
+
+    def test_origin_is_trimmed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "discord_channel_id", "")
+        assert DiscordProvider.resolve_channel_id("  4242  ") == "4242"
+
+    def test_dm_sentinel_means_dm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "discord_channel_id", "9001")
+        assert DiscordProvider.resolve_channel_id(DM_ORIGIN) is None
+
+    def test_no_origin_uses_configured_channel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "discord_channel_id", "9001")
+        assert DiscordProvider.resolve_channel_id(None) == "9001"
+
+    def test_no_origin_and_no_config_means_dm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "discord_channel_id", "")
+        assert DiscordProvider.resolve_channel_id(None) is None
 
 
 class TestDiscordChannelIdValidation:
@@ -211,6 +297,7 @@ class TestShouldHandleMessage:
 
 BOT_ID = 999000111
 ALLOWED_ID = "111222333444555666"
+GUILD_CHANNEL_ID = "778899001122334455"
 
 
 def make_message(
@@ -219,6 +306,7 @@ def make_message(
     content: str = "book saturday 8am",
     is_bot: bool = False,
     in_guild: bool = False,
+    channel_id: str = GUILD_CHANNEL_ID,
 ) -> MagicMock:
     """Build a stand-in for discord.Message with a spy on channel.send."""
     message = MagicMock()
@@ -226,6 +314,7 @@ def make_message(
     message.author.bot = is_bot
     message.content = content
     message.guild = MagicMock() if in_guild else None
+    message.channel.id = channel_id
     message.channel.name = "tee-times"
     message.channel.send = AsyncMock()
     return message
@@ -249,17 +338,18 @@ class TestGatewayOnMessage:
 
         await gw._on_message(message)
 
-        handler.assert_awaited_once_with(ALLOWED_ID, "book saturday 8am")
+        handler.assert_awaited_once_with(ALLOWED_ID, "book saturday 8am", DM_ORIGIN)
         message.channel.send.assert_awaited_once_with("ok")
 
     async def test_guild_message_from_allowed_user_dispatched(self, gateway) -> None:  # type: ignore[no-untyped-def]
-        """Server-channel messages must work, not just DMs."""
+        """Server-channel messages must work, not just DMs, and the channel they
+        arrived in is passed along so later notifications can reply there."""
         gw, handler = gateway
         message = make_message(in_guild=True)
 
         await gw._on_message(message)
 
-        handler.assert_awaited_once_with(ALLOWED_ID, "book saturday 8am")
+        handler.assert_awaited_once_with(ALLOWED_ID, "book saturday 8am", GUILD_CHANNEL_ID)
         message.channel.send.assert_awaited_once_with("ok")
 
     async def test_own_message_suppressed(
@@ -313,7 +403,7 @@ class TestGatewayOnMessage:
 
         await gw._on_message(message)
 
-        handler.assert_awaited_once_with(ALLOWED_ID, "book 8/2 at 5:06p")
+        handler.assert_awaited_once_with(ALLOWED_ID, "book 8/2 at 5:06p", GUILD_CHANNEL_ID)
 
     @pytest.mark.parametrize("mention_fmt", ["<@{id}>", "<@!{id}>"])
     async def test_mention_only_message_ignored(self, gateway, mention_fmt: str) -> None:  # type: ignore[no-untyped-def]

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -903,3 +903,89 @@ class TestJobsIntegration:
             assert result[0].id == "scheduled-booking"
 
         await engine.dispose()
+
+
+class TestOriginChannelRouting:
+    """The 6:30am batch job is the real notification path: its messages must go
+    back to the channel each booking was requested in."""
+
+    def test_confirmation_routed_to_booking_origin_channel(
+        self,
+        test_client: TestClient,
+        sample_booking: TeeTimeBooking,
+        successful_booking: TeeTimeBooking,
+    ) -> None:
+        """A successful booking's confirmation carries the originating channel."""
+        sample_booking.origin_channel_id = "778899001122334455"
+        successful_booking.origin_channel_id = "778899001122334455"
+
+        with patch("app.api.jobs.settings") as mock_settings:
+            mock_settings.scheduler_api_key = "test-api-key"
+            mock_settings.timezone = "America/Chicago"
+
+            with patch("app.api.jobs.booking_service") as mock_service:
+                mock_service.get_due_bookings = AsyncMock(return_value=[sample_booking])
+                mock_service.execute_bookings_batch = AsyncMock(
+                    return_value=[
+                        (
+                            "test1234",
+                            BookingResult(
+                                success=True,
+                                booked_time=time(8, 0),
+                                confirmation_number="CONF123",
+                            ),
+                        )
+                    ]
+                )
+                mock_service.get_booking = AsyncMock(return_value=successful_booking)
+
+                with patch("app.api.jobs.sms_service") as mock_sms:
+                    mock_sms.send_booking_confirmation = AsyncMock()
+
+                    response = test_client.post(
+                        "/jobs/execute-due-bookings",
+                        headers={"X-Scheduler-API-Key": "test-api-key"},
+                    )
+
+                    assert response.status_code == 200
+                    args = mock_sms.send_booking_confirmation.call_args.args
+                    assert args[2] == "778899001122334455"
+
+    def test_failure_routed_to_booking_origin_channel(
+        self,
+        test_client: TestClient,
+        sample_booking: TeeTimeBooking,
+        failed_booking: TeeTimeBooking,
+    ) -> None:
+        """A failure notification - the case in the bug report - goes to the
+        channel rather than a DM."""
+        sample_booking.origin_channel_id = "778899001122334455"
+        failed_booking.origin_channel_id = "778899001122334455"
+
+        with patch("app.api.jobs.settings") as mock_settings:
+            mock_settings.scheduler_api_key = "test-api-key"
+            mock_settings.timezone = "America/Chicago"
+
+            with patch("app.api.jobs.booking_service") as mock_service:
+                mock_service.get_due_bookings = AsyncMock(return_value=[sample_booking])
+                mock_service.execute_bookings_batch = AsyncMock(
+                    return_value=[
+                        (
+                            "test1234",
+                            BookingResult(success=False, error_message="No available slots"),
+                        )
+                    ]
+                )
+                mock_service.get_booking = AsyncMock(return_value=failed_booking)
+
+                with patch("app.api.jobs.sms_service") as mock_sms:
+                    mock_sms.send_booking_failure = AsyncMock()
+
+                    response = test_client.post(
+                        "/jobs/execute-due-bookings",
+                        headers={"X-Scheduler-API-Key": "test-api-key"},
+                    )
+
+                    assert response.status_code == 200
+                    kwargs = mock_sms.send_booking_failure.call_args.kwargs
+                    assert kwargs["origin_channel_id"] == "778899001122334455"


### PR DESCRIPTION
## The problem

Booking notifications still arrived as private DMs even when the request was made in a shared channel, so the conversation ended up split across two places.

#120 added `DISCORD_CHANNEL_ID` as a static &#34;post here instead of DM&#34; setting, which helps only if every conversation happens in that one channel. A single configured channel is the wrong shape for the problem: it can&#39;t tell where any given request actually came from, so a DM conversation gets answered in public, and a second channel can never be used at all.

## The fix

Route each reply by its own conversation rather than by configuration.

The Discord gateway now passes the channel a message arrived in to `handle_incoming_message()`. That channel is stored on the user&#39;s session and copied onto any booking created from the conversation, so the 6:30 AM result — sent days later, by the batch job, from a different process — can find its way back to where the user asked.

Synchronous replies already went to the right place; this change is about the asynchronous ones.

### Changes

- **Schema and storage**: `origin_channel_id` on `TeeTimeBooking` and `UserSession`, with matching nullable columns and idempotent migrations. The per-column SQLite/Postgres migration code is now driven by a table, so future nullable columns are a one-line addition instead of a copied block.
- **Provider interface**: `send_sms` and the notification helpers take an optional `origin_channel_id`. Twilio and the mock provider ignore it; Discord routes on it.
- **Destination precedence** (`DiscordProvider.resolve_channel_id`): the originating guild channel, then the DM sentinel, then `DISCORD_CHANNEL_ID`, then a DM. A conversation started in a DM stays a DM even when a shared channel is configured, since a DM is where the user chose to talk. Neither a malformed stored origin nor an unusable configured value is interpolated into the API path.
- **`DISCORD_CHANNEL_ID`** keeps working, but is now only the fallback for notifications with no conversation behind them: REST API bookings, SMS, the weekly prompt, and bookings created before origins were recorded.

## Testing

`546 passed, 10 skipped`; `ruff check`, `ruff format --check`, and `mypy app` all clean.

Tests cover the destination precedence, the gateway handing off the channel it received a message on, the session-to-booking hand-off on confirm (both the single and multi-booking paths), both notification paths (`execute_booking` and the batch job), and a database round trip — the recorded channel is only useful if it survives to execution time, including across the status update the job performs.

I also ran the full chain end to end against a real SQLite database with the Discord API mocked: a message in `#general` created a booking carrying that channel, and the failure notification posted to `#general` mentioning the user — not a DM, and not the differently-configured `DISCORD_CHANNEL_ID`.

## Deploying

The new columns are added by the existing idempotent migration on startup; no manual step. Existing scheduled bookings have no recorded channel and keep their current behavior, falling back to `DISCORD_CHANNEL_ID` or a DM.



## Summary by CodeRabbit

* **New Features**
  * Discord conversations can now continue in the channel or direct message where they started.
  * Booking confirmations and failure notifications are routed to the originating conversation.
  * Bookings and sessions retain their originating Discord channel for follow-up messages.
  * Shared-channel messages support user mentions and configurable fallback destinations.

* **Documentation**
  * Updated Discord setup guidance for channel-based notifications and fallback behavior.
