### PR TITLE
feat: direct-HTTP booking path for the 6:30 race

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,13 @@ WALDEN_MEMBER_NUMBER=your_member_number
 WALDEN_PASSWORD=your_password
 WALDEN_BASE_URL=https://www.waldengolf.com
 
+# Run the 6:30 booking chain as direct PrimeFaces HTTP calls instead of browser
+# clicks. Login, navigation and slot discovery still run in Chrome; only the
+# race moves to HTTP, and any failure before the reservation is submitted falls
+# back to the JavaScript chain. Verify the transport first with:
+#   poetry run python scripts/probe_direct_http.py
+WALDEN_DIRECT_HTTP_BOOKING=false
+
 # User Configuration
 USER_PHONE_NUMBER=+1234567890
 

--- a/app/config.py
+++ b/app/config.py
@@ -42,6 +42,13 @@ class Settings(BaseSettings):
     walden_password: str = ""
     walden_base_url: str = "https://www.waldengolf.com"
 
+    # Run the 6:30 booking chain as direct PrimeFaces HTTP calls instead of
+    # browser clicks. Login, navigation and slot discovery still run in Chrome;
+    # only the race itself moves to HTTP. Any failure falls back to the JS
+    # chain, so the worst case is the current behavior plus one wasted POST.
+    # Off by default until it has won a real race.
+    walden_direct_http_booking: bool = False
+
     user_phone_number: str = ""
 
     database_url: str = "sqlite+aiosqlite:///./teetime.db"

--- a/app/config.py
+++ b/app/config.py
@@ -44,8 +44,9 @@ class Settings(BaseSettings):
 
     # Run the 6:30 booking chain as direct PrimeFaces HTTP calls instead of
     # browser clicks. Login, navigation and slot discovery still run in Chrome;
-    # only the race itself moves to HTTP. Any failure falls back to the JS
-    # chain, so the worst case is the current behavior plus one wasted POST.
+    # only the race itself moves to HTTP. A failure before the reservation is
+    # submitted falls back to the JS chain; a failure after it is reported
+    # without a browser retry, because the slot may already be held.
     # Off by default until it has won a real race.
     walden_direct_http_booking: bool = False
 

--- a/app/providers/walden_http.py
+++ b/app/providers/walden_http.py
@@ -128,10 +128,12 @@ class Node:
 
     @property
     def id(self) -> str:
+        """The element's ``id`` attribute, or an empty string."""
         return self.attrs.get("id", "")
 
     @property
     def classes(self) -> frozenset[str]:
+        """The element's CSS classes as a set."""
         return frozenset(self.attrs.get("class", "").split())
 
     def descendants(self) -> "list[Node]":
@@ -145,10 +147,12 @@ class Node:
         return out
 
     def text_content(self) -> str:
+        """This element's text plus all descendant text, whitespace-collapsed."""
         parts = [self.text] + [d.text for d in self.descendants()]
         return " ".join(p for p in parts if p).strip()
 
     def find_by_id(self, element_id: str) -> "Node | None":
+        """Find the first descendant with the given id."""
         for node in self.descendants():
             if node.id == element_id:
                 return node
@@ -166,6 +170,7 @@ class Node:
         return found
 
     def find_with_class(self, css_class: str) -> "list[Node]":
+        """Find descendants carrying a CSS class."""
         return [n for n in self.descendants() if css_class in n.classes]
 
 
@@ -173,11 +178,13 @@ class _TreeBuilder(HTMLParser):
     """Builds a :class:`Node` tree, tolerating the tee sheet's unclosed tags."""
 
     def __init__(self) -> None:
+        """Start an empty document tree."""
         super().__init__(convert_charrefs=True)
         self.root = Node(tag="#document")
         self._stack: list[Node] = [self.root]
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        """Open an element, descending into it unless it is a void tag."""
         node = Node(
             tag=tag,
             attrs={k: (v if v is not None else "") for k, v in attrs},
@@ -188,6 +195,7 @@ class _TreeBuilder(HTMLParser):
             self._stack.append(node)
 
     def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        """Add a self-closing element without descending into it."""
         node = Node(
             tag=tag,
             attrs={k: (v if v is not None else "") for k, v in attrs},
@@ -196,6 +204,7 @@ class _TreeBuilder(HTMLParser):
         self._stack[-1].children.append(node)
 
     def handle_endtag(self, tag: str) -> None:
+        """Close the matching open element, ignoring stray end tags."""
         # Unwind to the matching open tag. Stray end tags are ignored rather
         # than allowed to pop the stack past their opener.
         for depth in range(len(self._stack) - 1, 0, -1):
@@ -204,6 +213,7 @@ class _TreeBuilder(HTMLParser):
                 return
 
     def handle_data(self, data: str) -> None:
+        """Attach non-whitespace text to the element currently open."""
         stripped = data.strip()
         if stripped:
             node = self._stack[-1]
@@ -216,6 +226,32 @@ def parse_html(html: str) -> Node:
     builder.feed(html)
     builder.close()
     return builder.root
+
+
+def visible_text(html: str) -> str:
+    """Extract user-visible text from markup, ignoring script and style bodies.
+
+    The HTTP-side counterpart of reading ``body.text`` from a WebDriver: it lets
+    the same success/failure phrase checks run against a partial response as
+    against a rendered page. Script contents are excluded so a JS string literal
+    cannot be mistaken for page copy.
+    """
+    document = parse_html(html)
+    parts = []
+    for node in [document, *document.descendants()]:
+        if node.text and not _has_ancestor_tag(node, ("script", "style")):
+            parts.append(node.text)
+    return " ".join(parts).strip()
+
+
+def _has_ancestor_tag(node: Node, tags: tuple[str, ...]) -> bool:
+    """Report whether the node sits inside any of the given tags."""
+    current: Node | None = node
+    while current is not None:
+        if current.tag in tags:
+            return True
+        current = current.parent
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -332,6 +368,7 @@ class FormState:
 
     @property
     def view_state(self) -> str | None:
+        """The form's current ``javax.faces.ViewState``, if it carries one."""
         for name, value in self.fields:
             if name == _VIEW_STATE_PARAM:
                 return value
@@ -524,22 +561,34 @@ class PrimeFacesSession:
         timeout_s: float = DEFAULT_TIMEOUT_S,
         client: httpx.Client | None = None,
     ) -> None:
+        """Build a session around a form's state and a browser's cookies.
+
+        Args:
+            form_state: The form this session will submit.
+            cookies: Cookie jar, normally adopted from a live WebDriver.
+            base_url: URL used to warm the connection and resolve relative actions.
+            user_agent: Sent on every request; match the browser's.
+            timeout_s: Per-request budget.
+            client: Optional pre-built client (tests inject a mock transport).
+        """
         self.form_state = form_state
         self.base_url = base_url
-        self._client = client or httpx.Client(
-            cookies=cookies,
-            timeout=timeout_s,
-            follow_redirects=False,
-            headers={
-                "User-Agent": user_agent,
-                # PrimeFaces sets these on every AJAX request; the bridge uses
-                # Faces-Request to route the call to the partial lifecycle.
-                "Faces-Request": "partial/ajax",
-                "X-Requested-With": "XMLHttpRequest",
-                "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-                "Accept": "application/xml, text/xml, */*; q=0.01",
-            },
-        )
+        headers = {
+            "User-Agent": user_agent,
+            # PrimeFaces sets these on every AJAX request; the bridge uses
+            # Faces-Request to route the call to the partial lifecycle.
+            "Faces-Request": "partial/ajax",
+            "X-Requested-With": "XMLHttpRequest",
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "Accept": "application/xml, text/xml, */*; q=0.01",
+        }
+        self._client = client or httpx.Client(timeout=timeout_s, follow_redirects=False)
+        # Applied after construction so an injected client (tests, or a caller
+        # supplying its own transport) gets the same protocol headers and cookie
+        # jar as one we build - otherwise the request under test is not the
+        # request production sends.
+        self._client.headers.update(headers)
+        self._client.cookies.update(cookies)
 
     @classmethod
     def from_selenium(
@@ -610,13 +659,32 @@ class PrimeFacesSession:
         """
         started = time_module.perf_counter()
         try:
-            self._client.get(self.base_url)
+            # HEAD first: the base URL is the portlet page, and a GET makes the
+            # server render the whole tee sheet seconds before the window for a
+            # body we discard. Liferay may not serve HEAD, so fall back to GET.
+            response = self._client.head(self.base_url)
+            if not response.is_success:
+                response = self._client.get(self.base_url)
         except httpx.HTTPError as exc:
             raise DirectHttpError(
                 f"Failed to warm up connection to {self.base_url}: {exc}"
             ) from exc
+
         rtt_ms = (time_module.perf_counter() - started) * 1000
-        logger.info("DIRECT_HTTP: Connection warm, round trip %.0fms", rtt_ms)
+        if not response.is_success:
+            # Anything but 2xx here means the adopted cookies did not carry the
+            # session - a logged-out portal answers with a redirect to the login
+            # page. Better to fail now, while falling back to the browser chain
+            # is still free, than as a baffling Reserve failure at 6:30.
+            raise DirectHttpError(
+                f"Warm-up of {self.base_url} returned HTTP {response.status_code}; "
+                "the adopted session may not be authenticated"
+            )
+        logger.info(
+            "DIRECT_HTTP: Connection warm, HTTP %d, round trip %.0fms",
+            response.status_code,
+            rtt_ms,
+        )
         return rtt_ms
 
     def post(self, config: AbConfig, *, body: bytes | None = None) -> PartialResponse:
@@ -639,6 +707,14 @@ class PrimeFacesSession:
             )
 
         response = parse_partial_response(http_response.text)
+        if response.redirect_url:
+            # JSF answers a dead session with a redirect to the login page
+            # rather than an error element. Without this the body is never
+            # updated and the chain would carry on against an expired view.
+            raise ViewExpiredError(
+                f"Server redirected {config.source} to {response.redirect_url}; "
+                "the adopted session is no longer valid"
+            )
         self._apply(response)
         return response
 
@@ -652,29 +728,46 @@ class PrimeFacesSession:
         """
         form_markup = self.form_state.form_id and response.updates.get(self.form_state.form_id)
         if form_markup and "<form" in form_markup:
-            try:
-                refreshed = FormState.from_html(form_markup, form_id=self.form_state.form_id)
-            except DirectHttpError as exc:
-                logger.warning("DIRECT_HTTP: Could not refresh form state from update: %s", exc)
+            document = parse_html(form_markup)
+            refreshed = next(
+                (f for f in document.find_all("form") if f.id == self.form_state.form_id), None
+            )
+            if refreshed is None:
+                logger.warning(
+                    "DIRECT_HTTP: Update for %s carried no matching form; keeping current fields",
+                    self.form_state.form_id,
+                )
             else:
-                self.form_state.fields = refreshed.fields
-                if refreshed.action_url:
-                    # A re-rendered form may carry a relative action; resolve it
-                    # against the URL we are already posting to.
+                # Field refresh and action resolution are independent: a
+                # re-rendered fragment often omits the action, and keeping stale
+                # fields in that case would submit the pre-click player count and
+                # guest state on the next step.
+                fields = _serialize_form(refreshed)
+                self.form_state.fields = fields
+                action_url = next(
+                    (value for name, value in fields if name == _ENCODED_URL_PARAM),
+                    refreshed.attrs.get("action", ""),
+                )
+                if action_url:
+                    # The action may be relative; resolve against the URL we are
+                    # already posting to.
                     self.form_state.action_url = urllib.parse.urljoin(
-                        self.form_state.action_url, refreshed.action_url
+                        self.form_state.action_url, action_url
                     )
 
         if response.view_state:
             self.form_state.set_field(_VIEW_STATE_PARAM, response.view_state)
 
     def close(self) -> None:
+        """Close the underlying HTTP client and its connection pool."""
         self._client.close()
 
     def __enter__(self) -> "PrimeFacesSession":
+        """Enter a context manager that closes the client on exit."""
         return self
 
     def __exit__(self, *exc_info: object) -> None:
+        """Close the client when leaving the context."""
         self.close()
 
 

--- a/app/providers/walden_http.py
+++ b/app/providers/walden_http.py
@@ -1,0 +1,694 @@
+"""
+Direct-HTTP booking path for the Walden Golf / Northstar tee sheet.
+
+Background
+----------
+The tee sheet is a JSF/PrimeFaces portlet running inside Liferay. Every
+interaction the Selenium chain performs by clicking - Reserve, the player-count
+button, each TBD guest, Book Now - is, underneath, a single
+``application/x-www-form-urlencoded`` POST that PrimeFaces builds from the
+element's ``PrimeFaces.ab({...})`` handler and sends as an XHR. The server
+answers with a ``<partial-response>`` XML document containing the re-rendered
+markup and a fresh ``javax.faces.ViewState``.
+
+Nothing about that exchange requires a browser. This module speaks the same
+protocol directly with ``httpx``:
+
+    click Reserve  ==  POST encodedURL
+                       javax.faces.partial.ajax=true
+                       javax.faces.source=<reserve button id>
+                       javax.faces.partial.execute=@all
+                       javax.faces.partial.render=<form id>
+                       <reserve button id>=<reserve button id>
+                       javax.faces.ViewState=<current view state>
+                       + the form's serialized fields (~1.2 KB total)
+
+Why it is faster is not the click itself - the staged JS chain (#113, #116)
+already fires with ~0 ms drift. It is everything the browser does *between*
+clicks:
+
+* Each response re-renders ``u:"...teeTimeForm"`` - the entire form. In Chrome
+  that is a ~700 KB HTML parse plus style/layout before the next step's element
+  exists. Over HTTP it is a regex over an XML payload.
+* The JS chain can only discover that work finished by polling every 10 ms, and
+  spaces the TBD clicks with fixed 200 ms sleeps so PrimeFaces can settle.
+  Request/response is strictly ordered - the next POST goes out the moment the
+  previous response lands.
+* Between bookings in a batch the browser re-navigates and re-scrolls the tee
+  sheet (~23 s, per #122). Over HTTP a second booking is just another POST on
+  the same session.
+
+Scope and safety
+----------------
+This module deliberately does *not* replace login, navigation, course/date
+selection or slot discovery. Those all happen minutes before the booking window
+opens, where latency is irrelevant and the Selenium path is proven. The HTTP
+session is adopted *from* a live, already-navigated WebDriver
+(:meth:`PrimeFacesSession.from_selenium`), inheriting its cookies and the exact
+form state the browser had built up.
+
+The booking window itself is unchanged: the reserve POST is fired at the same
+target timestamp the JS chain would have clicked at, never earlier.
+
+Every step after Reserve is derived from the markup the server just returned, by
+parsing the same ``PrimeFaces.ab({...})`` handler the browser would have
+executed. Nothing about the request sequence is hardcoded, so a component id
+churning from ``j_idt1076`` to ``j_idt1082`` does not break the chain.
+"""
+
+import logging
+import re
+import time as time_module
+import urllib.parse
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from typing import Any
+from xml.etree import ElementTree
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# Elements that never carry an end tag; the tree builder must not nest into them.
+_VOID_TAGS = frozenset(
+    {
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+    }
+)
+
+# Request budget for a single PrimeFaces POST. The whole chain is 3-6 of these,
+# and a stalled one at 6:30 is worth abandoning to the Selenium fallback fast.
+DEFAULT_TIMEOUT_S = 10.0
+
+# Final busy-wait before the target timestamp, mirroring the JS chain's 25 ms
+# spin. Python only needs a couple of ms since there is no DOM work left to do.
+_SPIN_WINDOW_MS = 3
+
+
+class DirectHttpError(RuntimeError):
+    """Raised when the direct-HTTP path cannot complete a step.
+
+    Always recoverable by the caller: the Selenium chain remains a valid way to
+    perform the same booking, so callers catch this and fall back.
+    """
+
+
+class ViewExpiredError(DirectHttpError):
+    """The server rejected our ViewState - the adopted session is stale."""
+
+
+# ---------------------------------------------------------------------------
+# Minimal HTML tree
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Node:
+    """A single element in the lightweight DOM built by :func:`parse_html`."""
+
+    tag: str
+    attrs: dict[str, str] = field(default_factory=dict)
+    children: list["Node"] = field(default_factory=list)
+    parent: "Node | None" = None
+    text: str = ""
+
+    @property
+    def id(self) -> str:
+        return self.attrs.get("id", "")
+
+    @property
+    def classes(self) -> frozenset[str]:
+        return frozenset(self.attrs.get("class", "").split())
+
+    def descendants(self) -> "list[Node]":
+        """All nodes beneath this one, in document order."""
+        out: list[Node] = []
+        stack = list(reversed(self.children))
+        while stack:
+            node = stack.pop()
+            out.append(node)
+            stack.extend(reversed(node.children))
+        return out
+
+    def text_content(self) -> str:
+        parts = [self.text] + [d.text for d in self.descendants()]
+        return " ".join(p for p in parts if p).strip()
+
+    def find_by_id(self, element_id: str) -> "Node | None":
+        for node in self.descendants():
+            if node.id == element_id:
+                return node
+        return None
+
+    def find_all(self, tag: str | None = None, **attr_match: str) -> "list[Node]":
+        """Find descendants by tag name and exact attribute values."""
+        found = []
+        for node in self.descendants():
+            if tag is not None and node.tag != tag:
+                continue
+            if any(node.attrs.get(k) != v for k, v in attr_match.items()):
+                continue
+            found.append(node)
+        return found
+
+    def find_with_class(self, css_class: str) -> "list[Node]":
+        return [n for n in self.descendants() if css_class in n.classes]
+
+
+class _TreeBuilder(HTMLParser):
+    """Builds a :class:`Node` tree, tolerating the tee sheet's unclosed tags."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.root = Node(tag="#document")
+        self._stack: list[Node] = [self.root]
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        node = Node(
+            tag=tag,
+            attrs={k: (v if v is not None else "") for k, v in attrs},
+            parent=self._stack[-1],
+        )
+        self._stack[-1].children.append(node)
+        if tag not in _VOID_TAGS:
+            self._stack.append(node)
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        node = Node(
+            tag=tag,
+            attrs={k: (v if v is not None else "") for k, v in attrs},
+            parent=self._stack[-1],
+        )
+        self._stack[-1].children.append(node)
+
+    def handle_endtag(self, tag: str) -> None:
+        # Unwind to the matching open tag. Stray end tags are ignored rather
+        # than allowed to pop the stack past their opener.
+        for depth in range(len(self._stack) - 1, 0, -1):
+            if self._stack[depth].tag == tag:
+                del self._stack[depth:]
+                return
+
+    def handle_data(self, data: str) -> None:
+        stripped = data.strip()
+        if stripped:
+            node = self._stack[-1]
+            node.text = f"{node.text} {stripped}".strip() if node.text else stripped
+
+
+def parse_html(html: str) -> Node:
+    """Parse an HTML document or fragment into a :class:`Node` tree."""
+    builder = _TreeBuilder()
+    builder.feed(html)
+    builder.close()
+    return builder.root
+
+
+# ---------------------------------------------------------------------------
+# PrimeFaces.ab handler parsing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AbConfig:
+    """A parsed ``PrimeFaces.ab({...})`` call - one AJAX request's parameters.
+
+    Mirrors the PrimeFaces shorthand keys: ``s`` source, ``f`` form, ``p``
+    process (execute), ``u`` update (render), ``e`` behavior event.
+    """
+
+    source: str
+    form: str
+    process: str | None = None
+    update: str | None = None
+    event: str | None = None
+
+
+# PrimeFaces.ab({s:"...",f:"...",p:"...",u:"..."}) - values may be quoted with
+# either quote style, and `this` appears unquoted for inline handlers.
+_AB_CALL_RE = re.compile(r"PrimeFaces\.ab\(\s*\{(?P<body>.*?)\}\s*[,)]", re.S)
+_AB_KEY_RE = re.compile(r"(?<![\w$])(?P<key>[sfpue])\s*:\s*(?P<value>\"[^\"]*\"|'[^']*'|this\b)")
+
+
+def parse_ab_call(js: str, *, element_id: str | None = None) -> AbConfig | None:
+    """Parse the first ``PrimeFaces.ab({...})`` call in a JS snippet.
+
+    Args:
+        js: JavaScript source - typically an ``onclick`` attribute value.
+        element_id: Id substituted for ``s:this``, which PrimeFaces emits for
+            handlers bound inline to the element they act on.
+
+    Returns:
+        The parsed config, or None when the snippet has no parseable call or
+        lacks the source/form pair every request needs.
+    """
+    call = _AB_CALL_RE.search(js)
+    if not call:
+        return None
+
+    values: dict[str, str] = {}
+    for match in _AB_KEY_RE.finditer(call.group("body")):
+        raw = match.group("value")
+        if raw == "this":
+            if element_id is None:
+                continue
+            values[match.group("key")] = element_id
+        else:
+            values[match.group("key")] = raw[1:-1]
+
+    source = values.get("s")
+    form = values.get("f")
+    if not source or not form:
+        return None
+
+    return AbConfig(
+        source=source,
+        form=form,
+        process=values.get("p"),
+        update=values.get("u"),
+        event=values.get("e"),
+    )
+
+
+def find_ab_for_element(node: Node, document_html: str) -> AbConfig | None:
+    """Resolve the AJAX request a click on ``node`` would have produced.
+
+    Checks the element's own event attributes first, then - for PrimeFaces
+    widgets such as ``selectOneButton``, whose behaviors live in a widget-init
+    script rather than an inline handler - searches the document for a call
+    whose source is this element's id.
+    """
+    for attr in ("onclick", "onchange", "onmousedown"):
+        handler = node.attrs.get(attr)
+        if handler:
+            config = parse_ab_call(handler, element_id=node.id)
+            if config:
+                return config
+
+    if not node.id:
+        return None
+
+    for call in _AB_CALL_RE.finditer(document_html):
+        config = parse_ab_call(f"PrimeFaces.ab({{{call.group('body')}}})")
+        if config and config.source == node.id:
+            return config
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Form state
+# ---------------------------------------------------------------------------
+
+_VIEW_STATE_PARAM = "javax.faces.ViewState"
+_ENCODED_URL_PARAM = "javax.faces.encodedURL"
+
+
+@dataclass
+class FormState:
+    """The serialized state of a JSF form, as a browser would submit it.
+
+    ``fields`` holds the form's successful controls in document order - exactly
+    what ``$(form).serialize()`` would produce, which is what PrimeFaces posts
+    for a non-``partialSubmit`` request.
+    """
+
+    form_id: str
+    action_url: str
+    fields: list[tuple[str, str]]
+
+    @property
+    def view_state(self) -> str | None:
+        for name, value in self.fields:
+            if name == _VIEW_STATE_PARAM:
+                return value
+        return None
+
+    def set_field(self, name: str, value: str) -> None:
+        """Replace (or append) a single field value, preserving field order."""
+        for index, (existing, _) in enumerate(self.fields):
+            if existing == name:
+                self.fields[index] = (name, value)
+                return
+        self.fields.append((name, value))
+
+    @classmethod
+    def from_html(cls, html: str, *, form_id: str | None = None) -> "FormState":
+        """Extract a form's submittable state from a rendered page.
+
+        Args:
+            html: Full page source.
+            form_id: Id of the form to read. Defaults to the first form that
+                carries a ViewState, which on the tee sheet is ``teeTimeForm``.
+        """
+        document = parse_html(html)
+        forms = document.find_all("form")
+
+        target: Node | None = None
+        if form_id is not None:
+            target = next((f for f in forms if f.id == form_id), None)
+            if target is None:
+                raise DirectHttpError(f"Form {form_id!r} not found in page")
+        else:
+            for candidate in forms:
+                if any(
+                    n.attrs.get("name") == _VIEW_STATE_PARAM for n in candidate.find_all("input")
+                ):
+                    target = candidate
+                    break
+            if target is None:
+                raise DirectHttpError("No JSF form (none carrying a ViewState) found in page")
+
+        fields = _serialize_form(target)
+
+        # PrimeFaces posts to javax.faces.encodedURL when the portlet bridge
+        # renders one (it routes to the resource phase), falling back to the
+        # form's action. This mirrors PrimeFaces.ajax.Utils.getPostUrl.
+        action_url = next(
+            (value for name, value in fields if name == _ENCODED_URL_PARAM),
+            target.attrs.get("action", ""),
+        )
+        if not action_url:
+            raise DirectHttpError(f"Form {target.id!r} has no action or encodedURL to post to")
+
+        return cls(form_id=target.id, action_url=action_url, fields=fields)
+
+
+def _serialize_form(form: Node) -> list[tuple[str, str]]:
+    """Serialize a form's successful controls the way a browser would.
+
+    Skips unnamed, disabled, and unchecked controls, and buttons (which are
+    only submitted when they are the activating control - PrimeFaces adds the
+    source parameter explicitly for that).
+    """
+    serialized: list[tuple[str, str]] = []
+    for node in form.descendants():
+        if node.tag not in ("input", "select", "textarea"):
+            continue
+        name = node.attrs.get("name")
+        if not name or "disabled" in node.attrs:
+            continue
+
+        if node.tag == "select":
+            for option in node.find_all("option"):
+                if "selected" in option.attrs:
+                    serialized.append((name, option.attrs.get("value", option.text_content())))
+            continue
+
+        if node.tag == "textarea":
+            serialized.append((name, node.text_content()))
+            continue
+
+        input_type = node.attrs.get("type", "text").lower()
+        if input_type in ("submit", "button", "reset", "image", "file"):
+            continue
+        if input_type in ("radio", "checkbox") and "checked" not in node.attrs:
+            continue
+        serialized.append((name, node.attrs.get("value", "")))
+
+    return serialized
+
+
+# ---------------------------------------------------------------------------
+# Partial response
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PartialResponse:
+    """A parsed JSF ``<partial-response>`` document."""
+
+    updates: dict[str, str] = field(default_factory=dict)
+    view_state: str | None = None
+    redirect_url: str | None = None
+    error_name: str | None = None
+    error_message: str | None = None
+
+    @property
+    def markup(self) -> str:
+        """All re-rendered markup concatenated, for element lookups."""
+        return "\n".join(
+            value for key, value in self.updates.items() if _VIEW_STATE_PARAM not in key
+        )
+
+
+def parse_partial_response(xml: str) -> PartialResponse:
+    """Parse a JSF partial-response payload.
+
+    Raises:
+        ViewExpiredError: if the server reports an expired/invalid view.
+        DirectHttpError: if the payload is not a partial-response at all -
+            typically an HTML error or login page, meaning the session died.
+    """
+    try:
+        root = ElementTree.fromstring(xml.strip())
+    except ElementTree.ParseError as exc:
+        raise DirectHttpError(
+            f"Response was not a JSF partial-response (parse failed: {exc}); "
+            f"first 200 chars: {xml[:200]!r}"
+        ) from exc
+
+    if root.tag != "partial-response":
+        raise DirectHttpError(
+            f"Response was not a JSF partial-response (root element {root.tag!r}); "
+            "the session has most likely expired"
+        )
+
+    response = PartialResponse()
+
+    error = root.find("error")
+    if error is not None:
+        name_node = error.find("error-name")
+        message_node = error.find("error-message")
+        response.error_name = (name_node.text or "").strip() if name_node is not None else None
+        response.error_message = (
+            (message_node.text or "").strip() if message_node is not None else None
+        )
+        if response.error_name and "ViewExpired" in response.error_name:
+            raise ViewExpiredError(
+                f"Server rejected the view state: {response.error_name} "
+                f"{response.error_message or ''}".strip()
+            )
+        raise DirectHttpError(
+            f"Server returned {response.error_name}: {response.error_message or ''}".strip()
+        )
+
+    redirect = root.find("redirect")
+    if redirect is not None:
+        response.redirect_url = redirect.get("url")
+
+    for update in root.iter("update"):
+        update_id = update.get("id") or ""
+        content = update.text or ""
+        response.updates[update_id] = content
+        # JSF namespaces the ViewState update id, e.g.
+        # "_teeTimePortlet_WAR_northstarportlet_:javax.faces.ViewState:0".
+        if _VIEW_STATE_PARAM in update_id:
+            response.view_state = content.strip()
+
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Session
+# ---------------------------------------------------------------------------
+
+
+class PrimeFacesSession:
+    """Speaks the PrimeFaces AJAX protocol directly over HTTP.
+
+    Holds the cookie jar and the current form state, refreshing the ViewState
+    from every partial response the way the browser's JSF runtime does.
+    """
+
+    def __init__(
+        self,
+        form_state: FormState,
+        cookies: dict[str, str],
+        *,
+        base_url: str,
+        user_agent: str = "Mozilla/5.0",
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self.form_state = form_state
+        self.base_url = base_url
+        self._client = client or httpx.Client(
+            cookies=cookies,
+            timeout=timeout_s,
+            follow_redirects=False,
+            headers={
+                "User-Agent": user_agent,
+                # PrimeFaces sets these on every AJAX request; the bridge uses
+                # Faces-Request to route the call to the partial lifecycle.
+                "Faces-Request": "partial/ajax",
+                "X-Requested-With": "XMLHttpRequest",
+                "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+                "Accept": "application/xml, text/xml, */*; q=0.01",
+            },
+        )
+
+    @classmethod
+    def from_selenium(
+        cls,
+        driver: Any,
+        *,
+        form_id: str | None = None,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+    ) -> "PrimeFacesSession":
+        """Adopt a live browser session: its cookies and its current form state.
+
+        Everything the browser established - login, course selection, the
+        selected date - is carried in the session cookies plus the ~12 form
+        fields this reads, so the HTTP session resumes exactly where the
+        browser is rather than rebuilding any of it.
+        """
+        cookies = {c["name"]: c["value"] for c in driver.get_cookies()}
+        if not cookies:
+            raise DirectHttpError("Browser session has no cookies to adopt")
+
+        form_state = FormState.from_html(driver.page_source, form_id=form_id)
+        user_agent = str(driver.execute_script("return navigator.userAgent;"))
+
+        logger.info(
+            "DIRECT_HTTP: Adopted browser session - form=%s, %d cookies, %d form fields, "
+            "viewState=%s",
+            form_state.form_id,
+            len(cookies),
+            len(form_state.fields),
+            "present" if form_state.view_state else "MISSING",
+        )
+        return cls(
+            form_state,
+            cookies,
+            base_url=str(driver.current_url),
+            user_agent=user_agent,
+            timeout_s=timeout_s,
+        )
+
+    def build_body(self, config: AbConfig) -> bytes:
+        """Build the exact POST body PrimeFaces would have sent for ``config``.
+
+        Ordered to match the browser: the form's serialized fields first, then
+        the partial-request parameters PrimeFaces appends.
+        """
+        params: list[tuple[str, str]] = list(self.form_state.fields)
+        params.append(("javax.faces.partial.ajax", "true"))
+        params.append(("javax.faces.source", config.source))
+        # PrimeFaces defaults execute to @all when a component declares no
+        # process list - the same default JSF applies to command components.
+        params.append(("javax.faces.partial.execute", config.process or "@all"))
+        if config.update:
+            params.append(("javax.faces.partial.render", config.update))
+        if config.event:
+            params.append(("javax.faces.behavior.event", config.event))
+            params.append(("javax.faces.partial.event", config.event))
+        # The activating control submits its own name - this is what makes JSF
+        # decode the click as an action on that component. (The form's own
+        # marker field is already among the serialized fields.)
+        params.append((config.source, config.source))
+        return urllib.parse.urlencode(params).encode("utf-8")
+
+    def warm_up(self) -> float:
+        """Open the TLS connection ahead of the race.
+
+        Returns the round-trip time in ms. Without this the first POST pays DNS
+        + TCP + TLS - easily 100-300 ms - at exactly the wrong moment.
+        """
+        started = time_module.perf_counter()
+        try:
+            self._client.get(self.base_url)
+        except httpx.HTTPError as exc:
+            raise DirectHttpError(
+                f"Failed to warm up connection to {self.base_url}: {exc}"
+            ) from exc
+        rtt_ms = (time_module.perf_counter() - started) * 1000
+        logger.info("DIRECT_HTTP: Connection warm, round trip %.0fms", rtt_ms)
+        return rtt_ms
+
+    def post(self, config: AbConfig, *, body: bytes | None = None) -> PartialResponse:
+        """Send one PrimeFaces AJAX request and fold the response into state.
+
+        Args:
+            config: The request to send.
+            body: Pre-built body from :meth:`build_body`, for the timed path
+                where serialization must not happen on the critical path.
+        """
+        payload = body if body is not None else self.build_body(config)
+        try:
+            http_response = self._client.post(self.form_state.action_url, content=payload)
+        except httpx.HTTPError as exc:
+            raise DirectHttpError(f"POST for {config.source} failed: {exc}") from exc
+
+        if http_response.status_code != 200:
+            raise DirectHttpError(
+                f"POST for {config.source} returned HTTP {http_response.status_code}"
+            )
+
+        response = parse_partial_response(http_response.text)
+        self._apply(response)
+        return response
+
+    def _apply(self, response: PartialResponse) -> None:
+        """Fold a partial response into the session state.
+
+        The tee sheet re-renders the whole form on every step (``u`` is the form
+        id), so the browser's next request would serialize the *new* fields.
+        Rebuild from the returned markup when it contains our form, then apply
+        the ViewState, which JSF always sends as its own update.
+        """
+        form_markup = self.form_state.form_id and response.updates.get(self.form_state.form_id)
+        if form_markup and "<form" in form_markup:
+            try:
+                refreshed = FormState.from_html(form_markup, form_id=self.form_state.form_id)
+            except DirectHttpError as exc:
+                logger.warning("DIRECT_HTTP: Could not refresh form state from update: %s", exc)
+            else:
+                self.form_state.fields = refreshed.fields
+                if refreshed.action_url:
+                    # A re-rendered form may carry a relative action; resolve it
+                    # against the URL we are already posting to.
+                    self.form_state.action_url = urllib.parse.urljoin(
+                        self.form_state.action_url, refreshed.action_url
+                    )
+
+        if response.view_state:
+            self.form_state.set_field(_VIEW_STATE_PARAM, response.view_state)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "PrimeFacesSession":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+
+def sleep_until(target_timestamp_ms: int) -> int:
+    """Block until ``target_timestamp_ms``, returning the drift in ms.
+
+    Coarse ``sleep`` down to the last few ms, then a spin - the same shape as
+    the JS chain's wait, minus a DOM to worry about. Returns immediately (with
+    a positive drift) when the target is already past.
+    """
+    coarse_s = (target_timestamp_ms - _SPIN_WINDOW_MS - time_module.time() * 1000) / 1000
+    if coarse_s > 0:
+        time_module.sleep(coarse_s)
+    target_s = target_timestamp_ms / 1000
+    while time_module.time() < target_s:
+        pass
+    return int(time_module.time() * 1000) - target_timestamp_ms

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -1,0 +1,380 @@
+"""
+The Walden booking chain, executed over direct HTTP instead of a browser.
+
+This is the browser-free equivalent of ``_JS_ASYNC_BOOKING_CHAIN`` in
+:mod:`app.providers.walden_provider`: Reserve -> player count -> TBD guests ->
+Book Now. Each step is one PrimeFaces AJAX POST (see
+:mod:`app.providers.walden_http` for the protocol), and each step's request is
+derived from the markup the previous response returned - the same
+``PrimeFaces.ab({...})`` handler the browser would have run on click.
+
+The critical-path design goal is that at the target timestamp there is nothing
+left to do but write bytes to an already-open socket:
+
+* The Reserve request body is serialized during :meth:`DirectHttpBooker.prepare`,
+  before the window opens.
+* The TLS connection is established during ``prepare`` too.
+* :meth:`DirectHttpBooker.book` waits out the remaining time and posts.
+
+Failures raise :class:`~app.providers.walden_http.DirectHttpError`, which the
+caller treats as "fall back to the Selenium chain". Nothing here is trusted
+enough to be the only path to a booking.
+"""
+
+import logging
+import time as time_module
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.providers.walden_dom_schema import DOM
+from app.providers.walden_http import (
+    AbConfig,
+    DirectHttpError,
+    Node,
+    PartialResponse,
+    PrimeFacesSession,
+    find_ab_for_element,
+    parse_html,
+    sleep_until,
+)
+
+logger = logging.getLogger(__name__)
+
+# Guest rows settle server-side within one request/response, so unlike the JS
+# chain there is no fixed inter-click delay to pay here.
+_MAX_PLAYERS = 4
+
+
+@dataclass
+class DirectBookingResult:
+    """Outcome of a direct-HTTP booking attempt.
+
+    Shaped to match the JS chain's result dict so the provider can log and
+    branch on both identically.
+    """
+
+    success: bool = False
+    blocked: bool = False
+    phase: str = "init"
+    error: str | None = None
+    timing: dict[str, Any] = field(default_factory=dict)
+
+    def as_chain_result(self) -> dict[str, Any]:
+        """Render as the dict shape ``_run_booking_chain_js`` returns."""
+        return {
+            "success": self.success,
+            "blocked": self.blocked,
+            "phase": self.phase,
+            "error": self.error,
+            "timing": self.timing,
+        }
+
+
+class DirectHttpBooker:
+    """Runs one booking over HTTP against an adopted browser session."""
+
+    def __init__(self, session: PrimeFacesSession) -> None:
+        self.session = session
+        self._reserve_config: AbConfig | None = None
+        self._reserve_body: bytes | None = None
+
+    # -- staging ----------------------------------------------------------
+
+    def prepare(self, reserve_button_id: str, page_html: str) -> None:
+        """Resolve and pre-serialize the Reserve request, and warm the socket.
+
+        Everything expensive happens here, before the booking window opens:
+        parsing the tee sheet, resolving the button's AJAX config, urlencoding
+        the body, DNS/TCP/TLS. What remains for the target instant is a socket
+        write.
+
+        Args:
+            reserve_button_id: Component id of the slot's Reserve link, e.g.
+                ``..._:teeTimeForm:teeTimeCourses:0:teeTimeSlots:67:slotTee:0:reserve_button``.
+            page_html: Current tee sheet source, used to resolve the handler.
+        """
+        document = parse_html(page_html)
+        button = document.find_by_id(reserve_button_id)
+        if button is None:
+            raise DirectHttpError(f"Reserve button {reserve_button_id!r} not found in page")
+
+        config = find_ab_for_element(button, page_html)
+        if config is None:
+            raise DirectHttpError(
+                f"Reserve button {reserve_button_id!r} has no PrimeFaces.ab handler to replay"
+            )
+
+        self._reserve_config = config
+        self._reserve_body = self.session.build_body(config)
+        logger.info(
+            "DIRECT_HTTP: Reserve request staged - source=%s, %d body bytes",
+            config.source,
+            len(self._reserve_body),
+        )
+        self.session.warm_up()
+
+    # -- the race ---------------------------------------------------------
+
+    def book(
+        self,
+        num_players: int,
+        *,
+        target_timestamp_ms: int | None = None,
+    ) -> DirectBookingResult:
+        """Run the full chain, firing Reserve at ``target_timestamp_ms``.
+
+        Args:
+            num_players: 1-4. Guests beyond the member are added as TBD.
+            target_timestamp_ms: Epoch ms to send the Reserve POST at. None
+                fires immediately (later bookings in a batch, window already
+                open).
+
+        Returns:
+            The outcome; never raises for an ordinary booking failure.
+        """
+        if self._reserve_config is None or self._reserve_body is None:
+            raise DirectHttpError("prepare() must be called before book()")
+        if not 1 <= num_players <= _MAX_PLAYERS:
+            raise DirectHttpError(f"num_players must be 1-{_MAX_PLAYERS}, got {num_players}")
+
+        result = DirectBookingResult()
+        try:
+            return self._run_chain(num_players, target_timestamp_ms, result)
+        except DirectHttpError as exc:
+            result.error = str(exc)
+            logger.warning("DIRECT_HTTP: Chain failed in phase %s: %s", result.phase, exc)
+            return result
+        except Exception as exc:  # noqa: BLE001 - this path must never abort a booking run
+            # An unexpected error here is a bug in this module, not a booking
+            # outcome. Report it as a failed attempt so the caller can fall
+            # back rather than losing the run entirely.
+            result.error = f"Unexpected {type(exc).__name__} in phase {result.phase}: {exc}"
+            logger.exception("DIRECT_HTTP: Unexpected error in phase %s", result.phase)
+            return result
+
+    def _run_chain(
+        self,
+        num_players: int,
+        target_timestamp_ms: int | None,
+        result: DirectBookingResult,
+    ) -> DirectBookingResult:
+        assert self._reserve_config is not None and self._reserve_body is not None
+
+        if target_timestamp_ms is not None:
+            result.phase = "precision_wait"
+            result.timing["msUntilTarget"] = target_timestamp_ms - int(time_module.time() * 1000)
+            result.timing["clickDriftMs"] = sleep_until(target_timestamp_ms)
+
+        start = time_module.perf_counter()
+
+        def elapsed_ms() -> int:
+            return int((time_module.perf_counter() - start) * 1000)
+
+        result.phase = "reserve_click"
+        response = self.session.post(self._reserve_config, body=self._reserve_body)
+        result.timing["reserveMs"] = elapsed_ms()
+
+        blocked_reason = _find_blocked_message(response)
+        if blocked_reason is not None:
+            result.blocked = True
+            result.error = blocked_reason
+            result.timing["blockedDetectedMs"] = elapsed_ms()
+            return result
+
+        result.phase = "player_count"
+        response = self._select_player_count(response, num_players)
+        result.timing["playerCountMs"] = elapsed_ms()
+
+        blocked_reason = _find_blocked_message(response)
+        if blocked_reason is not None:
+            result.blocked = True
+            result.error = blocked_reason
+            return result
+
+        if num_players > 1:
+            result.phase = "tbd_guests"
+            response = self._add_tbd_guests(response, num_players)
+            result.timing["tbdGuestsMs"] = elapsed_ms()
+
+        result.phase = "book_now"
+        response = self._click_book_now(response)
+        result.timing["bookNowMs"] = elapsed_ms()
+
+        result.phase = "complete"
+        result.success = True
+        result.timing["totalMs"] = elapsed_ms()
+        return result
+
+    # -- individual steps -------------------------------------------------
+
+    def _select_player_count(self, response: PartialResponse, num_players: int) -> PartialResponse:
+        """Set the player-count radio and replay its change behavior.
+
+        The group is identified the same way the JS chain does it: a
+        ``.ui-selectonebutton`` carrying a radio for the requested count but no
+        ``value="0"`` option, which is what distinguishes it from the
+        ALL/MORNING/AFTERNOON time filter (issue #105).
+        """
+        markup = response.markup
+        document = parse_html(markup)
+
+        radio = _find_player_count_radio(document, num_players)
+        if radio is None:
+            raise DirectHttpError(
+                f"Player count selector for {num_players} players not found in response"
+            )
+        if DOM.PLAYER_COUNT.disabled_class in _parent_classes(radio):
+            raise DirectHttpError(f"Player count {num_players} is disabled for this slot")
+
+        name = radio.attrs.get("name")
+        if not name:
+            raise DirectHttpError("Player count radio has no name to submit")
+
+        # Selecting a radio *is* setting the form field; the change behavior
+        # then tells the server to re-render the player rows.
+        self.session.form_state.set_field(name, radio.attrs.get("value", str(num_players)))
+
+        config = find_ab_for_element(radio, markup) or _group_ab_config(radio, markup)
+        if config is None:
+            raise DirectHttpError("Player count control has no PrimeFaces.ab handler to replay")
+
+        logger.info("DIRECT_HTTP: Selecting %d players via %s", num_players, config.source)
+        return self.session.post(config)
+
+    def _add_tbd_guests(self, response: PartialResponse, num_players: int) -> PartialResponse:
+        """Click the TBD link on each guest row (row 0 is the member)."""
+        for guest_index in range(1, num_players):
+            document = parse_html(response.markup)
+            rows = _find_player_rows(document)
+            if len(rows) <= guest_index:
+                raise DirectHttpError(
+                    f"Only {len(rows)} player row(s) rendered; need {num_players}"
+                )
+
+            tbd = _find_tbd_link(rows[guest_index])
+            if tbd is None:
+                raise DirectHttpError(f"TBD button not found on guest row {guest_index}")
+
+            config = find_ab_for_element(tbd, response.markup)
+            if config is None:
+                raise DirectHttpError(
+                    f"TBD button on guest row {guest_index} has no PrimeFaces.ab handler"
+                )
+
+            logger.info("DIRECT_HTTP: Adding TBD guest %d via %s", guest_index, config.source)
+            response = self.session.post(config)
+        return response
+
+    def _click_book_now(self, response: PartialResponse) -> PartialResponse:
+        """Submit the booking."""
+        markup = response.markup
+        document = parse_html(markup)
+
+        book_now = _find_book_now(document)
+        if book_now is None:
+            raise DirectHttpError("Book Now button not found in response")
+
+        config = find_ab_for_element(book_now, markup)
+        if config is None:
+            raise DirectHttpError("Book Now button has no PrimeFaces.ab handler to replay")
+
+        logger.info("DIRECT_HTTP: Clicking Book Now via %s", config.source)
+        return self.session.post(config)
+
+
+# ---------------------------------------------------------------------------
+# Element lookups - the HTTP-side counterparts of the chain's DOM queries
+# ---------------------------------------------------------------------------
+
+
+def _parent_classes(node: Node) -> frozenset[str]:
+    return node.parent.classes if node.parent is not None else frozenset()
+
+
+def _find_player_count_radio(document: Node, num_players: int) -> Node | None:
+    """Find the player-count radio, skipping the time-filter button group."""
+    for group in document.find_with_class("ui-selectonebutton"):
+        radios = [n for n in group.find_all("input") if n.attrs.get("type") == "radio"]
+        if any(r.attrs.get("value") == "0" for r in radios):
+            continue  # time period filter (ALL/MORNING/AFTERNOON/AVAILABLE)
+        for radio in radios:
+            if radio.attrs.get("value") == str(num_players):
+                return radio
+    return None
+
+
+def _group_ab_config(radio: Node, markup: str) -> AbConfig | None:
+    """Fall back to the enclosing widget's handler for a radio with none.
+
+    PrimeFaces binds a ``selectOneButton``'s ``change`` behavior to the widget
+    container, not to the individual radio inputs.
+    """
+    node: Node | None = radio.parent
+    while node is not None:
+        if node.id:
+            config = find_ab_for_element(node, markup)
+            if config is not None:
+                return config
+        node = node.parent
+    return None
+
+
+def _find_player_rows(document: Node) -> list[Node]:
+    """Find the rendered player rows, mirroring the chain's row selectors."""
+    rows = [
+        n
+        for n in document.find_all("tr")
+        if "data-ri" in n.attrs and _has_ancestor_id_containing(n, "playersTable")
+    ]
+    if rows:
+        return rows
+    return [n for n in document.find_all("tr") if _has_ancestor_id_containing(n, "player")]
+
+
+def _has_ancestor_id_containing(node: Node, fragment: str) -> bool:
+    current: Node | None = node.parent
+    while current is not None:
+        if fragment.lower() in current.id.lower():
+            return True
+        current = current.parent
+    return False
+
+
+def _find_tbd_link(row: Node) -> Node | None:
+    """Find a row's TBD link by id, then by link text."""
+    for node in row.descendants():
+        if node.tag in ("a", "span", "button") and "tbd" in node.id.lower():
+            return node
+    for node in row.find_all("a"):
+        if "TBD" in node.text_content().upper():
+            return node
+    return None
+
+
+def _find_book_now(document: Node) -> Node | None:
+    """Find the Book Now action by id, then by exact link text.
+
+    Exact text only: substring matching on 'Book' would hit navigation links
+    like 'Book a Tee Time' - the same trap the JS chain guards against.
+    """
+    for node in document.find_all("a"):
+        if "bookteetimeaction" in node.id.lower():
+            return node
+    for node in document.find_all("a"):
+        if node.text_content().strip().lower() in ("book now", "book"):
+            return node
+    return None
+
+
+def _find_blocked_message(response: PartialResponse) -> str | None:
+    """Detect the 'slot blocked by another user' validation popup.
+
+    Returns the matched reason, or None when the response carries no blocked
+    indication. Uses the same patterns as the Selenium path so both report the
+    condition identically.
+    """
+    text = response.markup.lower()
+    for pattern in DOM.SLOT_BLOCKED.blocked_text_patterns:
+        if pattern.lower() in text:
+            return f"Slot blocked by another user ({pattern})"
+    return None

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -44,20 +44,43 @@ logger = logging.getLogger(__name__)
 # chain there is no fixed inter-click delay to pay here.
 _MAX_PLAYERS = 4
 
+# Chain phases. These are a cross-module contract: the provider decides whether
+# a Selenium retry is safe by looking at which phase the chain stopped in, so
+# the names live here and are imported there rather than duplicated.
+#
+# The split around the Reserve POST is the point of the whole set. Once the
+# request is on the wire we cannot know whether the server acted on it, so a
+# browser retry from that point risks racing our own reservation.
+PHASE_INIT = "init"
+PHASE_PRECISION_WAIT = "precision_wait"
+PHASE_RESERVE_STAGED = "reserve_staged"  # request built, nothing sent yet
+PHASE_RESERVE_SENT = "reserve_sent"  # written to the socket, outcome unknown
+PHASE_PLAYER_COUNT = "player_count"
+PHASE_TBD_GUESTS = "tbd_guests"
+PHASE_BOOK_NOW = "book_now"
+PHASE_COMPLETE = "complete"
+
+# The only phases in which nothing can have reached the server, and therefore
+# the only ones after which a browser retry is safe.
+PRE_SUBMIT_PHASES = frozenset({PHASE_INIT, PHASE_PRECISION_WAIT, PHASE_RESERVE_STAGED})
+
 
 @dataclass
 class DirectBookingResult:
     """Outcome of a direct-HTTP booking attempt.
 
     Shaped to match the JS chain's result dict so the provider can log and
-    branch on both identically.
+    branch on both identically, plus ``final_markup`` - the last response body,
+    which is the only record of the booking outcome, since the browser DOM is
+    untouched by this path.
     """
 
     success: bool = False
     blocked: bool = False
-    phase: str = "init"
+    phase: str = PHASE_INIT
     error: str | None = None
     timing: dict[str, Any] = field(default_factory=dict)
+    final_markup: str = ""
 
     def as_chain_result(self) -> dict[str, Any]:
         """Render as the dict shape ``_run_booking_chain_js`` returns."""
@@ -67,6 +90,7 @@ class DirectBookingResult:
             "phase": self.phase,
             "error": self.error,
             "timing": self.timing,
+            "finalMarkup": self.final_markup,
         }
 
 
@@ -74,6 +98,7 @@ class DirectHttpBooker:
     """Runs one booking over HTTP against an adopted browser session."""
 
     def __init__(self, session: PrimeFacesSession) -> None:
+        """Bind the booker to an adopted, authenticated session."""
         self.session = session
         self._reserve_config: AbConfig | None = None
         self._reserve_body: bytes | None = None
@@ -158,20 +183,28 @@ class DirectHttpBooker:
         target_timestamp_ms: int | None,
         result: DirectBookingResult,
     ) -> DirectBookingResult:
+        """Drive the request sequence, advancing ``result.phase`` as it goes."""
         assert self._reserve_config is not None and self._reserve_body is not None
 
+        result.phase = PHASE_RESERVE_STAGED
+
         if target_timestamp_ms is not None:
-            result.phase = "precision_wait"
+            result.phase = PHASE_PRECISION_WAIT
             result.timing["msUntilTarget"] = target_timestamp_ms - int(time_module.time() * 1000)
             result.timing["clickDriftMs"] = sleep_until(target_timestamp_ms)
 
         start = time_module.perf_counter()
 
         def elapsed_ms() -> int:
+            """Milliseconds since the Reserve request went out."""
             return int((time_module.perf_counter() - start) * 1000)
 
-        result.phase = "reserve_click"
+        # Advance before the call, not after. Once the request is handed to the
+        # socket we cannot tell "never sent" from "sent, response lost", and a
+        # browser retry in the second case races our own reservation.
+        result.phase = PHASE_RESERVE_SENT
         response = self.session.post(self._reserve_config, body=self._reserve_body)
+        result.final_markup = response.markup
         result.timing["reserveMs"] = elapsed_ms()
 
         blocked_reason = _find_blocked_message(response)
@@ -181,8 +214,9 @@ class DirectHttpBooker:
             result.timing["blockedDetectedMs"] = elapsed_ms()
             return result
 
-        result.phase = "player_count"
+        result.phase = PHASE_PLAYER_COUNT
         response = self._select_player_count(response, num_players)
+        result.final_markup = response.markup
         result.timing["playerCountMs"] = elapsed_ms()
 
         blocked_reason = _find_blocked_message(response)
@@ -192,15 +226,17 @@ class DirectHttpBooker:
             return result
 
         if num_players > 1:
-            result.phase = "tbd_guests"
+            result.phase = PHASE_TBD_GUESTS
             response = self._add_tbd_guests(response, num_players)
+            result.final_markup = response.markup
             result.timing["tbdGuestsMs"] = elapsed_ms()
 
-        result.phase = "book_now"
+        result.phase = PHASE_BOOK_NOW
         response = self._click_book_now(response)
+        result.final_markup = response.markup
         result.timing["bookNowMs"] = elapsed_ms()
 
-        result.phase = "complete"
+        result.phase = PHASE_COMPLETE
         result.success = True
         result.timing["totalMs"] = elapsed_ms()
         return result
@@ -288,6 +324,7 @@ class DirectHttpBooker:
 
 
 def _parent_classes(node: Node) -> frozenset[str]:
+    """CSS classes of the node's parent, or an empty set at the root."""
     return node.parent.classes if node.parent is not None else frozenset()
 
 
@@ -328,10 +365,18 @@ def _find_player_rows(document: Node) -> list[Node]:
     ]
     if rows:
         return rows
-    return [n for n in document.find_all("tr") if _has_ancestor_id_containing(n, "player")]
+    # Require data cells: a <thead> row counted as row 0 would be mistaken for
+    # the member row and shift every guest index by one, clicking TBD on the
+    # wrong rows with no error to show for it.
+    return [
+        n
+        for n in document.find_all("tr")
+        if _has_ancestor_id_containing(n, "player") and n.find_all("td")
+    ]
 
 
 def _has_ancestor_id_containing(node: Node, fragment: str) -> bool:
+    """Report whether any ancestor's id contains the fragment, case-insensitively."""
     current: Node | None = node.parent
     while current is not None:
         if fragment.lower() in current.id.lower():
@@ -369,12 +414,23 @@ def _find_book_now(document: Node) -> Node | None:
 def _find_blocked_message(response: PartialResponse) -> str | None:
     """Detect the 'slot blocked by another user' validation popup.
 
+    Scoped to the popup element, and only when it is not explicitly hidden -
+    the same test the Selenium path applies (``aria-hidden`` flips to false when
+    the popup is shown). Matching the whole response instead would let a hidden
+    popup template, or any markup quoting one of these phrases, abort the chain
+    on a slot we actually hold.
+
     Returns the matched reason, or None when the response carries no blocked
-    indication. Uses the same patterns as the Selenium path so both report the
-    condition identically.
+    indication.
     """
-    text = response.markup.lower()
-    for pattern in DOM.SLOT_BLOCKED.blocked_text_patterns:
-        if pattern.lower() in text:
-            return f"Slot blocked by another user ({pattern})"
+    document = parse_html(response.markup)
+    for node in document.descendants():
+        if "teesheetvalidationerrorpopup" not in node.id.lower():
+            continue
+        if node.attrs.get("aria-hidden", "").lower() == "true":
+            continue
+        text = node.text_content().lower()
+        for pattern in DOM.SLOT_BLOCKED.blocked_text_patterns:
+            if pattern.lower() in text:
+                return f"Slot blocked by another user ({pattern})"
     return None

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -157,12 +157,19 @@ class DirectHttpBooker:
         Returns:
             The outcome; never raises for an ordinary booking failure.
         """
-        if self._reserve_config is None or self._reserve_body is None:
-            raise DirectHttpError("prepare() must be called before book()")
-        if not 1 <= num_players <= _MAX_PLAYERS:
-            raise DirectHttpError(f"num_players must be 1-{_MAX_PLAYERS}, got {num_players}")
-
         result = DirectBookingResult()
+
+        # Misuse, not a booking outcome - but reported as a PHASE_INIT result
+        # rather than raised, because nothing has been sent and the caller's
+        # correct response is to fall back, not to lose the booking.
+        if self._reserve_config is None or self._reserve_body is None:
+            result.error = "prepare() must be called before book()"
+            logger.error("DIRECT_HTTP: %s", result.error)
+            return result
+        if not 1 <= num_players <= _MAX_PLAYERS:
+            result.error = f"num_players must be 1-{_MAX_PLAYERS}, got {num_players}"
+            logger.error("DIRECT_HTTP: %s", result.error)
+            return result
         try:
             return self._run_chain(num_players, target_timestamp_ms, result)
         except DirectHttpError as exc:

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -37,8 +37,8 @@ from app.providers.base import (
 )
 from app.providers.wait_helper import WaitStrategy
 from app.providers.walden_dom_schema import DOM
-from app.providers.walden_http import DirectHttpError, PrimeFacesSession
-from app.providers.walden_http_booker import DirectHttpBooker
+from app.providers.walden_http import PrimeFacesSession, visible_text
+from app.providers.walden_http_booker import PRE_SUBMIT_PHASES, DirectHttpBooker
 from app.utils.timezone import CTDateTime
 
 logger = logging.getLogger(__name__)
@@ -2890,6 +2890,33 @@ class WaldenGolfProvider(ReservationProvider):
                     course_name=self.NORTHGATE_COURSE_NAME,
                 )
 
+            # The direct-HTTP chain never touches the browser, so the DOM still
+            # shows the pre-booking tee sheet. Verifying against it would time
+            # out on every wait and then report a completed booking as failed;
+            # the last partial response is the only record of the outcome.
+            direct_markup = chain_result.get("finalMarkup")
+            if direct_markup:
+                page_text = visible_text(direct_markup)
+                confirmation_number = self._extract_confirmation_number_from_text(page_text)
+                if self._verify_booking_success_text(page_text, "direct HTTP response"):
+                    return BookingResult(
+                        success=True,
+                        booked_time=booked_time,
+                        confirmation_number=confirmation_number,
+                        fallback_reason=fallback_reason,
+                        course_name=self.NORTHGATE_COURSE_NAME,
+                    )
+                self._capture_diagnostic_info(driver, "direct_http_verify_failed")
+                return BookingResult(
+                    success=False,
+                    error_message=(
+                        "Direct-HTTP booking chain completed but the response did not "
+                        "confirm the reservation"
+                    ),
+                    booked_time=booked_time,
+                    course_name=self.NORTHGATE_COURSE_NAME,
+                )
+
             # Fast chain succeeded - wait briefly for page to settle after Book Now click
             # The JS chain clicked Book Now but the page may still be processing
             try:
@@ -3650,8 +3677,9 @@ class WaldenGolfProvider(ReservationProvider):
     # Chain phases the direct-HTTP path can fail in without having submitted
     # anything the server acted on. Past these, a Selenium retry would be
     # racing our own half-finished booking against a stale browser DOM, so the
-    # failure is reported instead of retried.
-    _DIRECT_HTTP_FALLBACK_PHASES = frozenset({"init", "precision_wait", "reserve_click"})
+    # failure is reported instead of retried. Imported rather than restated so
+    # the two modules cannot drift apart on which phases are recoverable.
+    _DIRECT_HTTP_FALLBACK_PHASES = PRE_SUBMIT_PHASES
 
     def _try_direct_http_booking(
         self,
@@ -3696,9 +3724,16 @@ class WaldenGolfProvider(ReservationProvider):
             session = PrimeFacesSession.from_selenium(driver)
             booker = DirectHttpBooker(session)
             booker.prepare(reserve_id, driver.page_source)
-        except (DirectHttpError, WebDriverException) as e:
+        except Exception as e:  # noqa: BLE001 - opt-in path must never break booking
+            # Staging parses live markup, so a malformed page can surface as
+            # almost anything. Nothing has reached the server yet, so every
+            # failure here is recoverable by the JS chain - and none of it may
+            # escape into _book_tee_time_sync, which handles only WebDriver
+            # errors and would raise instead of returning a BookingResult.
             logger.warning(
-                "DIRECT_HTTP: Could not stage direct booking (%s); using the JS chain", e
+                "DIRECT_HTTP: Could not stage direct booking (%s: %s); using the JS chain",
+                type(e).__name__,
+                e,
             )
             if session is not None:
                 session.close()
@@ -3706,6 +3741,18 @@ class WaldenGolfProvider(ReservationProvider):
 
         try:
             result = booker.book(num_players, target_timestamp_ms=execute_at_timestamp_ms)
+        except Exception as e:  # noqa: BLE001 - see above
+            # book() turns its own failures into results, so anything raised
+            # here is a bug. Reserve may already have been sent, so report it
+            # rather than handing the slot to a browser retry.
+            logger.exception("DIRECT_HTTP: Booking attempt raised unexpectedly")
+            return {
+                "success": False,
+                "blocked": False,
+                "phase": "unknown",
+                "error": f"Direct-HTTP booking raised {type(e).__name__}: {e}",
+                "timing": {},
+            }
         finally:
             session.close()
 
@@ -5192,7 +5239,18 @@ class WaldenGolfProvider(ReservationProvider):
     def _extract_confirmation_number(self, driver: webdriver.Chrome) -> str | None:
         """Try to extract a confirmation number from the page after booking."""
         try:
-            page_text = self._get_visible_page_text(driver)
+            return self._extract_confirmation_number_from_text(self._get_visible_page_text(driver))
+        except Exception as e:
+            logger.debug(f"Could not extract confirmation number: {e}")
+            return None
+
+    def _extract_confirmation_number_from_text(self, page_text: str) -> str | None:
+        """Extract a confirmation number from post-booking page text.
+
+        Split from the driver-reading wrapper so the direct-HTTP path can run the
+        same extraction against its final partial response.
+        """
+        try:
             page_text_lower = page_text.lower()
 
             if (
@@ -5225,10 +5283,31 @@ class WaldenGolfProvider(ReservationProvider):
         without positive confirmation.
         """
         try:
-            logger.info(
-                f"BOOKING_DEBUG: Verifying booking success. Current URL: {driver.current_url}"
+            return self._verify_booking_success_text(
+                self._get_visible_page_text(driver), driver.current_url
             )
-            page_text = self._get_visible_page_text(driver).lower()
+        except Exception as e:
+            logger.error(f"BOOKING_DEBUG: Error verifying booking: {e}")
+            return False
+
+    def _verify_booking_success_text(self, text: str, context: str) -> bool:
+        """
+        Verify a booking outcome from page text.
+
+        Split from the driver-reading wrapper so the direct-HTTP path can apply
+        the same phrase checks to its final partial response, whose markup is the
+        only record of that booking's outcome.
+
+        Args:
+            text: Visible text from the page or partial response
+            context: Where the text came from, for logging
+
+        Returns:
+            True only on positive confirmation; ambiguity is treated as failure.
+        """
+        try:
+            logger.info(f"BOOKING_DEBUG: Verifying booking success. Source: {context}")
+            page_text = text.lower()
 
             success_indicators = [
                 "successfully",
@@ -5271,7 +5350,7 @@ class WaldenGolfProvider(ReservationProvider):
 
             logger.warning(
                 f"BOOKING_DEBUG: No clear success or failure indicators found - treating as failure. "
-                f"URL: {driver.current_url}"
+                f"Source: {context}"
             )
             return False
 

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -37,6 +37,8 @@ from app.providers.base import (
 )
 from app.providers.wait_helper import WaitStrategy
 from app.providers.walden_dom_schema import DOM
+from app.providers.walden_http import DirectHttpError, PrimeFacesSession
+from app.providers.walden_http_booker import DirectHttpBooker
 from app.utils.timezone import CTDateTime
 
 logger = logging.getLogger(__name__)
@@ -2840,19 +2842,32 @@ class WaldenGolfProvider(ReservationProvider):
             # When execute_at_timestamp_ms is provided, use the timed chain which
             # busy-waits in JS until the exact target timestamp before clicking.
             # This eliminates Python→Selenium→JS handoff latency at the critical moment.
-            if execute_at_timestamp_ms is not None:
-                chain_result = self._stage_timed_booking_chain_js(
-                    driver,
-                    slot_info["index"],
-                    num_players,
-                    execute_at_timestamp_ms,
-                )
-            else:
-                chain_result = self._execute_fast_booking_chain_js(
-                    driver,
-                    slot_info["index"],
-                    num_players,
-                )
+            # The direct-HTTP path replays the same PrimeFaces requests without
+            # the browser on the critical path. It returns None when it is
+            # disabled or could not be staged, and a result whose phase says
+            # the booking was never submitted when it failed early - both mean
+            # the JS chain below is still free to run.
+            chain_result = self._try_direct_http_booking(
+                driver,
+                slot_info,
+                num_players,
+                execute_at_timestamp_ms,
+            )
+
+            if chain_result is None:
+                if execute_at_timestamp_ms is not None:
+                    chain_result = self._stage_timed_booking_chain_js(
+                        driver,
+                        slot_info["index"],
+                        num_players,
+                        execute_at_timestamp_ms,
+                    )
+                else:
+                    chain_result = self._execute_fast_booking_chain_js(
+                        driver,
+                        slot_info["index"],
+                        num_players,
+                    )
 
             if chain_result.get("blocked"):
                 # Slot was grabbed by another user at the same moment
@@ -3363,6 +3378,12 @@ class WaldenGolfProvider(ReservationProvider):
 
             if (!isAvailable) continue;
 
+            // Component id of the slot's Reserve link. The direct-HTTP path
+            // replays that component's PrimeFaces request, so it needs the id
+            // rather than the NodeList index the JS chain clicks by.
+            var reserveEl = item.querySelector("a[id*='reserve_button']") ||
+                item.querySelector('a.slot-link');
+
             var slotInfo = {
                 timeStr: h + ':' + (m < 10 ? '0' : '') + m,
                 hours: h,
@@ -3370,7 +3391,8 @@ class WaldenGolfProvider(ReservationProvider):
                 index: i,
                 diff: diff,
                 available: availableCount,
-                isExact: (diff === 0)
+                isExact: (diff === 0),
+                reserveId: reserveEl ? reserveEl.id : null
             };
 
             if (diff === 0) {
@@ -3624,6 +3646,97 @@ class WaldenGolfProvider(ReservationProvider):
             "phase": "unknown",
             "timing": {},
         }
+
+    # Chain phases the direct-HTTP path can fail in without having submitted
+    # anything the server acted on. Past these, a Selenium retry would be
+    # racing our own half-finished booking against a stale browser DOM, so the
+    # failure is reported instead of retried.
+    _DIRECT_HTTP_FALLBACK_PHASES = frozenset({"init", "precision_wait", "reserve_click"})
+
+    def _try_direct_http_booking(
+        self,
+        driver: webdriver.Chrome,
+        slot_info: dict[str, Any],
+        num_players: int,
+        execute_at_timestamp_ms: int | None,
+    ) -> dict[str, Any] | None:
+        """
+        Attempt the booking chain over direct HTTP instead of browser clicks.
+
+        Adopts the browser's cookies and form state, stages the Reserve request
+        (serialized body plus a warm TLS connection) and fires it at the target
+        timestamp. See app/providers/walden_http.py for why this is faster than
+        driving the same requests through Chrome.
+
+        Args:
+            driver: The WebDriver instance, already logged in and on the tee sheet
+            slot_info: Slot dict from _find_target_slot_js; needs 'reserveId'
+            num_players: Number of players (1-4)
+            execute_at_timestamp_ms: Epoch ms to fire Reserve at, or None for now
+
+        Returns:
+            A chain-result dict (same shape as _run_booking_chain_js) when the
+            direct path produced an outcome worth honoring, or None when the
+            caller should fall back to the JavaScript chain.
+        """
+        if not settings.walden_direct_http_booking:
+            return None
+
+        reserve_id = slot_info.get("reserveId")
+        if not reserve_id:
+            logger.info(
+                "DIRECT_HTTP: Slot at index %s exposes no Reserve component id "
+                "(partially-booked slot); using the JS chain",
+                slot_info.get("index"),
+            )
+            return None
+
+        session: PrimeFacesSession | None = None
+        try:
+            session = PrimeFacesSession.from_selenium(driver)
+            booker = DirectHttpBooker(session)
+            booker.prepare(reserve_id, driver.page_source)
+        except (DirectHttpError, WebDriverException) as e:
+            logger.warning(
+                "DIRECT_HTTP: Could not stage direct booking (%s); using the JS chain", e
+            )
+            if session is not None:
+                session.close()
+            return None
+
+        try:
+            result = booker.book(num_players, target_timestamp_ms=execute_at_timestamp_ms)
+        finally:
+            session.close()
+
+        logger.info(
+            "DIRECT_HTTP: Chain finished - phase=%s, success=%s, blocked=%s, "
+            "clickDrift=%sms, totalMs=%s, error=%s",
+            result.phase,
+            result.success,
+            result.blocked,
+            result.timing.get("clickDriftMs", "N/A"),
+            result.timing.get("totalMs", "N/A"),
+            result.error,
+        )
+
+        if result.success or result.blocked:
+            return result.as_chain_result()
+
+        if result.phase in self._DIRECT_HTTP_FALLBACK_PHASES:
+            logger.warning(
+                "DIRECT_HTTP: Failed in phase %s before any booking was submitted; "
+                "falling back to the JS chain",
+                result.phase,
+            )
+            return None
+
+        logger.error(
+            "DIRECT_HTTP: Failed in phase %s after Reserve was accepted; not retrying "
+            "in the browser (the slot may be held server-side)",
+            result.phase,
+        )
+        return result.as_chain_result()
 
     def _check_slot_blocked_popup(self, driver: webdriver.Chrome) -> bool:
         """

--- a/scripts/probe_direct_http.py
+++ b/scripts/probe_direct_http.py
@@ -31,6 +31,7 @@ import sys
 import time
 from datetime import date, timedelta
 from pathlib import Path
+from typing import Any
 
 from dotenv import load_dotenv
 from selenium.webdriver.common.by import By
@@ -43,6 +44,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from app.config import settings  # noqa: E402
 from app.providers.walden_http import (  # noqa: E402
+    AbConfig,
     DirectHttpError,
     PrimeFacesSession,
     find_ab_for_element,
@@ -58,7 +60,7 @@ logger = logging.getLogger("probe")
 SAFE_COMPONENT_SUFFIX = "showLegends"
 
 
-def find_safe_component(page_html: str) -> tuple[str, object]:
+def find_safe_component(page_html: str) -> tuple[str, AbConfig]:
     """Locate the read-only component this probe will exercise."""
     document = parse_html(page_html)
     for node in document.descendants():
@@ -71,13 +73,13 @@ def find_safe_component(page_html: str) -> tuple[str, object]:
     )
 
 
-def time_direct_http(session: PrimeFacesSession, config: object, samples: int) -> list[float]:
+def time_direct_http(session: PrimeFacesSession, config: AbConfig, samples: int) -> list[float]:
     """Time the component's request over direct HTTP."""
     timings = []
-    body = session.build_body(config)  # type: ignore[arg-type]
+    body = session.build_body(config)
     for i in range(samples):
         started = time.perf_counter()
-        response = session.post(config, body=body)  # type: ignore[arg-type]
+        response = session.post(config, body=body)
         elapsed_ms = (time.perf_counter() - started) * 1000
         timings.append(elapsed_ms)
         logger.info(
@@ -88,22 +90,22 @@ def time_direct_http(session: PrimeFacesSession, config: object, samples: int) -
             "refreshed" if response.view_state else "unchanged",
         )
         # The ViewState may have rolled; re-serialize for the next sample.
-        body = session.build_body(config)  # type: ignore[arg-type]
+        body = session.build_body(config)
     return timings
 
 
 _BROWSER_TIMING_JS = """
 var cfg = arguments[0];
 var done = arguments[arguments.length - 1];
-var t0 = Date.now();
+var t0 = performance.now();
 PrimeFaces.ab({
     s: cfg.source, f: cfg.form, p: cfg.process, u: cfg.update,
-    onco: function() { done(Date.now() - t0); }
+    onco: function() { done(performance.now() - t0); }
 });
 """
 
 
-def time_browser(driver: object, config: object, samples: int) -> list[float]:
+def time_browser(driver: Any, config: AbConfig, samples: int) -> list[float]:
     """Time the identical request as the browser performs it.
 
     Measured from issuing the PrimeFaces call to its ``oncomplete`` - so it
@@ -113,13 +115,13 @@ def time_browser(driver: object, config: object, samples: int) -> list[float]:
     timings = []
     for i in range(samples):
         elapsed_ms = float(
-            driver.execute_async_script(  # type: ignore[attr-defined]
+            driver.execute_async_script(
                 _BROWSER_TIMING_JS,
                 {
-                    "source": config.source,  # type: ignore[attr-defined]
-                    "form": config.form,  # type: ignore[attr-defined]
-                    "process": config.process,  # type: ignore[attr-defined]
-                    "update": config.update,  # type: ignore[attr-defined]
+                    "source": config.source,
+                    "form": config.form,
+                    "process": config.process,
+                    "update": config.update,
                 },
             )
         )
@@ -129,6 +131,7 @@ def time_browser(driver: object, config: object, samples: int) -> list[float]:
 
 
 def summarize(label: str, timings: list[float]) -> dict[str, float]:
+    """Log and return min/median/mean/max for one transport's samples."""
     stats = {
         "min": min(timings),
         "median": statistics.median(timings),
@@ -147,8 +150,11 @@ def summarize(label: str, timings: list[float]) -> dict[str, float]:
 
 
 def main() -> int:
+    """Run the probe end to end; returns a process exit code."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--samples", type=int, default=5, help="round trips per transport")
+    parser.add_argument(
+        "--samples", type=int, default=5, help="round trips per transport (minimum 1)"
+    )
     parser.add_argument(
         "--days-ahead",
         type=int,
@@ -157,6 +163,9 @@ def main() -> int:
     )
     parser.add_argument("--json", type=Path, help="write the timing summary here")
     args = parser.parse_args()
+
+    if args.samples < 1:
+        parser.error("--samples must be at least 1")
 
     if not settings.walden_member_number or not settings.walden_password:
         logger.error("WALDEN_MEMBER_NUMBER / WALDEN_PASSWORD are not set")

--- a/scripts/probe_direct_http.py
+++ b/scripts/probe_direct_http.py
@@ -1,0 +1,226 @@
+"""
+Prove out - and time - the direct-HTTP path against the live Walden site.
+
+This is the safe way to answer "is direct HTTP actually faster here?" without
+booking anything. It logs in with Selenium exactly as the booking job does,
+hands the session to :class:`PrimeFacesSession`, then exercises a **read-only**
+PrimeFaces component (the tee sheet's "Legends" dialog) over both transports and
+compares round-trip times.
+
+What it verifies
+    * the adopted cookie jar authenticates a direct POST
+    * the ViewState, encodedURL and namespaced parameters are accepted
+    * the server answers with a real <partial-response> and a fresh ViewState
+    * how long the same interaction takes through Chrome vs. through httpx
+
+What it does NOT do
+    It never clicks Reserve and never submits a booking. The only component it
+    touches opens an informational dialog.
+
+Usage (needs WALDEN_MEMBER_NUMBER / WALDEN_PASSWORD in env or .env):
+
+    poetry run python scripts/probe_direct_http.py
+    poetry run python scripts/probe_direct_http.py --samples 10
+"""
+
+import argparse
+import json
+import logging
+import statistics
+import sys
+import time
+from datetime import date, timedelta
+from pathlib import Path
+
+from dotenv import load_dotenv
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support.ui import WebDriverWait
+
+load_dotenv()
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.config import settings  # noqa: E402
+from app.providers.walden_http import (  # noqa: E402
+    DirectHttpError,
+    PrimeFacesSession,
+    find_ab_for_element,
+    parse_html,
+)
+from app.providers.walden_provider import WaldenGolfProvider  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("probe")
+
+# A component with no side effects: it opens the tee sheet's legend dialog.
+# Nothing here reserves, cancels or modifies anything.
+SAFE_COMPONENT_SUFFIX = "showLegends"
+
+
+def find_safe_component(page_html: str) -> tuple[str, object]:
+    """Locate the read-only component this probe will exercise."""
+    document = parse_html(page_html)
+    for node in document.descendants():
+        if node.id.endswith(SAFE_COMPONENT_SUFFIX):
+            config = find_ab_for_element(node, page_html)
+            if config is not None:
+                return node.id, config
+    raise DirectHttpError(
+        f"No safe probe component (*:{SAFE_COMPONENT_SUFFIX}) found on the tee sheet"
+    )
+
+
+def time_direct_http(session: PrimeFacesSession, config: object, samples: int) -> list[float]:
+    """Time the component's request over direct HTTP."""
+    timings = []
+    body = session.build_body(config)  # type: ignore[arg-type]
+    for i in range(samples):
+        started = time.perf_counter()
+        response = session.post(config, body=body)  # type: ignore[arg-type]
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        timings.append(elapsed_ms)
+        logger.info(
+            "  direct  #%d: %6.1f ms  (%d update(s), viewState=%s)",
+            i + 1,
+            elapsed_ms,
+            len(response.updates),
+            "refreshed" if response.view_state else "unchanged",
+        )
+        # The ViewState may have rolled; re-serialize for the next sample.
+        body = session.build_body(config)  # type: ignore[arg-type]
+    return timings
+
+
+_BROWSER_TIMING_JS = """
+var cfg = arguments[0];
+var done = arguments[arguments.length - 1];
+var t0 = Date.now();
+PrimeFaces.ab({
+    s: cfg.source, f: cfg.form, p: cfg.process, u: cfg.update,
+    onco: function() { done(Date.now() - t0); }
+});
+"""
+
+
+def time_browser(driver: object, config: object, samples: int) -> list[float]:
+    """Time the identical request as the browser performs it.
+
+    Measured from issuing the PrimeFaces call to its ``oncomplete`` - so it
+    covers the request, the response, and the DOM update the browser has to
+    apply before the next step could run.
+    """
+    timings = []
+    for i in range(samples):
+        elapsed_ms = float(
+            driver.execute_async_script(  # type: ignore[attr-defined]
+                _BROWSER_TIMING_JS,
+                {
+                    "source": config.source,  # type: ignore[attr-defined]
+                    "form": config.form,  # type: ignore[attr-defined]
+                    "process": config.process,  # type: ignore[attr-defined]
+                    "update": config.update,  # type: ignore[attr-defined]
+                },
+            )
+        )
+        timings.append(elapsed_ms)
+        logger.info("  browser #%d: %6.1f ms", i + 1, elapsed_ms)
+    return timings
+
+
+def summarize(label: str, timings: list[float]) -> dict[str, float]:
+    stats = {
+        "min": min(timings),
+        "median": statistics.median(timings),
+        "mean": statistics.fmean(timings),
+        "max": max(timings),
+    }
+    logger.info(
+        "%-8s min=%.1fms median=%.1fms mean=%.1fms max=%.1fms",
+        label,
+        stats["min"],
+        stats["median"],
+        stats["mean"],
+        stats["max"],
+    )
+    return stats
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--samples", type=int, default=5, help="round trips per transport")
+    parser.add_argument(
+        "--days-ahead",
+        type=int,
+        default=settings.days_in_advance,
+        help="tee sheet date to load (default: the booking horizon)",
+    )
+    parser.add_argument("--json", type=Path, help="write the timing summary here")
+    args = parser.parse_args()
+
+    if not settings.walden_member_number or not settings.walden_password:
+        logger.error("WALDEN_MEMBER_NUMBER / WALDEN_PASSWORD are not set")
+        return 2
+
+    provider = WaldenGolfProvider()
+    driver = provider._create_driver()
+    try:
+        logger.info("Logging in...")
+        if not provider._perform_login(driver):
+            logger.error("Login failed")
+            return 1
+
+        logger.info("Loading the tee sheet...")
+        driver.get(provider.TEE_TIME_URL)
+        WebDriverWait(driver, 20).until(
+            expected_conditions.presence_of_element_located((By.CSS_SELECTOR, "form"))
+        )
+        provider._select_course_sync(driver, provider.NORTHGATE_COURSE_NAME)
+        provider._select_date_sync(driver, date.today() + timedelta(days=args.days_ahead))
+
+        page_html = driver.page_source
+        component_id, config = find_safe_component(page_html)
+        logger.info("Probing read-only component: %s", component_id)
+
+        logger.info("Adopting the browser session over HTTP...")
+        session = PrimeFacesSession.from_selenium(driver)
+        rtt_ms = session.warm_up()
+
+        try:
+            logger.info("Direct HTTP (%d samples):", args.samples)
+            direct = time_direct_http(session, config, args.samples)
+            logger.info("Browser (%d samples):", args.samples)
+            browser = time_browser(driver, config, args.samples)
+        finally:
+            session.close()
+
+        logger.info("--- results ---")
+        summary = {
+            "component": component_id,
+            "warmup_rtt_ms": rtt_ms,
+            "direct_http": summarize("direct", direct),
+            "browser": summarize("browser", browser),
+        }
+        speedup = summary["browser"]["median"] / summary["direct_http"]["median"]
+        summary["median_speedup"] = speedup
+        logger.info("Direct HTTP is %.1fx faster per interaction (median)", speedup)
+        logger.info(
+            "A 4-player booking is 6 interactions: ~%.0fms direct vs ~%.0fms browser",
+            summary["direct_http"]["median"] * 6,
+            summary["browser"]["median"] * 6,
+        )
+
+        if args.json:
+            args.json.write_text(json.dumps(summary, indent=2))
+            logger.info("Wrote %s", args.json)
+        return 0
+
+    except DirectHttpError as exc:
+        logger.error("Direct-HTTP probe failed: %s", exc)
+        return 1
+    finally:
+        driver.quit()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -1,0 +1,619 @@
+"""
+Tests for the direct-HTTP (browser-free) booking path.
+
+The protocol tests run against the real captured tee sheet in
+tests/fixtures/, so the request this builds is the request the site actually
+expects - not one derived from a hand-written mock.
+"""
+
+import urllib.parse
+from pathlib import Path
+
+import httpx
+import pytest
+
+from app.providers.walden_http import (
+    AbConfig,
+    DirectHttpError,
+    FormState,
+    PrimeFacesSession,
+    ViewExpiredError,
+    find_ab_for_element,
+    parse_ab_call,
+    parse_html,
+    parse_partial_response,
+    sleep_until,
+)
+from app.providers.walden_http_booker import DirectHttpBooker
+
+FIXTURES = Path(__file__).parent / "fixtures"
+TEE_SHEET = (FIXTURES / "walden_tee_time_loaded.html").read_text(encoding="utf-8", errors="replace")
+
+FORM_ID = "_teeTimePortlet_WAR_northstarportlet_:teeTimeForm"
+RESERVE_ID = f"{FORM_ID}:teeTimeCourses:0:teeTimeSlots:67:slotTee:0:reserve_button"
+
+
+@pytest.fixture(scope="module")
+def tee_sheet_form() -> FormState:
+    return FormState.from_html(TEE_SHEET)
+
+
+def make_session(
+    form_state: FormState,
+    handler: "object",
+) -> PrimeFacesSession:
+    """Build a session whose transport is a MockTransport handler."""
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler),  # type: ignore[arg-type]
+        headers={"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"},
+    )
+    return PrimeFacesSession(
+        form_state,
+        {},
+        base_url="https://www.waldengolf.com/group/pages/book-a-tee-time",
+        client=client,
+    )
+
+
+def partial_response(body: str, view_state: str = "new-view-state") -> str:
+    return (
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        "<partial-response><changes>"
+        f'<update id="{FORM_ID}"><![CDATA[{body}]]></update>'
+        f'<update id="_teeTimePortlet_WAR_northstarportlet_:javax.faces.ViewState:0">'
+        f"<![CDATA[{view_state}]]></update>"
+        "</changes></partial-response>"
+    )
+
+
+class TestParseAbCall:
+    """The PrimeFaces.ab parser, exercised against the real handlers."""
+
+    def test_parses_reserve_button_handler(self) -> None:
+        config = parse_ab_call('PrimeFaces.ab({s:"btn-id",f:"form-id",u:"form-id"});return false;')
+        assert config == AbConfig(source="btn-id", form="form-id", update="form-id")
+
+    def test_resolves_s_this_to_element_id(self) -> None:
+        config = parse_ab_call(
+            'PrimeFaces.ab({s:this,e:"mousedown",f:"form-id",p:"link-id",u:"area-id"});',
+            element_id="link-id",
+        )
+        assert config is not None
+        assert config.source == "link-id"
+        assert config.event == "mousedown"
+        assert config.process == "link-id"
+
+    def test_s_this_without_element_id_is_unresolvable(self) -> None:
+        assert parse_ab_call('PrimeFaces.ab({s:this,f:"form-id"});') is None
+
+    def test_ignores_snippet_without_source_and_form(self) -> None:
+        assert parse_ab_call('PrimeFaces.ab({u:"only-update"});') is None
+
+    def test_ignores_non_ab_javascript(self) -> None:
+        assert parse_ab_call("showLoader(); return false;") is None
+
+    def test_does_not_mistake_callback_keys_for_config_keys(self) -> None:
+        """onst/onco callbacks contain 'f' and 's' inside identifiers."""
+        config = parse_ab_call(
+            'PrimeFaces.ab({s:"btn",f:"form",u:"form",'
+            "onst:function(cfg){showLoader();},"
+            "onco:function(xhr,status,args){hideLoader();}});"
+        )
+        assert config == AbConfig(source="btn", form="form", update="form")
+
+    def test_parses_every_handler_in_the_real_tee_sheet(self) -> None:
+        """No handler on the captured page defeats the parser."""
+        document = parse_html(TEE_SHEET)
+        handlers = [
+            node
+            for node in document.descendants()
+            if "PrimeFaces.ab(" in node.attrs.get("onclick", "")
+        ]
+        assert len(handlers) > 20, "fixture should contain many ab handlers"
+        for node in handlers:
+            config = parse_ab_call(node.attrs["onclick"], element_id=node.id)
+            assert config is not None, f"failed to parse handler on {node.id}"
+            assert config.form == FORM_ID
+
+
+class TestFormState:
+    """Form serialization against the captured tee sheet."""
+
+    def test_finds_the_tee_time_form(self, tee_sheet_form: FormState) -> None:
+        assert tee_sheet_form.form_id == FORM_ID
+
+    def test_posts_to_the_encoded_url_not_the_form_action(self, tee_sheet_form: FormState) -> None:
+        """Liferay's bridge routes AJAX to encodedURL (lifecycle=2)."""
+        assert "p_p_lifecycle=2" in tee_sheet_form.action_url
+        assert "_jsfBridgeAjax=true" in tee_sheet_form.action_url
+
+    def test_extracts_view_state(self, tee_sheet_form: FormState) -> None:
+        assert tee_sheet_form.view_state == "3597409561974113966:-1460199378475720306"
+
+    def test_serializes_the_state_the_browser_built_up(self, tee_sheet_form: FormState) -> None:
+        """Course selection and date come across as form fields."""
+        fields = dict(tee_sheet_form.fields)
+        assert fields[f"{FORM_ID}:j_idt104_input"] == "02/01/2026"  # selected date
+        assert fields[f"{FORM_ID}:maxDateInputField"] == "02/01/2027"
+        # Course checkboxes: only the checked ones are submitted.
+        assert (f"{FORM_ID}:j_idt101", "2") in tee_sheet_form.fields
+
+    def test_skips_unchecked_and_disabled_controls(self) -> None:
+        state = FormState.from_html(
+            '<form id="f" action="/post">'
+            '<input type="hidden" name="javax.faces.ViewState" value="v">'
+            '<input type="checkbox" name="on" value="1" checked>'
+            '<input type="checkbox" name="off" value="2">'
+            '<input type="text" name="dis" value="3" disabled>'
+            '<input type="submit" name="btn" value="Go">'
+            "</form>"
+        )
+        names = [name for name, _ in state.fields]
+        assert "on" in names
+        assert "off" not in names
+        assert "dis" not in names
+        assert "btn" not in names
+
+    def test_serializes_selected_options_and_textareas(self) -> None:
+        state = FormState.from_html(
+            '<form id="f" action="/post">'
+            '<input type="hidden" name="javax.faces.ViewState" value="v">'
+            '<select name="s"><option value="a">A</option>'
+            '<option value="b" selected>B</option></select>'
+            '<textarea name="t">hello</textarea>'
+            "</form>"
+        )
+        assert ("s", "b") in state.fields
+        assert ("t", "hello") in state.fields
+
+    def test_rejects_page_without_a_jsf_form(self) -> None:
+        with pytest.raises(DirectHttpError, match="No JSF form"):
+            FormState.from_html("<html><body><form id='x'></form></body></html>")
+
+    def test_set_field_replaces_in_place(self, tee_sheet_form: FormState) -> None:
+        state = FormState(
+            form_id="f", action_url="/post", fields=[("a", "1"), ("b", "2"), ("c", "3")]
+        )
+        state.set_field("b", "changed")
+        assert state.fields == [("a", "1"), ("b", "changed"), ("c", "3")]
+
+    def test_set_field_appends_when_absent(self) -> None:
+        state = FormState(form_id="f", action_url="/post", fields=[("a", "1")])
+        state.set_field("new", "v")
+        assert state.fields == [("a", "1"), ("new", "v")]
+
+
+class TestBuildBody:
+    """The POST body is the one PrimeFaces would have sent."""
+
+    def test_reserve_body_carries_the_partial_request_params(
+        self, tee_sheet_form: FormState
+    ) -> None:
+        document = parse_html(TEE_SHEET)
+        button = document.find_by_id(RESERVE_ID)
+        assert button is not None
+        config = find_ab_for_element(button, TEE_SHEET)
+        assert config is not None
+
+        session = make_session(tee_sheet_form, lambda request: httpx.Response(200))
+        params = urllib.parse.parse_qsl(session.build_body(config).decode(), keep_blank_values=True)
+        as_dict = dict(params)
+
+        assert as_dict["javax.faces.partial.ajax"] == "true"
+        assert as_dict["javax.faces.source"] == RESERVE_ID
+        assert as_dict["javax.faces.partial.execute"] == "@all"
+        assert as_dict["javax.faces.partial.render"] == FORM_ID
+        assert as_dict["javax.faces.ViewState"] == tee_sheet_form.view_state
+        # The activating control submits its own name so JSF decodes the action.
+        assert as_dict[RESERVE_ID] == RESERVE_ID
+        # And the form's own state rides along.
+        assert as_dict[f"{FORM_ID}:j_idt104_input"] == "02/01/2026"
+
+    def test_behavior_event_is_sent_for_change_handlers(self, tee_sheet_form: FormState) -> None:
+        session = make_session(tee_sheet_form, lambda request: httpx.Response(200))
+        config = AbConfig(source="s", form=FORM_ID, event="change", process="s")
+        as_dict = dict(urllib.parse.parse_qsl(session.build_body(config).decode()))
+        assert as_dict["javax.faces.behavior.event"] == "change"
+        assert as_dict["javax.faces.partial.event"] == "change"
+        assert as_dict["javax.faces.partial.execute"] == "s"
+
+    def test_render_is_omitted_when_the_handler_declares_none(
+        self, tee_sheet_form: FormState
+    ) -> None:
+        session = make_session(tee_sheet_form, lambda request: httpx.Response(200))
+        body = session.build_body(AbConfig(source="s", form=FORM_ID)).decode()
+        assert "javax.faces.partial.render" not in body
+
+    def test_reserve_body_is_small(self, tee_sheet_form: FormState) -> None:
+        """The race-critical payload is ~2KB, not a 700KB page render."""
+        document = parse_html(TEE_SHEET)
+        button = document.find_by_id(RESERVE_ID)
+        assert button is not None
+        config = find_ab_for_element(button, TEE_SHEET)
+        assert config is not None
+        session = make_session(tee_sheet_form, lambda request: httpx.Response(200))
+        assert len(session.build_body(config)) < 4096
+
+
+class TestPartialResponse:
+    """Parsing the server's XML replies."""
+
+    def test_extracts_updates_and_view_state(self) -> None:
+        response = parse_partial_response(partial_response("<div>hi</div>", "vs-2"))
+        assert response.view_state == "vs-2"
+        assert "<div>hi</div>" in response.markup
+
+    def test_view_state_update_is_not_part_of_markup(self) -> None:
+        response = parse_partial_response(partial_response("<div>hi</div>", "vs-2"))
+        assert "vs-2" not in response.markup
+
+    def test_view_expired_raises_a_distinct_error(self) -> None:
+        xml = (
+            "<partial-response><error>"
+            "<error-name>class javax.faces.application.ViewExpiredException</error-name>"
+            "<error-message>View could not be restored</error-message>"
+            "</error></partial-response>"
+        )
+        with pytest.raises(ViewExpiredError, match="ViewExpired"):
+            parse_partial_response(xml)
+
+    def test_other_server_errors_raise_direct_http_error(self) -> None:
+        xml = (
+            "<partial-response><error>"
+            "<error-name>java.lang.NullPointerException</error-name>"
+            "<error-message>boom</error-message>"
+            "</error></partial-response>"
+        )
+        with pytest.raises(DirectHttpError, match="NullPointerException"):
+            parse_partial_response(xml)
+
+    def test_html_login_page_is_reported_clearly(self) -> None:
+        """A dead session returns HTML, not XML - say so rather than crash."""
+        with pytest.raises(DirectHttpError, match="not a JSF partial-response"):
+            parse_partial_response("<html><body>Please log in</body></html>")
+
+    def test_captures_redirect(self) -> None:
+        xml = '<partial-response><redirect url="/login"/></partial-response>'
+        assert parse_partial_response(xml).redirect_url == "/login"
+
+
+class TestSessionState:
+    """State handling across a request/response round trip."""
+
+    def test_view_state_is_refreshed_from_the_response(self, tee_sheet_form: FormState) -> None:
+        state = FormState.from_html(TEE_SHEET)
+        session = make_session(
+            state, lambda request: httpx.Response(200, text=partial_response("<p>ok</p>", "vs-9"))
+        )
+        session.post(AbConfig(source="s", form=FORM_ID))
+        assert session.form_state.view_state == "vs-9"
+
+    def test_form_fields_are_rebuilt_when_the_form_re_renders(self) -> None:
+        """The tee sheet re-renders the whole form; stale fields must not persist."""
+        state = FormState.from_html(TEE_SHEET)
+        assert dict(state.fields)[f"{FORM_ID}:j_idt104_input"] == "02/01/2026"
+
+        rerendered = (
+            f'<form id="{FORM_ID}" action="/post">'
+            f'<input type="hidden" name="{FORM_ID}:newField" value="fresh">'
+            "</form>"
+        )
+        session = make_session(
+            state,
+            lambda request: httpx.Response(200, text=partial_response(rerendered, "vs-3")),
+        )
+        session.post(AbConfig(source="s", form=FORM_ID))
+
+        fields = dict(session.form_state.fields)
+        assert fields[f"{FORM_ID}:newField"] == "fresh"
+        assert f"{FORM_ID}:j_idt104_input" not in fields
+        assert fields["javax.faces.ViewState"] == "vs-3"
+
+    def test_non_200_is_an_error(self, tee_sheet_form: FormState) -> None:
+        session = make_session(FormState.from_html(TEE_SHEET), lambda request: httpx.Response(503))
+        with pytest.raises(DirectHttpError, match="HTTP 503"):
+            session.post(AbConfig(source="s", form=FORM_ID))
+
+    def test_pre_built_body_is_sent_verbatim(self) -> None:
+        """The staged body must not be re-serialized on the critical path."""
+        sent: list[bytes] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            sent.append(request.content)
+            return httpx.Response(200, text=partial_response("<p>ok</p>"))
+
+        session = make_session(FormState.from_html(TEE_SHEET), handler)
+        session.post(AbConfig(source="s", form=FORM_ID), body=b"staged=body")
+        assert sent == [b"staged=body"]
+
+
+class TestSleepUntil:
+    """The Python-side precision wait."""
+
+    def test_returns_immediately_when_the_target_is_past(self) -> None:
+        import time as time_module
+
+        past = int(time_module.time() * 1000) - 5000
+        assert sleep_until(past) >= 0
+
+    def test_waits_until_the_target(self) -> None:
+        import time as time_module
+
+        target = int(time_module.time() * 1000) + 40
+        drift = sleep_until(target)
+        assert int(time_module.time() * 1000) >= target
+        assert abs(drift) < 25
+
+
+# ---------------------------------------------------------------------------
+# The booking chain
+# ---------------------------------------------------------------------------
+
+# Shaped like a real PrimeFaces selectOneButton: the radios carry no inline
+# handler, and the change behavior lives in the widget-init script keyed on the
+# group's component id. The time-period filter (values 0-3) sits alongside it,
+# which is the collision issue #105 was about.
+PLAYER_PAGE = f"""
+<form id="{FORM_ID}" action="/post">
+  <input type="hidden" name="javax.faces.ViewState" value="vs">
+  <div class="ui-selectonebutton" id="timeFilter">
+    <div class="ui-button"><input type="radio" name="filter" value="0" checked></div>
+    <div class="ui-button"><input type="radio" name="filter" value="1"></div>
+    <div class="ui-button"><input type="radio" name="filter" value="2"></div>
+  </div>
+  <div class="ui-selectonebutton" id="playerGroup">
+    <div class="ui-button"><input type="radio" name="players" value="1"></div>
+    <div class="ui-button"><input type="radio" name="players" value="2"></div>
+    <div class="ui-button"><input type="radio" name="players" value="4"></div>
+  </div>
+  <script type="text/javascript">
+    PrimeFaces.cw("SelectOneButton","widget_players",{{id:"playerGroup",
+      behaviors:{{change:function(ext,event){{PrimeFaces.ab({{s:"playerGroup",
+      e:"change",f:"{FORM_ID}",p:"playerGroup",u:"{FORM_ID}"}},ext);}}}}}});
+  </script>
+</form>
+"""
+
+# The alternative shape: an inline onclick straight on the control.
+PLAYER_PAGE_INLINE_HANDLER = f"""
+<form id="{FORM_ID}" action="/post">
+  <input type="hidden" name="javax.faces.ViewState" value="vs">
+  <div class="ui-selectonebutton" id="playerGroup">
+    <div class="ui-button"><input type="radio" name="players" value="4" id="playerRadio4"
+      onclick='PrimeFaces.ab({{s:"playerRadio4",f:"{FORM_ID}",e:"change",u:"{FORM_ID}"}});'></div>
+  </div>
+</form>
+"""
+
+ROWS_PAGE = f"""
+<form id="{FORM_ID}" action="/post">
+  <input type="hidden" name="javax.faces.ViewState" value="vs">
+  <table id="playersTable"><tbody>
+    <tr data-ri="0"><td>Member</td></tr>
+    <tr data-ri="1"><td><a id="tbd1"
+      onclick='PrimeFaces.ab({{s:"tbd1",f:"{FORM_ID}",u:"{FORM_ID}"}});'>TBD</a></td></tr>
+    <tr data-ri="2"><td><a id="tbd2"
+      onclick='PrimeFaces.ab({{s:"tbd2",f:"{FORM_ID}",u:"{FORM_ID}"}});'>TBD</a></td></tr>
+    <tr data-ri="3"><td><a id="tbd3"
+      onclick='PrimeFaces.ab({{s:"tbd3",f:"{FORM_ID}",u:"{FORM_ID}"}});'>TBD</a></td></tr>
+  </tbody></table>
+  <a id="bookTeeTimeAction"
+     onclick='PrimeFaces.ab({{s:"bookTeeTimeAction",f:"{FORM_ID}",u:"{FORM_ID}"}});'>Book Now</a>
+</form>
+"""
+
+BOOKED_PAGE = f'<form id="{FORM_ID}" action="/post"><p>Booking confirmed</p></form>'
+
+BLOCKED_PAGE = (
+    f'<form id="{FORM_ID}" action="/post">'
+    '<div id="teeSheetValidationErrorPopup" aria-hidden="false">'
+    "This slot is blocked by another user</div></form>"
+)
+
+
+class ChainRecorder:
+    """Serves canned responses in order, recording each request's source."""
+
+    def __init__(self, pages: list[str]) -> None:
+        self.pages = pages
+        self.sources: list[str] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        params = dict(urllib.parse.parse_qsl(request.content.decode()))
+        self.sources.append(params.get("javax.faces.source", ""))
+        page = self.pages[min(len(self.sources) - 1, len(self.pages) - 1)]
+        return httpx.Response(200, text=partial_response(page, f"vs-{len(self.sources)}"))
+
+
+def make_booker(recorder: ChainRecorder) -> DirectHttpBooker:
+    session = make_session(FormState.from_html(TEE_SHEET), recorder)
+    booker = DirectHttpBooker(session)
+    config = AbConfig(source=RESERVE_ID, form=FORM_ID, update=FORM_ID)
+    booker._reserve_config = config
+    booker._reserve_body = session.build_body(config)
+    return booker
+
+
+class TestDirectHttpBooker:
+    """The Reserve -> players -> TBD -> Book Now chain."""
+
+    def test_full_four_player_chain(self) -> None:
+        recorder = ChainRecorder(
+            [PLAYER_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, BOOKED_PAGE]
+        )
+        result = make_booker(recorder).book(4)
+
+        assert result.success, result.error
+        assert result.phase == "complete"
+        # Reserve, player count, three TBD guests, Book Now.
+        assert recorder.sources == [
+            RESERVE_ID,
+            "playerGroup",
+            "tbd1",
+            "tbd2",
+            "tbd3",
+            "bookTeeTimeAction",
+        ]
+
+    def test_single_player_skips_tbd_guests(self) -> None:
+        recorder = ChainRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        result = make_booker(recorder).book(1)
+
+        assert result.success, result.error
+        assert "tbd1" not in recorder.sources
+        assert recorder.sources == [RESERVE_ID, "playerGroup", "bookTeeTimeAction"]
+
+    def test_inline_handler_on_the_control_is_used_directly(self) -> None:
+        """Not every control puts its behavior in a widget script."""
+        recorder = ChainRecorder(
+            [PLAYER_PAGE_INLINE_HANDLER, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, BOOKED_PAGE]
+        )
+        result = make_booker(recorder).book(4)
+
+        assert result.success, result.error
+        # The radio's own handler is used, not the enclosing group's.
+        assert recorder.sources[1] == "playerRadio4"
+
+    def test_blocked_slot_is_detected_after_reserve(self) -> None:
+        recorder = ChainRecorder([BLOCKED_PAGE])
+        result = make_booker(recorder).book(4)
+
+        assert not result.success
+        assert result.blocked
+        assert result.phase == "reserve_click"
+        assert result.error is not None and "blocked by another user" in result.error
+        # It must stop, not push on into the player-count step.
+        assert recorder.sources == [RESERVE_ID]
+
+    def test_ignores_the_time_filter_button_group(self) -> None:
+        """Issue #105: both groups are .ui-selectonebutton."""
+        recorder = ChainRecorder([PLAYER_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        make_booker(recorder).book(4)
+        assert recorder.sources[1] == "playerGroup"
+
+    def test_player_count_radio_value_is_submitted(self) -> None:
+        """Selecting a radio means posting its value, not just its behavior."""
+        bodies: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            params = dict(urllib.parse.parse_qsl(request.content.decode()))
+            bodies.append(params)
+            page = PLAYER_PAGE if len(bodies) == 1 else ROWS_PAGE
+            return httpx.Response(200, text=partial_response(page))
+
+        session = make_session(FormState.from_html(TEE_SHEET), handler)
+        booker = DirectHttpBooker(session)
+        booker._reserve_config = AbConfig(source=RESERVE_ID, form=FORM_ID)
+        booker._reserve_body = b"staged=reserve"
+        result = booker.book(1)
+
+        assert result.success, result.error
+        assert bodies[1]["players"] == "1"
+
+    def test_missing_player_selector_fails_in_that_phase(self) -> None:
+        recorder = ChainRecorder([BOOKED_PAGE])
+        result = make_booker(recorder).book(4)
+
+        assert not result.success
+        assert result.phase == "player_count"
+        assert result.error is not None and "Player count selector" in result.error
+
+    def test_disabled_player_count_is_reported(self) -> None:
+        disabled = PLAYER_PAGE.replace(
+            '<div class="ui-button"><input type="radio" name="players" value="4">',
+            '<div class="ui-button ui-state-disabled">'
+            '<input type="radio" name="players" value="4">',
+        )
+        result = make_booker(ChainRecorder([disabled])).book(4)
+
+        assert not result.success
+        assert result.phase == "player_count"
+        assert result.error is not None and "disabled" in result.error
+
+    def test_too_few_player_rows_fails_in_the_tbd_phase(self) -> None:
+        short_rows = ROWS_PAGE.replace('<tr data-ri="3"', '<tr data-ignored="3"').replace(
+            '<tr data-ri="2"', '<tr data-ignored="2"'
+        )
+        recorder = ChainRecorder([PLAYER_PAGE, short_rows])
+        result = make_booker(recorder).book(4)
+
+        assert not result.success
+        assert result.phase == "tbd_guests"
+        assert result.error is not None and "player row" in result.error
+
+    def test_missing_book_now_fails_in_that_phase(self) -> None:
+        no_button = ROWS_PAGE.replace('id="bookTeeTimeAction"', 'id="somethingElse"').replace(
+            ">Book Now<", ">Other<"
+        )
+        recorder = ChainRecorder([PLAYER_PAGE, no_button, no_button, no_button, no_button])
+        result = make_booker(recorder).book(4)
+
+        assert not result.success
+        assert result.phase == "book_now"
+        assert result.error is not None and "Book Now" in result.error
+
+    def test_transport_failure_is_reported_not_raised(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection reset")
+
+        session = make_session(FormState.from_html(TEE_SHEET), handler)
+        booker = DirectHttpBooker(session)
+        booker._reserve_config = AbConfig(source=RESERVE_ID, form=FORM_ID)
+        booker._reserve_body = b"staged=reserve"
+        result = booker.book(4)
+
+        assert not result.success
+        assert result.phase == "reserve_click"
+        assert result.error is not None and "connection reset" in result.error
+
+    def test_book_without_prepare_is_rejected(self) -> None:
+        session = make_session(FormState.from_html(TEE_SHEET), lambda request: httpx.Response(200))
+        with pytest.raises(DirectHttpError, match="prepare"):
+            DirectHttpBooker(session).book(4)
+
+    def test_invalid_player_count_is_rejected(self) -> None:
+        booker = make_booker(ChainRecorder([BOOKED_PAGE]))
+        with pytest.raises(DirectHttpError, match="num_players"):
+            booker.book(5)
+
+    def test_timed_mode_waits_for_the_target(self) -> None:
+        import time as time_module
+
+        recorder = ChainRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        target = int(time_module.time() * 1000) + 60
+        result = make_booker(recorder).book(1, target_timestamp_ms=target)
+
+        assert result.success, result.error
+        assert int(time_module.time() * 1000) >= target
+        assert "clickDriftMs" in result.timing
+        assert abs(result.timing["clickDriftMs"]) < 25
+
+
+class TestPrepare:
+    """Staging the Reserve request off the real tee sheet."""
+
+    def test_stages_the_reserve_request_from_the_page(self) -> None:
+        session = make_session(FormState.from_html(TEE_SHEET), lambda request: httpx.Response(200))
+        booker = DirectHttpBooker(session)
+        booker.prepare(RESERVE_ID, TEE_SHEET)
+
+        assert booker._reserve_config is not None
+        assert booker._reserve_config.source == RESERVE_ID
+        assert booker._reserve_body is not None
+        params = dict(urllib.parse.parse_qsl(booker._reserve_body.decode()))
+        assert params["javax.faces.source"] == RESERVE_ID
+
+    def test_unknown_button_id_is_rejected(self) -> None:
+        session = make_session(FormState.from_html(TEE_SHEET), lambda request: httpx.Response(200))
+        with pytest.raises(DirectHttpError, match="not found"):
+            DirectHttpBooker(session).prepare("no-such-button", TEE_SHEET)
+
+    def test_button_without_a_handler_is_rejected(self) -> None:
+        html = (
+            f'<form id="{FORM_ID}" action="/post">'
+            '<input type="hidden" name="javax.faces.ViewState" value="v">'
+            '<a id="plain">Reserve</a></form>'
+        )
+        session = make_session(FormState.from_html(html), lambda request: httpx.Response(200))
+        with pytest.raises(DirectHttpError, match="no PrimeFaces.ab handler"):
+            DirectHttpBooker(session).prepare("plain", html)

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -7,6 +7,7 @@ expects - not one derived from a hand-written mock.
 """
 
 import urllib.parse
+from collections.abc import Callable
 from pathlib import Path
 
 import httpx
@@ -23,8 +24,12 @@ from app.providers.walden_http import (
     parse_html,
     parse_partial_response,
     sleep_until,
+    visible_text,
 )
-from app.providers.walden_http_booker import DirectHttpBooker
+from app.providers.walden_http_booker import (
+    PHASE_RESERVE_SENT,
+    DirectHttpBooker,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures"
 TEE_SHEET = (FIXTURES / "walden_tee_time_loaded.html").read_text(encoding="utf-8", errors="replace")
@@ -35,18 +40,21 @@ RESERVE_ID = f"{FORM_ID}:teeTimeCourses:0:teeTimeSlots:67:slotTee:0:reserve_butt
 
 @pytest.fixture(scope="module")
 def tee_sheet_form() -> FormState:
+    """The captured tee sheet's form state, parsed once per module."""
     return FormState.from_html(TEE_SHEET)
 
 
 def make_session(
     form_state: FormState,
-    handler: "object",
+    handler: Callable[[httpx.Request], httpx.Response],
 ) -> PrimeFacesSession:
-    """Build a session whose transport is a MockTransport handler."""
-    client = httpx.Client(
-        transport=httpx.MockTransport(handler),  # type: ignore[arg-type]
-        headers={"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"},
-    )
+    """Build a session whose transport is a MockTransport handler.
+
+    No headers are set here on purpose: the session must apply its own protocol
+    headers to an injected client, so what these tests exercise is what
+    production sends.
+    """
+    client = httpx.Client(transport=httpx.MockTransport(handler))
     return PrimeFacesSession(
         form_state,
         {},
@@ -56,6 +64,7 @@ def make_session(
 
 
 def partial_response(body: str, view_state: str = "new-view-state") -> str:
+    """Wrap markup in the partial-response envelope JSF returns."""
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
         "<partial-response><changes>"
@@ -70,10 +79,12 @@ class TestParseAbCall:
     """The PrimeFaces.ab parser, exercised against the real handlers."""
 
     def test_parses_reserve_button_handler(self) -> None:
+        """The Reserve link's handler yields source, form and update targets."""
         config = parse_ab_call('PrimeFaces.ab({s:"btn-id",f:"form-id",u:"form-id"});return false;')
         assert config == AbConfig(source="btn-id", form="form-id", update="form-id")
 
     def test_resolves_s_this_to_element_id(self) -> None:
+        """``s:this`` resolves to the id of the element carrying the handler."""
         config = parse_ab_call(
             'PrimeFaces.ab({s:this,e:"mousedown",f:"form-id",p:"link-id",u:"area-id"});',
             element_id="link-id",
@@ -84,12 +95,15 @@ class TestParseAbCall:
         assert config.process == "link-id"
 
     def test_s_this_without_element_id_is_unresolvable(self) -> None:
+        """``s:this`` cannot be resolved without knowing the element."""
         assert parse_ab_call('PrimeFaces.ab({s:this,f:"form-id"});') is None
 
     def test_ignores_snippet_without_source_and_form(self) -> None:
+        """A call missing source or form is not a usable request."""
         assert parse_ab_call('PrimeFaces.ab({u:"only-update"});') is None
 
     def test_ignores_non_ab_javascript(self) -> None:
+        """JavaScript with no PrimeFaces.ab call yields nothing."""
         assert parse_ab_call("showLoader(); return false;") is None
 
     def test_does_not_mistake_callback_keys_for_config_keys(self) -> None:
@@ -120,6 +134,7 @@ class TestFormState:
     """Form serialization against the captured tee sheet."""
 
     def test_finds_the_tee_time_form(self, tee_sheet_form: FormState) -> None:
+        """The form carrying a ViewState is the one selected."""
         assert tee_sheet_form.form_id == FORM_ID
 
     def test_posts_to_the_encoded_url_not_the_form_action(self, tee_sheet_form: FormState) -> None:
@@ -128,6 +143,7 @@ class TestFormState:
         assert "_jsfBridgeAjax=true" in tee_sheet_form.action_url
 
     def test_extracts_view_state(self, tee_sheet_form: FormState) -> None:
+        """The ViewState is read from the form's hidden input."""
         assert tee_sheet_form.view_state == "3597409561974113966:-1460199378475720306"
 
     def test_serializes_the_state_the_browser_built_up(self, tee_sheet_form: FormState) -> None:
@@ -139,6 +155,7 @@ class TestFormState:
         assert (f"{FORM_ID}:j_idt101", "2") in tee_sheet_form.fields
 
     def test_skips_unchecked_and_disabled_controls(self) -> None:
+        """Only successful controls are submitted, as a browser would."""
         state = FormState.from_html(
             '<form id="f" action="/post">'
             '<input type="hidden" name="javax.faces.ViewState" value="v">'
@@ -155,6 +172,7 @@ class TestFormState:
         assert "btn" not in names
 
     def test_serializes_selected_options_and_textareas(self) -> None:
+        """Selects submit their chosen option; textareas submit their body."""
         state = FormState.from_html(
             '<form id="f" action="/post">'
             '<input type="hidden" name="javax.faces.ViewState" value="v">'
@@ -167,10 +185,12 @@ class TestFormState:
         assert ("t", "hello") in state.fields
 
     def test_rejects_page_without_a_jsf_form(self) -> None:
+        """A page with no ViewState-bearing form cannot be posted to."""
         with pytest.raises(DirectHttpError, match="No JSF form"):
             FormState.from_html("<html><body><form id='x'></form></body></html>")
 
     def test_set_field_replaces_in_place(self, tee_sheet_form: FormState) -> None:
+        """Replacing a field keeps the surrounding field order intact."""
         state = FormState(
             form_id="f", action_url="/post", fields=[("a", "1"), ("b", "2"), ("c", "3")]
         )
@@ -178,6 +198,7 @@ class TestFormState:
         assert state.fields == [("a", "1"), ("b", "changed"), ("c", "3")]
 
     def test_set_field_appends_when_absent(self) -> None:
+        """A field the form did not carry is appended."""
         state = FormState(form_id="f", action_url="/post", fields=[("a", "1")])
         state.set_field("new", "v")
         assert state.fields == [("a", "1"), ("new", "v")]
@@ -189,6 +210,7 @@ class TestBuildBody:
     def test_reserve_body_carries_the_partial_request_params(
         self, tee_sheet_form: FormState
     ) -> None:
+        """The body carries the partial-request params and the form's state."""
         document = parse_html(TEE_SHEET)
         button = document.find_by_id(RESERVE_ID)
         assert button is not None
@@ -210,6 +232,7 @@ class TestBuildBody:
         assert as_dict[f"{FORM_ID}:j_idt104_input"] == "02/01/2026"
 
     def test_behavior_event_is_sent_for_change_handlers(self, tee_sheet_form: FormState) -> None:
+        """A behavior-driven control sends its event name."""
         session = make_session(tee_sheet_form, lambda request: httpx.Response(200))
         config = AbConfig(source="s", form=FORM_ID, event="change", process="s")
         as_dict = dict(urllib.parse.parse_qsl(session.build_body(config).decode()))
@@ -220,6 +243,7 @@ class TestBuildBody:
     def test_render_is_omitted_when_the_handler_declares_none(
         self, tee_sheet_form: FormState
     ) -> None:
+        """No update target means no render parameter."""
         session = make_session(tee_sheet_form, lambda request: httpx.Response(200))
         body = session.build_body(AbConfig(source="s", form=FORM_ID)).decode()
         assert "javax.faces.partial.render" not in body
@@ -239,15 +263,18 @@ class TestPartialResponse:
     """Parsing the server's XML replies."""
 
     def test_extracts_updates_and_view_state(self) -> None:
+        """Updates and the refreshed ViewState are both read out."""
         response = parse_partial_response(partial_response("<div>hi</div>", "vs-2"))
         assert response.view_state == "vs-2"
         assert "<div>hi</div>" in response.markup
 
     def test_view_state_update_is_not_part_of_markup(self) -> None:
+        """The ViewState update is state, not renderable markup."""
         response = parse_partial_response(partial_response("<div>hi</div>", "vs-2"))
         assert "vs-2" not in response.markup
 
     def test_view_expired_raises_a_distinct_error(self) -> None:
+        """An expired view is distinguishable from other server errors."""
         xml = (
             "<partial-response><error>"
             "<error-name>class javax.faces.application.ViewExpiredException</error-name>"
@@ -258,6 +285,7 @@ class TestPartialResponse:
             parse_partial_response(xml)
 
     def test_other_server_errors_raise_direct_http_error(self) -> None:
+        """Non-ViewState server errors surface with their Java class name."""
         xml = (
             "<partial-response><error>"
             "<error-name>java.lang.NullPointerException</error-name>"
@@ -273,6 +301,7 @@ class TestPartialResponse:
             parse_partial_response("<html><body>Please log in</body></html>")
 
     def test_captures_redirect(self) -> None:
+        """A redirect element is captured rather than silently dropped."""
         xml = '<partial-response><redirect url="/login"/></partial-response>'
         assert parse_partial_response(xml).redirect_url == "/login"
 
@@ -281,6 +310,7 @@ class TestSessionState:
     """State handling across a request/response round trip."""
 
     def test_view_state_is_refreshed_from_the_response(self, tee_sheet_form: FormState) -> None:
+        """Each response rolls the ViewState the next request must carry."""
         state = FormState.from_html(TEE_SHEET)
         session = make_session(
             state, lambda request: httpx.Response(200, text=partial_response("<p>ok</p>", "vs-9"))
@@ -310,6 +340,7 @@ class TestSessionState:
         assert fields["javax.faces.ViewState"] == "vs-3"
 
     def test_non_200_is_an_error(self, tee_sheet_form: FormState) -> None:
+        """A non-200 status is a failed step, not an empty response."""
         session = make_session(FormState.from_html(TEE_SHEET), lambda request: httpx.Response(503))
         with pytest.raises(DirectHttpError, match="HTTP 503"):
             session.post(AbConfig(source="s", form=FORM_ID))
@@ -319,6 +350,7 @@ class TestSessionState:
         sent: list[bytes] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
+            """Mock transport handler for one test case."""
             sent.append(request.content)
             return httpx.Response(200, text=partial_response("<p>ok</p>"))
 
@@ -327,22 +359,178 @@ class TestSessionState:
         assert sent == [b"staged=body"]
 
 
+class StubDriver:
+    """Minimal stand-in for a logged-in WebDriver on the tee sheet."""
+
+    def __init__(self, cookies: list[dict[str, str]], page_source: str = TEE_SHEET) -> None:
+        """Queue the pages this recorder will serve, in order."""
+        self._cookies = cookies
+        self.page_source = page_source
+        self.current_url = "https://www.waldengolf.com/group/pages/book-a-tee-time"
+
+    def get_cookies(self) -> list[dict[str, str]]:
+        """Return the browser's cookie jar in Selenium's shape."""
+        return self._cookies
+
+    def execute_script(self, script: str) -> str:
+        """Answer the user-agent lookup from_selenium performs."""
+        return "Mozilla/5.0 (StubDriver)"
+
+
+class TestFromSelenium:
+    """Adopting a live browser session - the production entry point."""
+
+    def test_adopts_cookies_user_agent_and_form_state(self) -> None:
+        """The session inherits everything the browser established."""
+        driver = StubDriver([{"name": "JSESSIONID", "value": "abc123"}])
+        session = PrimeFacesSession.from_selenium(driver)
+
+        assert session.form_state.form_id == FORM_ID
+        assert session.form_state.view_state == "3597409561974113966:-1460199378475720306"
+        assert session.base_url == driver.current_url
+        assert session._client.headers["User-Agent"] == "Mozilla/5.0 (StubDriver)"
+        assert session._client.cookies["JSESSIONID"] == "abc123"
+        session.close()
+
+    def test_rejects_a_session_with_no_cookies(self) -> None:
+        """Without the session cookie every POST would come back unauthenticated."""
+        with pytest.raises(DirectHttpError, match="no cookies"):
+            PrimeFacesSession.from_selenium(StubDriver([]))
+
+
+class TestProtocolHeaders:
+    """The headers the JSF bridge routes on must reach the wire."""
+
+    def test_posted_request_carries_the_primefaces_headers(self) -> None:
+        """The bridge routes on these headers, so they must reach the wire."""
+        seen: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Mock transport handler for one test case."""
+            seen.append(request)
+            return httpx.Response(200, text=partial_response("<p>ok</p>"))
+
+        session = make_session(FormState.from_html(TEE_SHEET), handler)
+        session.post(AbConfig(source="s", form=FORM_ID))
+
+        assert seen[0].headers["Faces-Request"] == "partial/ajax"
+        assert seen[0].headers["X-Requested-With"] == "XMLHttpRequest"
+        assert seen[0].headers["Content-Type"].startswith("application/x-www-form-urlencoded")
+
+
+class TestWarmUp:
+    """Opening the connection before the window."""
+
+    def test_reports_round_trip_and_prefers_head(self) -> None:
+        """Warm-up measures RTT and avoids a full page render."""
+        methods: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Mock transport handler for one test case."""
+            methods.append(request.method)
+            return httpx.Response(200)
+
+        session = make_session(FormState.from_html(TEE_SHEET), handler)
+        assert session.warm_up() >= 0
+        # HEAD avoids making the server render the whole tee sheet for a body
+        # we discard.
+        assert methods == ["HEAD"]
+
+    def test_falls_back_to_get_when_head_is_unsupported(self) -> None:
+        """A server refusing HEAD still gets its connection warmed."""
+        methods: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Mock transport handler for one test case."""
+            methods.append(request.method)
+            return httpx.Response(405) if request.method == "HEAD" else httpx.Response(200)
+
+        session = make_session(FormState.from_html(TEE_SHEET), handler)
+        session.warm_up()
+        assert methods == ["HEAD", "GET"]
+
+    def test_unauthenticated_warm_up_is_an_error(self) -> None:
+        """Better to find out now than as a confusing Reserve failure at 6:30."""
+        session = make_session(FormState.from_html(TEE_SHEET), lambda request: httpx.Response(302))
+        with pytest.raises(DirectHttpError, match="may not be authenticated"):
+            session.warm_up()
+
+    def test_transport_error_becomes_direct_http_error(self) -> None:
+        """A connection failure surfaces as a recoverable error."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Mock transport handler for one test case."""
+            raise httpx.ConnectError("no route to host")
+
+        session = make_session(FormState.from_html(TEE_SHEET), handler)
+        with pytest.raises(DirectHttpError, match="Failed to warm up"):
+            session.warm_up()
+
+
+class TestExpiredSession:
+    """A session that died between staging and the race."""
+
+    def test_post_propagates_view_expired(self) -> None:
+        """An expired view reaches the caller as ViewExpiredError."""
+        xml = (
+            "<partial-response><error>"
+            "<error-name>class javax.faces.application.ViewExpiredException</error-name>"
+            "<error-message>View could not be restored</error-message>"
+            "</error></partial-response>"
+        )
+        session = make_session(
+            FormState.from_html(TEE_SHEET), lambda request: httpx.Response(200, text=xml)
+        )
+        with pytest.raises(ViewExpiredError):
+            session.post(AbConfig(source="s", form=FORM_ID))
+
+    def test_redirect_response_is_treated_as_expired(self) -> None:
+        """JSF answers a dead session with a redirect, not an error element."""
+        xml = '<partial-response><redirect url="/web/pages/login"/></partial-response>'
+        session = make_session(
+            FormState.from_html(TEE_SHEET), lambda request: httpx.Response(200, text=xml)
+        )
+        with pytest.raises(ViewExpiredError, match="no longer valid"):
+            session.post(AbConfig(source="s", form=FORM_ID))
+
+
+class TestVisibleText:
+    """Text extraction used to verify a booking from a partial response."""
+
+    def test_reads_element_text(self) -> None:
+        """Element text is extracted from markup."""
+        assert "Booking confirmed" in visible_text("<div><p>Booking confirmed</p></div>")
+
+    def test_ignores_script_and_style_bodies(self) -> None:
+        """A JS string must not be mistaken for page copy."""
+        html = '<div><script>var m = "booking failed";</script><p>Confirmed</p></div>'
+        text = visible_text(html)
+        assert "Confirmed" in text
+        assert "booking failed" not in text
+
+
 class TestSleepUntil:
     """The Python-side precision wait."""
 
     def test_returns_immediately_when_the_target_is_past(self) -> None:
+        """A target already in the past does not block."""
         import time as time_module
 
         past = int(time_module.time() * 1000) - 5000
         assert sleep_until(past) >= 0
 
     def test_waits_until_the_target(self) -> None:
+        """The wait never returns before the target instant."""
         import time as time_module
 
         target = int(time_module.time() * 1000) + 40
         drift = sleep_until(target)
+
+        # The invariant is that it never returns early. The drift bound is
+        # deliberately loose: it is bounded by OS scheduler latency, so a tight
+        # assertion just makes this flaky on a loaded CI runner.
         assert int(time_module.time() * 1000) >= target
-        assert abs(drift) < 25
+        assert 0 <= drift < 250
 
 
 # ---------------------------------------------------------------------------
@@ -415,10 +603,12 @@ class ChainRecorder:
     """Serves canned responses in order, recording each request's source."""
 
     def __init__(self, pages: list[str]) -> None:
+        """Queue the pages this recorder will serve, in order."""
         self.pages = pages
         self.sources: list[str] = []
 
     def __call__(self, request: httpx.Request) -> httpx.Response:
+        """Serve the next canned page and record the request's source."""
         params = dict(urllib.parse.parse_qsl(request.content.decode()))
         self.sources.append(params.get("javax.faces.source", ""))
         page = self.pages[min(len(self.sources) - 1, len(self.pages) - 1)]
@@ -426,6 +616,7 @@ class ChainRecorder:
 
 
 def make_booker(recorder: ChainRecorder) -> DirectHttpBooker:
+    """A booker with the Reserve request pre-staged against a recorder."""
     session = make_session(FormState.from_html(TEE_SHEET), recorder)
     booker = DirectHttpBooker(session)
     config = AbConfig(source=RESERVE_ID, form=FORM_ID, update=FORM_ID)
@@ -438,6 +629,7 @@ class TestDirectHttpBooker:
     """The Reserve -> players -> TBD -> Book Now chain."""
 
     def test_full_four_player_chain(self) -> None:
+        """Reserve, player count, three TBD guests, then Book Now."""
         recorder = ChainRecorder(
             [PLAYER_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, BOOKED_PAGE]
         )
@@ -456,6 +648,7 @@ class TestDirectHttpBooker:
         ]
 
     def test_single_player_skips_tbd_guests(self) -> None:
+        """A solo booking has no guest rows to fill."""
         recorder = ChainRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
         result = make_booker(recorder).book(1)
 
@@ -475,20 +668,25 @@ class TestDirectHttpBooker:
         assert recorder.sources[1] == "playerRadio4"
 
     def test_blocked_slot_is_detected_after_reserve(self) -> None:
+        """Losing the slot stops the chain instead of pressing on."""
         recorder = ChainRecorder([BLOCKED_PAGE])
         result = make_booker(recorder).book(4)
 
         assert not result.success
         assert result.blocked
-        assert result.phase == "reserve_click"
+        assert result.phase == PHASE_RESERVE_SENT
         assert result.error is not None and "blocked by another user" in result.error
         # It must stop, not push on into the player-count step.
         assert recorder.sources == [RESERVE_ID]
 
     def test_ignores_the_time_filter_button_group(self) -> None:
         """Issue #105: both groups are .ui-selectonebutton."""
-        recorder = ChainRecorder([PLAYER_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, BOOKED_PAGE])
-        make_booker(recorder).book(4)
+        recorder = ChainRecorder(
+            [PLAYER_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, BOOKED_PAGE]
+        )
+        result = make_booker(recorder).book(4)
+
+        assert result.success, result.error
         assert recorder.sources[1] == "playerGroup"
 
     def test_player_count_radio_value_is_submitted(self) -> None:
@@ -496,6 +694,7 @@ class TestDirectHttpBooker:
         bodies: list[dict[str, str]] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
+            """Mock transport handler for one test case."""
             params = dict(urllib.parse.parse_qsl(request.content.decode()))
             bodies.append(params)
             page = PLAYER_PAGE if len(bodies) == 1 else ROWS_PAGE
@@ -511,6 +710,7 @@ class TestDirectHttpBooker:
         assert bodies[1]["players"] == "1"
 
     def test_missing_player_selector_fails_in_that_phase(self) -> None:
+        """A response without the selector fails in player_count."""
         recorder = ChainRecorder([BOOKED_PAGE])
         result = make_booker(recorder).book(4)
 
@@ -519,6 +719,7 @@ class TestDirectHttpBooker:
         assert result.error is not None and "Player count selector" in result.error
 
     def test_disabled_player_count_is_reported(self) -> None:
+        """A disabled count is reported rather than clicked anyway."""
         disabled = PLAYER_PAGE.replace(
             '<div class="ui-button"><input type="radio" name="players" value="4">',
             '<div class="ui-button ui-state-disabled">'
@@ -531,6 +732,7 @@ class TestDirectHttpBooker:
         assert result.error is not None and "disabled" in result.error
 
     def test_too_few_player_rows_fails_in_the_tbd_phase(self) -> None:
+        """Fewer rows than players is a tbd_guests failure."""
         short_rows = ROWS_PAGE.replace('<tr data-ri="3"', '<tr data-ignored="3"').replace(
             '<tr data-ri="2"', '<tr data-ignored="2"'
         )
@@ -542,6 +744,7 @@ class TestDirectHttpBooker:
         assert result.error is not None and "player row" in result.error
 
     def test_missing_book_now_fails_in_that_phase(self) -> None:
+        """A response without Book Now fails in book_now."""
         no_button = ROWS_PAGE.replace('id="bookTeeTimeAction"', 'id="somethingElse"').replace(
             ">Book Now<", ">Other<"
         )
@@ -553,7 +756,10 @@ class TestDirectHttpBooker:
         assert result.error is not None and "Book Now" in result.error
 
     def test_transport_failure_is_reported_not_raised(self) -> None:
+        """A dropped connection becomes a result, not an exception."""
+
         def handler(request: httpx.Request) -> httpx.Response:
+            """Mock transport handler for one test case."""
             raise httpx.ConnectError("connection reset")
 
         session = make_session(FormState.from_html(TEE_SHEET), handler)
@@ -563,20 +769,23 @@ class TestDirectHttpBooker:
         result = booker.book(4)
 
         assert not result.success
-        assert result.phase == "reserve_click"
+        assert result.phase == PHASE_RESERVE_SENT
         assert result.error is not None and "connection reset" in result.error
 
     def test_book_without_prepare_is_rejected(self) -> None:
+        """The Reserve request must be staged before the race."""
         session = make_session(FormState.from_html(TEE_SHEET), lambda request: httpx.Response(200))
         with pytest.raises(DirectHttpError, match="prepare"):
             DirectHttpBooker(session).book(4)
 
     def test_invalid_player_count_is_rejected(self) -> None:
+        """Player counts outside 1-4 are refused up front."""
         booker = make_booker(ChainRecorder([BOOKED_PAGE]))
         with pytest.raises(DirectHttpError, match="num_players"):
             booker.book(5)
 
     def test_timed_mode_waits_for_the_target(self) -> None:
+        """Timed mode holds the POST until the target instant."""
         import time as time_module
 
         recorder = ChainRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
@@ -586,13 +795,100 @@ class TestDirectHttpBooker:
         assert result.success, result.error
         assert int(time_module.time() * 1000) >= target
         assert "clickDriftMs" in result.timing
-        assert abs(result.timing["clickDriftMs"]) < 25
+        # Loose for the same reason as test_waits_until_the_target.
+        assert 0 <= result.timing["clickDriftMs"] < 250
+
+
+class TestBlockedDetectionScope:
+    """Blocked detection must key on the popup, not on any matching text."""
+
+    def test_hidden_popup_template_does_not_block(self) -> None:
+        """A popup rendered but hidden is a template, not a verdict."""
+        hidden = (
+            f'<form id="{FORM_ID}" action="/post">'
+            '<div id="teeSheetValidationErrorPopup" aria-hidden="true">'
+            "This slot is blocked by another user</div>" + PLAYER_PAGE + "</form>"
+        )
+        recorder = ChainRecorder([hidden, ROWS_PAGE, BOOKED_PAGE])
+        result = make_booker(recorder).book(1)
+
+        assert not result.blocked
+        assert result.success, result.error
+
+    def test_matching_text_outside_the_popup_does_not_block(self) -> None:
+        """Copy elsewhere on the page must not abort a slot we hold."""
+        noisy = (
+            f'<form id="{FORM_ID}" action="/post">'
+            "<p>Times already reserved are shown in grey.</p>" + PLAYER_PAGE + "</form>"
+        )
+        recorder = ChainRecorder([noisy, ROWS_PAGE, BOOKED_PAGE])
+        result = make_booker(recorder).book(1)
+
+        assert not result.blocked
+        assert result.success, result.error
+
+    def test_visible_popup_still_blocks(self) -> None:
+        """A shown popup is honored as a lost slot."""
+        result = make_booker(ChainRecorder([BLOCKED_PAGE])).book(4)
+
+        assert result.blocked
+        assert result.error is not None and "blocked by another user" in result.error
+
+
+class TestPlayerRowFallback:
+    """The non-playersTable fallback must not count header rows."""
+
+    def test_header_row_is_not_mistaken_for_the_member_row(self) -> None:
+        """A header counted as row 0 shifts every guest index by one."""
+        with_header = f"""
+        <form id="{FORM_ID}" action="/post">
+          <input type="hidden" name="javax.faces.ViewState" value="vs">
+          <table id="playerPanel">
+            <thead><tr><th>Player</th></tr></thead>
+            <tbody>
+              <tr><td>Member</td></tr>
+              <tr><td><a id="tbd1"
+                onclick='PrimeFaces.ab({{s:"tbd1",f:"{FORM_ID}",u:"{FORM_ID}"}});'>TBD</a></td></tr>
+            </tbody>
+          </table>
+          <a id="bookTeeTimeAction"
+             onclick='PrimeFaces.ab({{s:"bookTeeTimeAction",f:"{FORM_ID}",u:"{FORM_ID}"}});'
+             >Book Now</a>
+        </form>
+        """
+        recorder = ChainRecorder([PLAYER_PAGE, with_header, with_header, BOOKED_PAGE])
+        result = make_booker(recorder).book(2)
+
+        assert result.success, result.error
+        # The guest row's TBD, not something shifted off the header row.
+        assert "tbd1" in recorder.sources
+
+
+class TestFinalMarkup:
+    """The last response is the only record of a direct booking's outcome."""
+
+    def test_success_carries_the_final_response_markup(self) -> None:
+        """The final response is retained as the record of the outcome."""
+        recorder = ChainRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        result = make_booker(recorder).book(1)
+
+        assert result.success, result.error
+        assert "Booking confirmed" in result.final_markup
+        assert "Booking confirmed" in visible_text(result.final_markup)
+
+    def test_chain_result_exposes_markup_to_the_provider(self) -> None:
+        """The provider receives the markup it needs to verify the booking."""
+        recorder = ChainRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        chain_result = make_booker(recorder).book(1).as_chain_result()
+
+        assert "Booking confirmed" in chain_result["finalMarkup"]
 
 
 class TestPrepare:
     """Staging the Reserve request off the real tee sheet."""
 
     def test_stages_the_reserve_request_from_the_page(self) -> None:
+        """Staging resolves the button's handler and serializes its body."""
         session = make_session(FormState.from_html(TEE_SHEET), lambda request: httpx.Response(200))
         booker = DirectHttpBooker(session)
         booker.prepare(RESERVE_ID, TEE_SHEET)
@@ -604,11 +900,13 @@ class TestPrepare:
         assert params["javax.faces.source"] == RESERVE_ID
 
     def test_unknown_button_id_is_rejected(self) -> None:
+        """A button id absent from the page cannot be staged."""
         session = make_session(FormState.from_html(TEE_SHEET), lambda request: httpx.Response(200))
         with pytest.raises(DirectHttpError, match="not found"):
             DirectHttpBooker(session).prepare("no-such-button", TEE_SHEET)
 
     def test_button_without_a_handler_is_rejected(self) -> None:
+        """A plain link with no PrimeFaces handler cannot be replayed."""
         html = (
             f'<form id="{FORM_ID}" action="/post">'
             '<input type="hidden" name="javax.faces.ViewState" value="v">'

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -28,6 +28,7 @@ from app.providers.walden_http import (
 )
 from app.providers.walden_http_booker import (
     PHASE_RESERVE_SENT,
+    PRE_SUBMIT_PHASES,
     DirectHttpBooker,
 )
 
@@ -773,16 +774,24 @@ class TestDirectHttpBooker:
         assert result.error is not None and "connection reset" in result.error
 
     def test_book_without_prepare_is_rejected(self) -> None:
-        """The Reserve request must be staged before the race."""
+        """Misuse is a pre-submit result, so the caller falls back rather than
+        losing the booking to a bug in an opt-in path."""
         session = make_session(FormState.from_html(TEE_SHEET), lambda request: httpx.Response(200))
-        with pytest.raises(DirectHttpError, match="prepare"):
-            DirectHttpBooker(session).book(4)
+        result = DirectHttpBooker(session).book(4)
+
+        assert not result.success
+        assert result.phase in PRE_SUBMIT_PHASES
+        assert result.error is not None and "prepare" in result.error
 
     def test_invalid_player_count_is_rejected(self) -> None:
-        """Player counts outside 1-4 are refused up front."""
-        booker = make_booker(ChainRecorder([BOOKED_PAGE]))
-        with pytest.raises(DirectHttpError, match="num_players"):
-            booker.book(5)
+        """Player counts outside 1-4 are refused before anything is sent."""
+        recorder = ChainRecorder([BOOKED_PAGE])
+        result = make_booker(recorder).book(5)
+
+        assert not result.success
+        assert result.phase in PRE_SUBMIT_PHASES
+        assert result.error is not None and "num_players" in result.error
+        assert recorder.sources == []
 
     def test_timed_mode_waits_for_the_target(self) -> None:
         """Timed mode holds the POST until the target instant."""

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -13,7 +13,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from selenium.webdriver.common.by import By
 
+from app.config import settings
 from app.providers.walden_dom_schema import DOM
+from app.providers.walden_http import DirectHttpError
 from app.providers.walden_provider import WaldenGolfProvider
 from app.utils.timezone import CTDateTime
 
@@ -2513,6 +2515,216 @@ class TestBatchBookingPreparation:
 
         # driver.refresh() should NOT have been called
         driver.refresh.assert_not_called()
+
+
+class TestDirectHttpBookingWiring:
+    """Tests for _try_direct_http_booking and its fallback policy.
+
+    The direct-HTTP path is opt-in and must never be able to cost a booking:
+    anything short of a submitted reservation hands control back to the JS chain.
+    """
+
+    SLOT = {
+        "timeStr": "8:42",
+        "hours": 8,
+        "minutes": 42,
+        "index": 5,
+        "diff": 0,
+        "available": 4,
+        "isExact": True,
+        "reserveId": "form:teeTimeCourses:0:teeTimeSlots:5:slotTee:0:reserve_button",
+    }
+
+    def _direct_result(self, **overrides: object) -> object:
+        from app.providers.walden_http_booker import DirectBookingResult
+
+        return DirectBookingResult(**overrides)  # type: ignore[arg-type]
+
+    def test_disabled_by_default(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The flag is off unless explicitly enabled."""
+        monkeypatch.setattr(settings, "walden_direct_http_booking", False)
+        assert provider._try_direct_http_booking(MagicMock(), self.SLOT, 4, None) is None
+
+    def test_skipped_when_slot_has_no_reserve_component(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Partially-booked slots expose an Available span, not a Reserve link."""
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        slot = {**self.SLOT, "reserveId": None}
+        assert provider._try_direct_http_booking(MagicMock(), slot, 4, None) is None
+
+    def test_staging_failure_falls_back(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A session we cannot adopt is not a booking failure."""
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        monkeypatch.setattr(
+            "app.providers.walden_provider.PrimeFacesSession.from_selenium",
+            MagicMock(side_effect=DirectHttpError("no cookies")),
+        )
+        assert provider._try_direct_http_booking(MagicMock(), self.SLOT, 4, None) is None
+
+    def _patch_booker(
+        self, monkeypatch: pytest.MonkeyPatch, result: object
+    ) -> tuple[MagicMock, MagicMock]:
+        session = MagicMock()
+        monkeypatch.setattr(
+            "app.providers.walden_provider.PrimeFacesSession.from_selenium",
+            MagicMock(return_value=session),
+        )
+        booker = MagicMock()
+        booker.book.return_value = result
+        monkeypatch.setattr(
+            "app.providers.walden_provider.DirectHttpBooker", MagicMock(return_value=booker)
+        )
+        return booker, session
+
+    def test_success_is_returned_as_a_chain_result(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        result = self._direct_result(success=True, phase="complete", timing={"totalMs": 300})
+        booker, session = self._patch_booker(monkeypatch, result)
+
+        chain_result = provider._try_direct_http_booking(MagicMock(), self.SLOT, 4, 1770000000000)
+
+        assert chain_result is not None
+        assert chain_result["success"] is True
+        assert chain_result["phase"] == "complete"
+        booker.book.assert_called_once_with(4, target_timestamp_ms=1770000000000)
+        session.close.assert_called_once()
+
+    def test_blocked_is_honored_not_retried(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Losing the slot is a real answer - re-clicking in the browser is not."""
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        result = self._direct_result(blocked=True, phase="reserve_click", error="blocked")
+        self._patch_booker(monkeypatch, result)
+
+        chain_result = provider._try_direct_http_booking(MagicMock(), self.SLOT, 4, None)
+
+        assert chain_result is not None
+        assert chain_result["blocked"] is True
+
+    @pytest.mark.parametrize("phase", ["init", "precision_wait", "reserve_click"])
+    def test_failure_before_submission_falls_back(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch, phase: str
+    ) -> None:
+        """Nothing was reserved, so the JS chain still gets its shot."""
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        result = self._direct_result(phase=phase, error="boom")
+        self._patch_booker(monkeypatch, result)
+
+        assert provider._try_direct_http_booking(MagicMock(), self.SLOT, 4, None) is None
+
+    @pytest.mark.parametrize("phase", ["player_count", "tbd_guests", "book_now"])
+    def test_failure_after_reserve_is_not_retried_in_the_browser(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch, phase: str
+    ) -> None:
+        """Reserve was accepted; the browser's DOM no longer reflects reality."""
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        result = self._direct_result(phase=phase, error="boom")
+        self._patch_booker(monkeypatch, result)
+
+        chain_result = provider._try_direct_http_booking(MagicMock(), self.SLOT, 4, None)
+
+        assert chain_result is not None
+        assert chain_result["success"] is False
+        assert chain_result["phase"] == phase
+
+    def test_session_is_closed_even_when_book_raises(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        booker, session = self._patch_booker(monkeypatch, None)
+        booker.book.side_effect = DirectHttpError("exploded")
+
+        with pytest.raises(DirectHttpError):
+            provider._try_direct_http_booking(MagicMock(), self.SLOT, 4, None)
+        session.close.assert_called_once()
+
+    def test_js_chain_runs_when_direct_path_declines(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End to end: flag off means the timed JS chain is still what books."""
+        monkeypatch.setattr(settings, "walden_direct_http_booking", False)
+        monkeypatch.setattr(
+            provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
+        )
+        timed_chain = MagicMock(
+            return_value={
+                "success": True,
+                "blocked": False,
+                "phase": "complete",
+                "error": None,
+                "timing": {},
+            }
+        )
+        monkeypatch.setattr(provider, "_stage_timed_booking_chain_js", timed_chain)
+        monkeypatch.setattr(provider, "_verify_booking_success", MagicMock(return_value=True))
+        monkeypatch.setattr(
+            provider, "_extract_confirmation_number", MagicMock(return_value="ABC123")
+        )
+
+        result = provider._find_and_book_time_slot_sync(
+            MagicMock(),
+            target_time=time(8, 42),
+            num_players=4,
+            fallback_window_minutes=32,
+            skip_scroll=True,
+            use_fast_js=True,
+            execute_at_timestamp_ms=1770000000000,
+        )
+
+        assert result.success is True
+        timed_chain.assert_called_once()
+
+    def test_direct_result_short_circuits_the_js_chain(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the direct path books, the browser chain must not also fire."""
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        monkeypatch.setattr(
+            provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
+        )
+        monkeypatch.setattr(
+            provider,
+            "_try_direct_http_booking",
+            MagicMock(
+                return_value={
+                    "success": True,
+                    "blocked": False,
+                    "phase": "complete",
+                    "error": None,
+                    "timing": {"totalMs": 250},
+                }
+            ),
+        )
+        timed_chain = MagicMock()
+        fast_chain = MagicMock()
+        monkeypatch.setattr(provider, "_stage_timed_booking_chain_js", timed_chain)
+        monkeypatch.setattr(provider, "_execute_fast_booking_chain_js", fast_chain)
+        monkeypatch.setattr(provider, "_verify_booking_success", MagicMock(return_value=True))
+        monkeypatch.setattr(
+            provider, "_extract_confirmation_number", MagicMock(return_value="ABC123")
+        )
+
+        result = provider._find_and_book_time_slot_sync(
+            MagicMock(),
+            target_time=time(8, 42),
+            num_players=4,
+            fallback_window_minutes=32,
+            skip_scroll=True,
+            use_fast_js=True,
+            execute_at_timestamp_ms=1770000000000,
+        )
+
+        assert result.success is True
+        timed_chain.assert_not_called()
+        fast_chain.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -2584,6 +2584,7 @@ class TestDirectHttpBookingWiring:
     def test_success_is_returned_as_a_chain_result(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """Success is returned as a chain result."""
         monkeypatch.setattr(settings, "walden_direct_http_booking", True)
         result = self._direct_result(success=True, phase="complete", timing={"totalMs": 300})
         booker, session = self._patch_booker(monkeypatch, result)
@@ -2609,7 +2610,7 @@ class TestDirectHttpBookingWiring:
         assert chain_result is not None
         assert chain_result["blocked"] is True
 
-    @pytest.mark.parametrize("phase", ["init", "precision_wait", "reserve_click"])
+    @pytest.mark.parametrize("phase", ["init", "precision_wait", "reserve_staged"])
     def test_failure_before_submission_falls_back(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch, phase: str
     ) -> None:
@@ -2620,7 +2621,7 @@ class TestDirectHttpBookingWiring:
 
         assert provider._try_direct_http_booking(MagicMock(), self.SLOT, 4, None) is None
 
-    @pytest.mark.parametrize("phase", ["player_count", "tbd_guests", "book_now"])
+    @pytest.mark.parametrize("phase", ["reserve_sent", "player_count", "tbd_guests", "book_now"])
     def test_failure_after_reserve_is_not_retried_in_the_browser(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch, phase: str
     ) -> None:
@@ -2635,16 +2636,34 @@ class TestDirectHttpBookingWiring:
         assert chain_result["success"] is False
         assert chain_result["phase"] == phase
 
-    def test_session_is_closed_even_when_book_raises(
+    def test_book_failure_is_reported_not_raised(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """An escape here would reach _book_tee_time_sync, which only handles
+        WebDriver errors, and raise instead of returning a BookingResult."""
         monkeypatch.setattr(settings, "walden_direct_http_booking", True)
         booker, session = self._patch_booker(monkeypatch, None)
         booker.book.side_effect = DirectHttpError("exploded")
 
-        with pytest.raises(DirectHttpError):
-            provider._try_direct_http_booking(MagicMock(), self.SLOT, 4, None)
+        chain_result = provider._try_direct_http_booking(MagicMock(), self.SLOT, 4, None)
+
+        # Reserve may already have been sent, so this is terminal, not a retry.
+        assert chain_result is not None
+        assert chain_result["success"] is False
+        assert "exploded" in chain_result["error"]
         session.close.assert_called_once()
+
+    def test_unexpected_staging_error_falls_back(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Staging parses live markup; a malformed page can raise anything."""
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        monkeypatch.setattr(
+            "app.providers.walden_provider.PrimeFacesSession.from_selenium",
+            MagicMock(side_effect=AttributeError("unexpected markup")),
+        )
+
+        assert provider._try_direct_http_booking(MagicMock(), self.SLOT, 4, None) is None
 
     def test_js_chain_runs_when_direct_path_declines(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
@@ -2681,6 +2700,98 @@ class TestDirectHttpBookingWiring:
 
         assert result.success is True
         timed_chain.assert_called_once()
+
+    def test_direct_success_verifies_against_the_response_not_the_browser(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The regression that stubs used to hide.
+
+        A direct-HTTP booking never touches the browser, so the DOM still shows
+        the pre-booking tee sheet. Verification is left unstubbed here: reading
+        the driver would find no confirmation and report a completed booking as
+        failed.
+        """
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        driver = MagicMock()
+        # The browser still shows the tee sheet - no booking confirmation.
+        driver.current_url = "https://www.waldengolf.com/group/pages/book-a-tee-time"
+        driver.page_source = "<html><body>Tee sheet - slots unavailable</body></html>"
+        driver.find_element.side_effect = Exception("no body text")
+
+        monkeypatch.setattr(
+            provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
+        )
+        monkeypatch.setattr(
+            provider,
+            "_try_direct_http_booking",
+            MagicMock(
+                return_value={
+                    "success": True,
+                    "blocked": False,
+                    "phase": "complete",
+                    "error": None,
+                    "timing": {"totalMs": 250},
+                    "finalMarkup": (
+                        "<div><h2>Booking confirmed</h2>"
+                        "<p>Confirmation #12345 - your tee time is booked.</p></div>"
+                    ),
+                }
+            ),
+        )
+        timed_chain = MagicMock()
+        monkeypatch.setattr(provider, "_stage_timed_booking_chain_js", timed_chain)
+
+        result = provider._find_and_book_time_slot_sync(
+            driver,
+            target_time=time(8, 42),
+            num_players=4,
+            fallback_window_minutes=32,
+            skip_scroll=True,
+            use_fast_js=True,
+            execute_at_timestamp_ms=1770000000000,
+        )
+
+        assert result.success is True
+        assert result.confirmation_number == "12345"
+        timed_chain.assert_not_called()
+
+    def test_direct_success_without_confirmation_is_reported_as_failure(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The chain finishing is not the same as the reservation being made."""
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        monkeypatch.setattr(
+            provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
+        )
+        monkeypatch.setattr(
+            provider,
+            "_try_direct_http_booking",
+            MagicMock(
+                return_value={
+                    "success": True,
+                    "blocked": False,
+                    "phase": "complete",
+                    "error": None,
+                    "timing": {},
+                    "finalMarkup": "<div><p>Select the number of players.</p></div>",
+                }
+            ),
+        )
+        monkeypatch.setattr(provider, "_capture_diagnostic_info", MagicMock())
+
+        result = provider._find_and_book_time_slot_sync(
+            MagicMock(),
+            target_time=time(8, 42),
+            num_players=4,
+            fallback_window_minutes=32,
+            skip_scroll=True,
+            use_fast_js=True,
+            execute_at_timestamp_ms=1770000000000,
+        )
+
+        assert result.success is False
+        assert result.error_message is not None
+        assert "did not confirm" in result.error_message
 
     def test_direct_result_short_circuits_the_js_chain(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## What this is

The direct-HTTP path flagged as future work in #116 — `scripts/capture_booking_traffic.py` was added there to record "the PrimeFaces request sequence ... so we can replay it over direct HTTP at 6:30:00 without a browser on the critical path." This implements the replay.

## How it works

The tee sheet is a JSF/PrimeFaces portlet inside Liferay. Every click the JS chain performs is, underneath, one `application/x-www-form-urlencoded` POST that PrimeFaces builds from the element's `PrimeFaces.ab({...})` handler:

```
POST  https://www.waldengolf.com/group/pages/book-a-tee-time?...&p_p_lifecycle=2&..._jsfBridgeAjax=true

  javax.faces.partial.ajax     = true
  javax.faces.source           = ..:teeTimeSlots:67:slotTee:0:reserve_button
  javax.faces.partial.execute  = @all
  javax.faces.partial.render   = _teeTimePortlet_WAR_northstarportlet_:teeTimeForm
  javax.faces.ViewState        = 3597409561974113966:-1460199378475720306
  ..:teeTimeSlots:67:slotTee:0:reserve_button = (same id, activating the control)
  + the form's 12 serialized fields (selected course, selected date, ...)
```

The server answers with a `partial-response` XML document carrying re-rendered markup and a fresh ViewState. Built off the captured tee sheet in `tests/fixtures/`, the whole Reserve request is **1,938 bytes**.

## Why it should be faster

Not the click instant — the staged JS chain (#113, #116) already fires with ~0 ms drift. It's the work *between* clicks:

| | JS chain | Direct HTTP |
|---|---|---|
| Response handling | the handler's update target is the **whole form**; Chrome parses ~700 KB + style/layout before the next element exists | XML parse of the payload |
| Step sequencing | polls the DOM every 10 ms to notice the step finished | next POST goes out when the response lands |
| TBD guests | fixed 200 ms sleep per guest so PrimeFaces can settle (600 ms for a foursome) | 3 sequential POSTs, no fixed delay |
| At the target instant | pre-located node, `.click()`, browser builds the XHR | pre-serialized body written to an already-open TLS socket |
| Next booking in a batch | re-navigate + re-scroll the tee sheet (~23 s, per #122) | another POST on the same session |

`prepare()` does all the expensive work before the window opens: parse the sheet, resolve the handler, urlencode the body, complete DNS/TCP/TLS. `book()` waits out the remaining time and writes bytes.

## Scope

Deliberately narrow. Login, navigation, course/date selection and slot discovery stay in Selenium — they run minutes before the window, where latency is irrelevant and the current path is proven. The HTTP session is **adopted from the live driver**, inheriting its cookies and the ~12 form fields that encode everything the browser built up (selected course, selected date).

**The booking window is unchanged.** Reserve fires at the same target timestamp the JS chain would have clicked at, never earlier.

Every step after Reserve is derived from the markup the server just returned, by parsing the same handler the browser would have executed — so generated component ids churning (`j_idt1076` → `j_idt1082`) doesn't break the chain.

## Safety

Off by default behind `WALDEN_DIRECT_HTTP_BOOKING`. The fallback policy keys on the chain phase, and the phase names are exported from `walden_http_booker` and imported by the provider so the two cannot drift:

- `init` / `precision_wait` / `reserve_staged` → nothing reached the server, fall back to the JS chain
- `reserve_sent` → the request is on the wire and its outcome is unknown; **never** retried in the browser, because that would race our own reservation
- `player_count` / `tbd_guests` / `book_now` → Reserve was accepted; report rather than re-click against a browser DOM that no longer reflects reality
- success, or a blocked slot → honored directly

Verification uses the direct path's own final partial response, not the browser DOM — the DOM is untouched by this path, so reading it would report a completed booking as failed. Unexpected exceptions become failed attempts rather than aborting a booking run.

## Trying it out

`scripts/probe_direct_http.py` verifies the transport end to end against the live site — cookies, ViewState, encodedURL, namespaced params — and times both transports on the same interaction. It exercises only the tee sheet's read-only "Legends" dialog; **it never touches Reserve and never submits a booking.**

```
poetry run python scripts/probe_direct_http.py --samples 10
```

It reports per-interaction median for each transport and extrapolates to the 6 interactions of a 4-player booking.

## Testing

`635 passed, 3 skipped`; `ruff` and `mypy --strict` clean.

Protocol tests run against the **real captured tee sheet**, not hand-written mocks:

- every `PrimeFaces.ab` handler on the captured page parses
- the POST URL resolves to `javax.faces.encodedURL` (lifecycle=2), not the form action
- form serialization reproduces the 12 fields a browser would submit, skipping unchecked/disabled/button controls
- the built Reserve body carries the right partial-request params and the browser's accumulated state

Chain tests cover the full four-player sequence, single-player (no TBD step), blocked-slot detection stopping the chain, the issue #105 time-filter collision, both PrimeFaces control shapes (inline handler and widget-script behavior), header-row exclusion in the player-row fallback, and a failure in each phase. Session tests cover `from_selenium`, `warm_up`, expired views and redirect responses. Wiring tests cover the fallback policy per phase, that a direct success prevents the JS chain from also firing, and — with verification left unstubbed — that a direct success is reported as a success.

## Not verified here

The post-Reserve markup (player modal, TBD rows, Book Now) isn't in the captured fixtures, so those steps are built to re-derive their requests from the returned markup rather than against a known-good capture. That is exactly what the flag and the phase-aware fallback are for — the probe script validates the transport, and the first real run should be one where losing the slot is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmRkWo1vrrA1PcqhnFSggj

## Summary by CodeRabbit

* **New Features**
  * Added an optional direct HTTP booking mode for faster Walden Golf reservations.
  * Existing browser-based booking remains the default and provides safe fallback when possible.
  * Added support for timed reservation workflows, slot validation, blocked-slot detection, and booking status reporting.
  * Added a non-booking probe command to compare direct HTTP and browser request performance.

* **Documentation**
  * Documented configuration, fallback behavior, and probe usage.

* **Tests**
  * Added comprehensive coverage for direct booking, error handling, timing, and fallback scenarios.