### PR TITLE
fix: stop losing booking results to an OOM kill mid-attempt

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,9 @@
+import asyncio
 import logging
 import sys
 from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
+from typing import TYPE_CHECKING
 
 from fastapi import FastAPI
 
@@ -11,6 +13,9 @@ from app.models.database import init_db
 from app.providers.base import ReservationProvider
 from app.providers.walden_provider import MockWaldenProvider, WaldenGolfProvider
 from app.services.booking_service import booking_service
+
+if TYPE_CHECKING:
+    from app.services.discord_gateway import DiscordGateway
 
 
 def configure_logging() -> None:
@@ -33,10 +38,16 @@ def configure_logging() -> None:
     # Ensure our app loggers use the configured level
     logging.getLogger("app").setLevel(log_level)
 
-    # Reduce noise from third-party libraries unless in debug mode
-    if log_level > logging.DEBUG:
-        logging.getLogger("selenium").setLevel(logging.WARNING)
-        logging.getLogger("urllib3").setLevel(logging.WARNING)
+    # Silence the WebDriver wire loggers unconditionally - NOT gated on LOG_LEVEL.
+    #
+    # selenium.webdriver.remote.remote_connection logs every command payload at
+    # DEBUG, which includes the send_keys body used to fill the login form. With
+    # LOG_LEVEL=DEBUG (how this runs in production, to get BOOKING_DEBUG output)
+    # that wrote the Walden member number and password to Cloud Logging in
+    # cleartext on every booking run. These loggers must never be allowed to
+    # emit below WARNING regardless of how verbose the app itself is.
+    for wire_logger in ("selenium", "urllib3", "websockets", "httpcore"):
+        logging.getLogger(wire_logger).setLevel(logging.WARNING)
 
 
 configure_logging()
@@ -79,11 +90,41 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         provider = MockWaldenProvider()
     booking_service.set_reservation_provider(provider)
 
+    # Any booking still IN_PROGRESS is left over from a process that died
+    # mid-attempt, since no attempt survives a restart. Resolve those and tell
+    # the user, rather than leaving the row stuck and the request unanswered.
+    # This runs as a background task so a slow or unreachable messaging channel
+    # cannot block startup, and it waits for the gateway first so the
+    # notification has somewhere to go.
+    reconcile_task = asyncio.create_task(
+        _reconcile_after_startup(discord_gateway), name="reconcile-interrupted-bookings"
+    )
+
     yield
 
+    # Cancel and collect the reconcile task before tearing the gateway down, so
+    # it can't be left pending against a closed client.
+    reconcile_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await reconcile_task
+    # Let any booking attempt still in flight report its outcome before the
+    # provider closes underneath it.
+    await booking_service.wait_for_background_bookings()
     if discord_gateway is not None:
         await discord_gateway.stop()
     await provider.close()
+
+
+async def _reconcile_after_startup(discord_gateway: "DiscordGateway | None") -> None:
+    """Reconcile interrupted bookings once the messaging channel can deliver."""
+    try:
+        if discord_gateway is not None:
+            await discord_gateway.client.wait_until_ready()
+        await booking_service.reconcile_interrupted_bookings()
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.exception("Failed to reconcile interrupted bookings at startup")
 
 
 app = FastAPI(

--- a/app/main.py
+++ b/app/main.py
@@ -53,6 +53,16 @@ def configure_logging() -> None:
 configure_logging()
 logger = logging.getLogger(__name__)
 
+# How long startup reconciliation waits for the Discord gateway before giving up
+# on delivering its notifications and resolving the stuck rows regardless.
+GATEWAY_READY_TIMEOUT_SECONDS = 60
+
+# How long shutdown waits for in-flight booking attempts to report their result.
+# Cloud Run allows roughly 10s between SIGTERM and SIGKILL, so this only needs
+# to cover an attempt that is seconds from finishing; a hung Selenium run must
+# not hold up gateway and provider cleanup.
+SHUTDOWN_BOOKING_TIMEOUT_SECONDS = 8
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
@@ -108,8 +118,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     with suppress(asyncio.CancelledError):
         await reconcile_task
     # Let any booking attempt still in flight report its outcome before the
-    # provider closes underneath it.
-    await booking_service.wait_for_background_bookings()
+    # provider closes underneath it - but bounded, because a hung Selenium run
+    # would otherwise block gateway and provider cleanup until the platform
+    # kills the container.
+    await booking_service.wait_for_background_bookings(timeout=SHUTDOWN_BOOKING_TIMEOUT_SECONDS)
     if discord_gateway is not None:
         await discord_gateway.stop()
     await provider.close()
@@ -119,7 +131,21 @@ async def _reconcile_after_startup(discord_gateway: "DiscordGateway | None") -> 
     """Reconcile interrupted bookings once the messaging channel can deliver."""
     try:
         if discord_gateway is not None:
-            await discord_gateway.client.wait_until_ready()
+            try:
+                await asyncio.wait_for(
+                    discord_gateway.client.wait_until_ready(),
+                    timeout=GATEWAY_READY_TIMEOUT_SECONDS,
+                )
+            except TimeoutError:
+                # A rejected token or an unreachable gateway would otherwise
+                # leave this waiting forever, and the stuck rows would never be
+                # resolved. Resolving them matters more than delivering the
+                # notification, so carry on and record why.
+                logger.warning(
+                    "Discord gateway not ready after %ss; reconciling anyway - "
+                    "interrupted-booking notifications may not be delivered",
+                    GATEWAY_READY_TIMEOUT_SECONDS,
+                )
         await booking_service.reconcile_interrupted_bookings()
     except asyncio.CancelledError:
         raise

--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -62,6 +62,10 @@ class BookingService:
         # holds weak references to tasks, so without this a booking run could be
         # garbage collected mid-attempt.
         self._background_tasks: set[asyncio.Task[None]] = set()
+        # When this instance came up, in the same naive-UTC space the database
+        # stamps onto updated_at. Startup reconciliation uses it to tell rows
+        # orphaned by a previous process from attempts running right now.
+        self._started_at = datetime.now(UTC).replace(tzinfo=None)
 
     def set_reservation_provider(self, provider: ReservationProvider) -> None:
         """Set the reservation provider for executing bookings."""
@@ -394,29 +398,49 @@ class BookingService:
         at IN_PROGRESS. If the process dies in that window (an OOM kill, a
         deploy, a Cloud Run instance replacement), nothing ever moves the row
         off IN_PROGRESS and nothing tells the user - the request simply goes
-        quiet. Because no attempt can survive a restart, any IN_PROGRESS row
-        found at startup is by definition orphaned.
+        quiet.
+
+        Only rows last touched before this process started are treated as
+        orphans. This instance can set IN_PROGRESS itself - through the REST
+        API, the scheduler's batch job, or a confirmed chat booking - and those
+        attempts are still running, so failing them here would both lie to the
+        user and clobber the real outcome they are about to write.
 
         Each orphan is marked FAILED with an explanation that the reservation's
         true state is unknown, and the user is notified. Callers should invoke
         this once at startup, after the messaging channel is ready.
 
         Returns:
-            The bookings that were reconciled.
+            The bookings that were successfully reconciled.
         """
-        orphaned = await database_service.get_bookings(status=BookingStatus.IN_PROGRESS)
+        in_progress = await database_service.get_bookings(status=BookingStatus.IN_PROGRESS)
+        orphaned = [b for b in in_progress if b.updated_at < self._started_at]
         if not orphaned:
             return []
 
+        live = len(in_progress) - len(orphaned)
         logger.warning(
-            "Found %d booking(s) stuck IN_PROGRESS from a previous run; marking failed",
+            "Found %d booking(s) stuck IN_PROGRESS from a previous run; marking failed "
+            "(%d in-progress booking(s) started by this instance left alone)",
             len(orphaned),
+            live,
         )
 
+        reconciled: list[TeeTimeBooking] = []
         for booking in orphaned:
             booking.status = BookingStatus.FAILED
             booking.error_message = INTERRUPTED_ERROR_MESSAGE
-            await database_service.update_booking(booking)
+
+            try:
+                await database_service.update_booking(booking)
+            except Exception:
+                # One unwritable row must not strand every other orphan. Skip it
+                # and leave it for the next startup rather than telling the user
+                # about a failure we could not actually record.
+                logger.exception("Could not reconcile interrupted booking %s", booking.id)
+                continue
+
+            reconciled.append(booking)
 
             date_str = booking.request.requested_date.strftime("%A, %B %d")
             time_str = booking.request.requested_time.strftime("%I:%M %p")
@@ -434,7 +458,7 @@ class BookingService:
                 # A notification failure must not stop us reconciling the rest.
                 logger.exception("Could not notify user about interrupted booking %s", booking.id)
 
-        return orphaned
+        return reconciled
 
     async def _handle_cancel_intent(self, session: UserSession, parsed: ParsedIntent) -> str:
         user_bookings = await database_service.get_bookings(phone_number=session.phone_number)
@@ -760,14 +784,35 @@ class BookingService:
         except Exception:
             logger.exception("Background booking execution failed for %s", booking_id)
 
-    async def wait_for_background_bookings(self) -> None:
+    async def wait_for_background_bookings(self, timeout: float | None = None) -> None:
         """Wait for all in-flight background booking attempts to finish.
 
         Used by shutdown and by tests, which need the attempt to complete before
         asserting on its result.
+
+        Args:
+            timeout: Seconds to wait before cancelling whatever is still
+                running. A booking attempt drives Selenium and can hang, so
+                shutdown passes a bound to keep one stuck attempt from blocking
+                gateway and provider cleanup. None waits indefinitely.
         """
         while self._background_tasks:
-            await asyncio.gather(*tuple(self._background_tasks), return_exceptions=True)
+            pending = tuple(self._background_tasks)
+            if timeout is None:
+                await asyncio.gather(*pending, return_exceptions=True)
+                continue
+
+            _, still_running = await asyncio.wait(pending, timeout=timeout)
+            if still_running:
+                logger.warning(
+                    "Cancelling %d booking attempt(s) still running after %ss",
+                    len(still_running),
+                    timeout,
+                )
+                for task in still_running:
+                    task.cancel()
+                await asyncio.gather(*still_running, return_exceptions=True)
+            return
 
     async def get_booking(self, booking_id: str) -> TeeTimeBooking | None:
         """

--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -5,6 +5,8 @@ This module provides the core business logic for handling SMS conversations,
 processing booking requests, and executing reservations at the scheduled time.
 """
 
+import asyncio
+import logging
 import uuid
 from datetime import UTC, date, datetime, timedelta
 
@@ -22,6 +24,17 @@ from app.services.database_service import database_service
 from app.services.gemini_service import gemini_service
 from app.services.sms_service import sms_service
 from app.utils.timezone import CTDateTime
+
+logger = logging.getLogger(__name__)
+
+# Error recorded on bookings that were still IN_PROGRESS when the process died.
+# The club website may or may not have accepted the reservation, so the message
+# deliberately tells the user to verify rather than asserting either outcome.
+INTERRUPTED_ERROR_MESSAGE = (
+    "The booking attempt was interrupted before it finished (the service "
+    "restarted mid-attempt). The reservation may or may not have gone through - "
+    "please check the club website before rebooking."
+)
 
 
 class BookingService:
@@ -45,6 +58,10 @@ class BookingService:
     def __init__(self) -> None:
         """Initialize the booking service."""
         self._reservation_provider: ReservationProvider | None = None
+        # Strong references to in-flight background booking tasks. asyncio only
+        # holds weak references to tasks, so without this a booking run could be
+        # garbage collected mid-attempt.
+        self._background_tasks: set[asyncio.Task[None]] = set()
 
     def set_reservation_provider(self, provider: ReservationProvider) -> None:
         """Set the reservation provider for executing bookings."""
@@ -206,9 +223,13 @@ class BookingService:
                 f"I'll text you with more details."
             )
         elif booking.status == BookingStatus.IN_PROGRESS:
+            # The booking window is already open, so the attempt is running right
+            # now in the background. This is the acknowledgement the user gets
+            # up front; the outcome arrives as a separate message.
             return (
-                f"Booking in progress for {date_str} at {time_str} "
-                f"for {request.num_players} players. I'll text you with the result."
+                f"On it - booking {date_str} at {time_str} "
+                f"for {request.num_players} players now. "
+                f"This takes a minute or two; I'll message you with the result."
             )
 
         exec_time = booking.scheduled_execution_time
@@ -300,8 +321,8 @@ class BookingService:
                         )
                     elif booking.status == BookingStatus.IN_PROGRESS:
                         response_parts.append(
-                            f"Booking in progress for {date_str} at {time_str}. "
-                            "I'll text you with the result."
+                            f"On it - booking {date_str} at {time_str} now. "
+                            "I'll message you with the result."
                         )
 
         if failed_requests:
@@ -318,19 +339,102 @@ class BookingService:
         if not user_bookings:
             return "You don't have any scheduled bookings. Would you like to book a tee time?"
 
-        pending = [
-            b for b in user_bookings if b.status in [BookingStatus.PENDING, BookingStatus.SCHEDULED]
+        today = CTDateTime.now().date()
+        upcoming = [b for b in user_bookings if b.request.requested_date >= today]
+
+        # IN_PROGRESS and SUCCESS belong here alongside PENDING/SCHEDULED. Leaving
+        # them out once made a booking that was mid-attempt look like it had never
+        # been created at all, which is worse than showing an unfinished state.
+        active = [
+            b
+            for b in upcoming
+            if b.status
+            in [
+                BookingStatus.PENDING,
+                BookingStatus.SCHEDULED,
+                BookingStatus.IN_PROGRESS,
+                BookingStatus.SUCCESS,
+            ]
         ]
-        if not pending:
+        # Failures are only worth surfacing for tee times that haven't happened
+        # yet - those are the ones the user can still do something about.
+        failed = [b for b in upcoming if b.status == BookingStatus.FAILED]
+
+        if not active and not failed:
             return "You don't have any upcoming bookings. Would you like to book a tee time?"
 
-        status_lines = []
-        for booking in pending:
+        def describe(booking: TeeTimeBooking) -> str:
             date_str = booking.request.requested_date.strftime("%A, %B %d")
             time_str = booking.request.requested_time.strftime("%I:%M %p")
-            status_lines.append(f"- {date_str} at {time_str}: {booking.status.value}")
+            if booking.status == BookingStatus.SUCCESS and booking.actual_booked_time:
+                time_str = booking.actual_booked_time.strftime("%I:%M %p")
+            return f"- {date_str} at {time_str}: {booking.status.value}"
 
-        return "Your upcoming bookings:\n" + "\n".join(status_lines)
+        active.sort(key=lambda b: (b.request.requested_date, b.request.requested_time))
+        failed.sort(key=lambda b: (b.request.requested_date, b.request.requested_time))
+
+        sections = []
+        if active:
+            sections.append("Your upcoming bookings:\n" + "\n".join(describe(b) for b in active))
+        if failed:
+            failure_lines = []
+            for booking in failed:
+                line = describe(booking)
+                if booking.error_message:
+                    line += f"\n  {booking.error_message}"
+                failure_lines.append(line)
+            sections.append("Recent failures:\n" + "\n".join(failure_lines))
+
+        return "\n\n".join(sections)
+
+    async def reconcile_interrupted_bookings(self) -> list[TeeTimeBooking]:
+        """Resolve bookings left IN_PROGRESS by a crash or restart.
+
+        A booking attempt drives Selenium for a minute or more with the row held
+        at IN_PROGRESS. If the process dies in that window (an OOM kill, a
+        deploy, a Cloud Run instance replacement), nothing ever moves the row
+        off IN_PROGRESS and nothing tells the user - the request simply goes
+        quiet. Because no attempt can survive a restart, any IN_PROGRESS row
+        found at startup is by definition orphaned.
+
+        Each orphan is marked FAILED with an explanation that the reservation's
+        true state is unknown, and the user is notified. Callers should invoke
+        this once at startup, after the messaging channel is ready.
+
+        Returns:
+            The bookings that were reconciled.
+        """
+        orphaned = await database_service.get_bookings(status=BookingStatus.IN_PROGRESS)
+        if not orphaned:
+            return []
+
+        logger.warning(
+            "Found %d booking(s) stuck IN_PROGRESS from a previous run; marking failed",
+            len(orphaned),
+        )
+
+        for booking in orphaned:
+            booking.status = BookingStatus.FAILED
+            booking.error_message = INTERRUPTED_ERROR_MESSAGE
+            await database_service.update_booking(booking)
+
+            date_str = booking.request.requested_date.strftime("%A, %B %d")
+            time_str = booking.request.requested_time.strftime("%I:%M %p")
+            booking_details = f"{date_str} at {time_str} for {booking.request.num_players} players"
+            logger.warning("Reconciled interrupted booking %s (%s)", booking.id, booking_details)
+
+            try:
+                await sms_service.send_booking_failure(
+                    booking.phone_number,
+                    INTERRUPTED_ERROR_MESSAGE,
+                    booking_details=booking_details,
+                    origin_channel_id=booking.origin_channel_id,
+                )
+            except Exception:
+                # A notification failure must not stop us reconciling the rest.
+                logger.exception("Could not notify user about interrupted booking %s", booking.id)
+
+        return orphaned
 
     async def _handle_cancel_intent(self, session: UserSession, parsed: ParsedIntent) -> str:
         user_bookings = await database_service.get_bookings(phone_number=session.phone_number)
@@ -556,8 +660,10 @@ class BookingService:
         conversation flow and the REST API.
 
         If the calculated execution time is in the past (i.e., the booking window
-        has already opened), the booking is executed immediately instead of being
-        scheduled for later.
+        has already opened), the attempt starts immediately in the background
+        rather than being scheduled for later. This call returns as soon as the
+        record is created, with the booking in IN_PROGRESS; the outcome is
+        reported to the user by execute_booking when the attempt finishes.
 
         Multi-player bookings (2+ players) are rejected if the tee time is within
         48 hours, because the Walden Golf website disables TBD guest placeholders
@@ -618,10 +724,50 @@ class BookingService:
         if exec_ct <= now_ct:
             booking_id_opt: str | None = created_booking.id
             if booking_id_opt is not None:
-                await self.execute_booking(booking_id_opt)
-                return await database_service.get_booking(booking_id_opt) or created_booking
+                # The booking window is already open, so this runs now rather
+                # than waiting for the scheduler. Run it as a background task
+                # instead of awaiting it: a booking attempt drives Selenium for
+                # a minute or more, and the caller (the Discord gateway) cannot
+                # send its reply until this returns. Awaiting it here means any
+                # crash during the attempt takes the user's reply down with it,
+                # leaving them with silence. The caller now acknowledges
+                # immediately and execute_booking sends the real outcome when
+                # it lands.
+                created_booking.status = BookingStatus.IN_PROGRESS
+                await database_service.update_booking(created_booking)
+                self._spawn_booking_execution(booking_id_opt)
 
         return created_booking
+
+    def _spawn_booking_execution(self, booking_id: str) -> None:
+        """Run execute_booking as a tracked background task."""
+        task = asyncio.create_task(
+            self._execute_booking_in_background(booking_id),
+            name=f"execute-booking-{booking_id}",
+        )
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    async def _execute_booking_in_background(self, booking_id: str) -> None:
+        """Execute a booking, ensuring failures are logged rather than swallowed.
+
+        execute_booking already reports its own outcome to the user and records
+        it on the booking row. This wrapper only guards against an exception
+        escaping into an unretrieved task result, where it would vanish silently.
+        """
+        try:
+            await self.execute_booking(booking_id)
+        except Exception:
+            logger.exception("Background booking execution failed for %s", booking_id)
+
+    async def wait_for_background_bookings(self) -> None:
+        """Wait for all in-flight background booking attempts to finish.
+
+        Used by shutdown and by tests, which need the attempt to complete before
+        asserting on its result.
+        """
+        while self._background_tasks:
+            await asyncio.gather(*tuple(self._background_tasks), return_exceptions=True)
 
     async def get_booking(self, booking_id: str) -> TeeTimeBooking | None:
         """

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -17,7 +17,9 @@ messaging_channel = "discord"
 # 1 (enforced by a precondition): the gateway holds a persistent WebSocket, so
 # 0 drops the connection and >1 double-processes every message. Switch to
 # twilio before relaxing these.
-cloud_run_memory        = "1Gi"
+# 2Gi is the floor: headless Chrome plus the always-on gateway OOM-kills a 1Gi
+# container mid-booking, which silently loses the result notification.
+cloud_run_memory        = "2Gi"
 cloud_run_cpu           = "1"
 cloud_run_max_instances = 1
 cloud_run_min_instances = 1

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,6 +38,22 @@ variable "cloud_run_memory" {
   EOT
   type        = string
   default     = "2Gi"
+
+  # The default only applies when a caller omits the variable; a tfvars override
+  # could still set 1Gi and silently reintroduce the OOM. Reject that outright.
+  #
+  # Normalises to MiB and compares once. Written as a single try() because
+  # Terraform does not guarantee short-circuit evaluation of && - a malformed
+  # value must fall through to false rather than erroring out of the check
+  # itself. Avoids endswith(), which needs Terraform 1.3 (this module allows 1.0).
+  validation {
+    condition = try(
+      tonumber(regex("^([0-9]+)(Mi|Gi)$", var.cloud_run_memory)[0]) *
+      (regex("^([0-9]+)(Mi|Gi)$", var.cloud_run_memory)[1] == "Gi" ? 1024 : 1) >= 2048,
+      false
+    )
+    error_message = "cloud_run_memory must be at least 2Gi (or 2048Mi), formatted like \"2Gi\" or \"2048Mi\". Headless Chrome OOM-killed the container at 1Gi, losing the booking result."
+  }
 }
 
 variable "cloud_run_cpu" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,9 +28,16 @@ variable "github_branch" {
 }
 
 variable "cloud_run_memory" {
-  description = "Memory allocation for Cloud Run service"
+  description = <<-EOT
+    Memory allocation for Cloud Run service.
+
+    Headless Chrome peaks around 1 GiB on its own while a booking page with
+    150+ slots is loaded, on top of the always-on FastAPI process and Discord
+    gateway. At 1Gi the container was OOM-killed mid-booking (2026-08-02),
+    losing the result notification. Do not lower this below 2Gi.
+  EOT
   type        = string
-  default     = "1Gi"
+  default     = "2Gi"
 }
 
 variable "cloud_run_cpu" {

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -7,7 +7,7 @@ and SMS conversations.
 
 import asyncio
 from collections.abc import Callable
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -2051,6 +2051,7 @@ class TestStatusIntentVisibility:
         requested_date: date,
         requested_time: time = time(8, 0),
         error_message: str | None = None,
+        actual_booked_time: time | None = None,
     ) -> TeeTimeBooking:
         return TeeTimeBooking(
             id=f"id-{status.value}-{requested_date}",
@@ -2062,6 +2063,7 @@ class TestStatusIntentVisibility:
             ),
             status=status,
             error_message=error_message,
+            actual_booked_time=actual_booked_time,
         )
 
     @pytest.mark.asyncio
@@ -2083,6 +2085,34 @@ class TestStatusIntentVisibility:
         assert "Saturday, August 08" in response
         assert "05:00 PM" in response
         assert "in_progress" in response
+
+    @pytest.mark.asyncio
+    async def test_success_shows_the_time_actually_booked(
+        self, booking_service: BookingService, sample_session: UserSession
+    ) -> None:
+        """A fallback booking lists the time secured, not the time asked for."""
+        import pytz
+
+        tz = pytz.timezone("America/Chicago")
+        # Asked for 5:00 PM, the fallback window landed 5:08 PM.
+        booked = self._booking(
+            BookingStatus.SUCCESS,
+            date(2026, 8, 8),
+            requested_time=time(17, 0),
+            actual_booked_time=time(17, 8),
+        )
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_bookings = AsyncMock(return_value=[booked])
+            with patch.object(CTDateTime, "now") as mock_ct_now:
+                mock_ct_now.return_value = tz.localize(datetime(2026, 8, 2, 15, 31))
+                response = await booking_service._handle_status_intent(sample_session)
+
+        assert "05:08 PM" in response
+        # Showing the requested time here would tell the user to turn up eight
+        # minutes early for a slot that isn't theirs.
+        assert "05:00 PM" not in response
+        assert "success" in response
 
     @pytest.mark.asyncio
     async def test_future_failure_is_listed_with_reason(
@@ -2132,17 +2162,21 @@ class TestStatusIntentVisibility:
 class TestReconcileInterruptedBookings:
     """Bookings orphaned in IN_PROGRESS by a crash must be resolved and reported.
 
-    No booking attempt survives a process restart, so any IN_PROGRESS row present
-    at startup is left over from a run that died mid-attempt (an OOM kill, a
-    deploy). Without reconciliation the row sits there forever and the user is
-    never told the attempt went nowhere.
+    A row left at IN_PROGRESS by a run that died mid-attempt (an OOM kill, a
+    deploy) sits there forever, and the user is never told the attempt went
+    nowhere. Reconciliation resolves those - but only those: this instance sets
+    IN_PROGRESS itself for attempts that are still running, and failing one of
+    those would both lie to the user and clobber the result it is about to write.
     """
 
     @staticmethod
-    def _in_progress_booking(origin_channel_id: str | None = None) -> TeeTimeBooking:
+    def _in_progress_booking(
+        origin_channel_id: str | None = None,
+        updated_at: datetime | None = None,
+    ) -> TeeTimeBooking:
         return TeeTimeBooking(
             id="orphan01",
-            phone_number="428931601318019073",
+            phone_number="+15550001111",
             request=TeeTimeRequest(
                 requested_date=date(2026, 8, 8),
                 requested_time=time(17, 0),
@@ -2150,6 +2184,9 @@ class TestReconcileInterruptedBookings:
             ),
             status=BookingStatus.IN_PROGRESS,
             origin_channel_id=origin_channel_id,
+            # Default to a row last touched well before any test-constructed
+            # service started, i.e. a genuine prior-run orphan.
+            updated_at=updated_at or datetime(2026, 8, 2, 20, 21, 54),
         )
 
     @staticmethod
@@ -2165,7 +2202,7 @@ class TestReconcileInterruptedBookings:
     @pytest.mark.asyncio
     async def test_marks_orphan_failed_and_notifies(self, booking_service: BookingService) -> None:
         """An orphaned booking is marked failed and the user is told."""
-        orphan = self._in_progress_booking(origin_channel_id="1533170075673296898")
+        orphan = self._in_progress_booking(origin_channel_id="9990001112223330")
         updated: list[TeeTimeBooking] = []
 
         with patch("app.services.booking_service.database_service") as mock_db:
@@ -2185,7 +2222,7 @@ class TestReconcileInterruptedBookings:
         mock_sms.send_booking_failure.assert_awaited_once()
         assert (
             mock_sms.send_booking_failure.await_args.kwargs["origin_channel_id"]
-            == "1533170075673296898"
+            == "9990001112223330"
         )
 
     @pytest.mark.asyncio
@@ -2221,6 +2258,63 @@ class TestReconcileInterruptedBookings:
 
         assert len(result) == 1
         assert updated[0].status == BookingStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_live_attempt_from_this_instance_is_left_alone(
+        self, booking_service: BookingService
+    ) -> None:
+        """An attempt this process started is still running, not orphaned.
+
+        The REST API, the scheduler's batch job and a confirmed chat booking can
+        all set IN_PROGRESS after startup. Reconciliation runs as a background
+        task once the gateway is ready, so it can overlap with those - and
+        failing one would both lie to the user and clobber the real outcome the
+        attempt is about to write.
+        """
+        live = self._in_progress_booking(
+            updated_at=booking_service._started_at + timedelta(seconds=1)
+        )
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_bookings = AsyncMock(return_value=[live])
+            mock_db.update_booking = AsyncMock()
+
+            with patch("app.services.booking_service.sms_service") as mock_sms:
+                mock_sms.send_booking_failure = AsyncMock()
+                result = await booking_service.reconcile_interrupted_bookings()
+
+        assert result == []
+        mock_db.update_booking.assert_not_awaited()
+        mock_sms.send_booking_failure.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unwritable_row_does_not_strand_the_others(
+        self, booking_service: BookingService
+    ) -> None:
+        """One row that won't persist must not abort the whole sweep."""
+        first = self._in_progress_booking()
+        first.id = "orphan-bad"
+        second = self._in_progress_booking()
+        second.id = "orphan-good"
+
+        async def update(booking: TeeTimeBooking) -> TeeTimeBooking:
+            if booking.id == "orphan-bad":
+                raise ValueError("Booking orphan-bad not found")
+            return booking
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_bookings = AsyncMock(return_value=[first, second])
+            mock_db.update_booking = AsyncMock(side_effect=update)
+
+            with patch("app.services.booking_service.sms_service") as mock_sms:
+                mock_sms.send_booking_failure = AsyncMock()
+                result = await booking_service.reconcile_interrupted_bookings()
+
+        # Only the row we actually persisted is reported, and only it is
+        # notified - telling the user about a failure we could not record would
+        # leave the row stuck and the message wrong.
+        assert [b.id for b in result] == ["orphan-good"]
+        assert mock_sms.send_booking_failure.await_count == 1
 
 
 class TestImmediateBookingDoesNotBlockReply:
@@ -2299,6 +2393,27 @@ class TestImmediateBookingDoesNotBlockReply:
 
             # Must not raise, and must not leave the task result unretrieved.
             await booking_service.wait_for_background_bookings()
+
+        assert not booking_service._background_tasks
+
+    @pytest.mark.asyncio
+    async def test_shutdown_wait_cancels_a_hung_attempt(
+        self, booking_service: BookingService
+    ) -> None:
+        """A hung Selenium run must not block gateway and provider cleanup.
+
+        Shutdown awaits this before stopping the gateway and closing the
+        provider, and Cloud Run allows only seconds between SIGTERM and SIGKILL.
+        """
+
+        async def never_finishes(_booking_id: str) -> bool:
+            await asyncio.Event().wait()
+            return True
+
+        with patch.object(booking_service, "execute_booking", new=never_finishes):
+            booking_service._spawn_booking_execution("hung01")
+
+            await booking_service.wait_for_background_bookings(timeout=0.05)
 
         assert not booking_service._background_tasks
 

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -5,6 +5,8 @@ These tests verify the core business logic for managing tee time bookings
 and SMS conversations.
 """
 
+import asyncio
+from collections.abc import Callable
 from datetime import date, datetime, time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -393,8 +395,12 @@ class TestBookingServiceImmediateExecution:
 
                     result = await booking_service.create_booking("+15551234567", past_request)
 
+                    # create_booking returns as soon as the record exists so the
+                    # caller can acknowledge; the attempt runs in the background.
+                    assert result.status == BookingStatus.IN_PROGRESS
+                    await booking_service.wait_for_background_bookings()
+
             mock_provider.book_tee_time.assert_called_once()
-            assert result.status == BookingStatus.SUCCESS
 
     @pytest.mark.asyncio
     async def test_create_booking_schedules_when_future(
@@ -492,8 +498,10 @@ class TestBookingServiceImmediateExecution:
 
                     result = await booking_service.create_booking("+15551234567", request)
 
+                    assert result.status == BookingStatus.IN_PROGRESS
+                    await booking_service.wait_for_background_bookings()
+
             mock_provider.book_tee_time.assert_called_once()
-            assert result.status == BookingStatus.SUCCESS
 
 
 class TestBookingServiceConfirmIntentImmediateExecution:
@@ -698,10 +706,22 @@ class TestBookingServiceIntentHandling:
         sample_booking: TeeTimeBooking,
     ) -> None:
         """Test handling a status intent with existing bookings."""
+        import pytz
+
+        tz = pytz.timezone("America/Chicago")
         with patch("app.services.booking_service.database_service") as mock_db:
             mock_db.get_bookings = AsyncMock(return_value=[sample_booking])
-            response = await booking_service._handle_status_intent(sample_session)
-            assert "upcoming bookings" in response.lower()
+            with patch.object(CTDateTime, "now") as mock_ct_now:
+                # sample_booking is for Dec 20; anchor "today" before it so the
+                # booking actually counts as upcoming rather than being filtered
+                # out (which would let the empty-state message satisfy the
+                # assertion by coincidence).
+                mock_ct_now.return_value = tz.localize(datetime(2025, 12, 13, 8, 0))
+                response = await booking_service._handle_status_intent(sample_session)
+
+        assert "upcoming bookings" in response.lower()
+        assert "Saturday, December 20" in response
+        assert "scheduled" in response
 
     @pytest.mark.asyncio
     async def test_handle_cancel_intent_no_bookings(
@@ -1471,6 +1491,8 @@ class TestBookingService48HourRestriction:
                 # for multi-player in test_multi_player_booking_rejected_within_48_hours)
                 booking = await booking_service.create_booking("+15551234567", request)
                 assert booking.request.num_players == 1
+                # Drain the background attempt before the database patch unwinds.
+                await booking_service.wait_for_background_bookings()
 
     @pytest.mark.asyncio
     async def test_multi_player_booking_allowed_after_48_hours(
@@ -2013,3 +2035,292 @@ class TestOriginChannelRouting:
                 await booking_service.execute_booking(sample_booking.id)
 
         assert mock_sms.send_booking_failure.await_args.args[4] == "778899"
+
+
+class TestStatusIntentVisibility:
+    """A booking must never be invisible just because it is mid-attempt.
+
+    A booking that was executing when the process died stayed IN_PROGRESS, and
+    the status listing only showed PENDING/SCHEDULED - so asking "did you book
+    it?" reported nothing at all about the booking that had just been made.
+    """
+
+    @staticmethod
+    def _booking(
+        status: BookingStatus,
+        requested_date: date,
+        requested_time: time = time(8, 0),
+        error_message: str | None = None,
+    ) -> TeeTimeBooking:
+        return TeeTimeBooking(
+            id=f"id-{status.value}-{requested_date}",
+            phone_number="+15551234567",
+            request=TeeTimeRequest(
+                requested_date=requested_date,
+                requested_time=requested_time,
+                num_players=4,
+            ),
+            status=status,
+            error_message=error_message,
+        )
+
+    @pytest.mark.asyncio
+    async def test_in_progress_booking_is_listed(
+        self, booking_service: BookingService, sample_session: UserSession
+    ) -> None:
+        """A booking that is mid-attempt shows up in the status listing."""
+        import pytz
+
+        tz = pytz.timezone("America/Chicago")
+        in_progress = self._booking(BookingStatus.IN_PROGRESS, date(2026, 8, 8), time(17, 0))
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_bookings = AsyncMock(return_value=[in_progress])
+            with patch.object(CTDateTime, "now") as mock_ct_now:
+                mock_ct_now.return_value = tz.localize(datetime(2026, 8, 2, 15, 31))
+                response = await booking_service._handle_status_intent(sample_session)
+
+        assert "Saturday, August 08" in response
+        assert "05:00 PM" in response
+        assert "in_progress" in response
+
+    @pytest.mark.asyncio
+    async def test_future_failure_is_listed_with_reason(
+        self, booking_service: BookingService, sample_session: UserSession
+    ) -> None:
+        """Failures for tee times that haven't happened yet are surfaced."""
+        import pytz
+
+        tz = pytz.timezone("America/Chicago")
+        failed = self._booking(
+            BookingStatus.FAILED,
+            date(2026, 8, 9),
+            error_message="No time slots with 4 available spots",
+        )
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_bookings = AsyncMock(return_value=[failed])
+            with patch.object(CTDateTime, "now") as mock_ct_now:
+                mock_ct_now.return_value = tz.localize(datetime(2026, 8, 2, 15, 31))
+                response = await booking_service._handle_status_intent(sample_session)
+
+        assert "Recent failures" in response
+        assert "No time slots with 4 available spots" in response
+
+    @pytest.mark.asyncio
+    async def test_past_bookings_are_not_listed(
+        self, booking_service: BookingService, sample_session: UserSession
+    ) -> None:
+        """Old failures don't accumulate in the listing forever."""
+        import pytz
+
+        tz = pytz.timezone("America/Chicago")
+        stale = [
+            self._booking(BookingStatus.FAILED, date(2023, 12, 23)),
+            self._booking(BookingStatus.SUCCESS, date(2025, 12, 29)),
+        ]
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_bookings = AsyncMock(return_value=stale)
+            with patch.object(CTDateTime, "now") as mock_ct_now:
+                mock_ct_now.return_value = tz.localize(datetime(2026, 8, 2, 15, 31))
+                response = await booking_service._handle_status_intent(sample_session)
+
+        assert "don't have any upcoming bookings" in response.lower()
+
+
+class TestReconcileInterruptedBookings:
+    """Bookings orphaned in IN_PROGRESS by a crash must be resolved and reported.
+
+    No booking attempt survives a process restart, so any IN_PROGRESS row present
+    at startup is left over from a run that died mid-attempt (an OOM kill, a
+    deploy). Without reconciliation the row sits there forever and the user is
+    never told the attempt went nowhere.
+    """
+
+    @staticmethod
+    def _in_progress_booking(origin_channel_id: str | None = None) -> TeeTimeBooking:
+        return TeeTimeBooking(
+            id="orphan01",
+            phone_number="428931601318019073",
+            request=TeeTimeRequest(
+                requested_date=date(2026, 8, 8),
+                requested_time=time(17, 0),
+                num_players=4,
+            ),
+            status=BookingStatus.IN_PROGRESS,
+            origin_channel_id=origin_channel_id,
+        )
+
+    @staticmethod
+    def _recorder(sink: list[TeeTimeBooking]) -> Callable[[TeeTimeBooking], TeeTimeBooking]:
+        """Build an update_booking side effect that records what it was given."""
+
+        def record(booking: TeeTimeBooking) -> TeeTimeBooking:
+            sink.append(booking)
+            return booking
+
+        return record
+
+    @pytest.mark.asyncio
+    async def test_marks_orphan_failed_and_notifies(self, booking_service: BookingService) -> None:
+        """An orphaned booking is marked failed and the user is told."""
+        orphan = self._in_progress_booking(origin_channel_id="1533170075673296898")
+        updated: list[TeeTimeBooking] = []
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_bookings = AsyncMock(return_value=[orphan])
+            mock_db.update_booking = AsyncMock(side_effect=self._recorder(updated))
+
+            with patch("app.services.booking_service.sms_service") as mock_sms:
+                mock_sms.send_booking_failure = AsyncMock()
+                result = await booking_service.reconcile_interrupted_bookings()
+
+        assert len(result) == 1
+        assert updated[0].status == BookingStatus.FAILED
+        # The reservation's true state is unknown - the message must say so
+        # rather than claiming the booking definitely failed.
+        assert updated[0].error_message is not None
+        assert "may or may not" in updated[0].error_message
+        mock_sms.send_booking_failure.assert_awaited_once()
+        assert (
+            mock_sms.send_booking_failure.await_args.kwargs["origin_channel_id"]
+            == "1533170075673296898"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_orphans_is_a_noop(self, booking_service: BookingService) -> None:
+        """With nothing stuck, reconciliation does nothing and sends nothing."""
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_bookings = AsyncMock(return_value=[])
+            mock_db.update_booking = AsyncMock()
+
+            with patch("app.services.booking_service.sms_service") as mock_sms:
+                mock_sms.send_booking_failure = AsyncMock()
+                result = await booking_service.reconcile_interrupted_bookings()
+
+        assert result == []
+        mock_db.update_booking.assert_not_awaited()
+        mock_sms.send_booking_failure.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_notification_failure_still_reconciles(
+        self, booking_service: BookingService
+    ) -> None:
+        """A dead messaging channel must not leave the row stuck IN_PROGRESS."""
+        orphan = self._in_progress_booking()
+        updated: list[TeeTimeBooking] = []
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_bookings = AsyncMock(return_value=[orphan])
+            mock_db.update_booking = AsyncMock(side_effect=self._recorder(updated))
+
+            with patch("app.services.booking_service.sms_service") as mock_sms:
+                mock_sms.send_booking_failure = AsyncMock(side_effect=RuntimeError("no gateway"))
+                result = await booking_service.reconcile_interrupted_bookings()
+
+        assert len(result) == 1
+        assert updated[0].status == BookingStatus.FAILED
+
+
+class TestImmediateBookingDoesNotBlockReply:
+    """The caller's reply must not depend on the booking attempt finishing.
+
+    execute_booking used to be awaited inline inside create_booking, which meant
+    the Discord gateway could not send its reply until a ~75s Selenium run
+    finished. When the container was OOM-killed mid-attempt the reply died with
+    it and the user got silence.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_booking_returns_before_attempt_completes(
+        self, booking_service: BookingService
+    ) -> None:
+        """create_booking returns while the attempt is still running."""
+        import pytz
+
+        request = TeeTimeRequest(
+            requested_date=date(2025, 12, 29),
+            requested_time=time(8, 0),
+            num_players=4,
+        )
+        release = asyncio.Event()
+
+        async def slow_booking(**_kwargs: object) -> BookingResult:
+            await release.wait()
+            return BookingResult(success=True, booked_time=time(8, 0))
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.create_booking = AsyncMock(side_effect=lambda b: b)
+            mock_db.update_booking = AsyncMock(side_effect=lambda b: b)
+            mock_db.get_booking = AsyncMock(
+                side_effect=lambda _id: TeeTimeBooking(
+                    id=_id,
+                    phone_number="+15551234567",
+                    request=request,
+                    status=BookingStatus.IN_PROGRESS,
+                )
+            )
+
+            mock_provider = MagicMock()
+            mock_provider.book_tee_time = AsyncMock(side_effect=slow_booking)
+            booking_service.set_reservation_provider(mock_provider)
+
+            with patch("app.services.booking_service.sms_service") as mock_sms:
+                mock_sms.send_booking_confirmation = AsyncMock()
+
+                with patch.object(CTDateTime, "now") as mock_ct_now:
+                    tz = pytz.timezone("America/Chicago")
+                    mock_ct_now.return_value = tz.localize(datetime(2025, 12, 22, 10, 0))
+
+                    result = await booking_service.create_booking("+15551234567", request)
+
+                    # The attempt is deliberately still blocked here: create_booking
+                    # returned without waiting for it.
+                    assert result.status == BookingStatus.IN_PROGRESS
+                    assert not mock_sms.send_booking_confirmation.await_count
+
+                    release.set()
+                    await booking_service.wait_for_background_bookings()
+
+                # Only once the attempt finishes does the user get the outcome.
+                mock_sms.send_booking_confirmation.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_background_attempt_crash_is_contained(
+        self, booking_service: BookingService
+    ) -> None:
+        """An exception in the background attempt is logged, not left unretrieved."""
+        with patch.object(
+            booking_service, "execute_booking", new=AsyncMock(side_effect=RuntimeError("boom"))
+        ):
+            booking_service._spawn_booking_execution("orphan01")
+            assert booking_service._background_tasks
+
+            # Must not raise, and must not leave the task result unretrieved.
+            await booking_service.wait_for_background_bookings()
+
+        assert not booking_service._background_tasks
+
+    @pytest.mark.asyncio
+    async def test_spawned_task_is_strongly_referenced(
+        self, booking_service: BookingService
+    ) -> None:
+        """The task is held until it completes, so it can't be garbage collected."""
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_execute(_booking_id: str) -> bool:
+            started.set()
+            await release.wait()
+            return True
+
+        with patch.object(booking_service, "execute_booking", new=slow_execute):
+            booking_service._spawn_booking_execution("orphan01")
+            await started.wait()
+            assert len(booking_service._background_tasks) == 1
+
+            release.set()
+            await booking_service.wait_for_background_bookings()
+
+        assert not booking_service._background_tasks

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -28,14 +28,25 @@ def isolated_logging() -> Iterator[None]:
     to WARNING. Without clearing them first a test would observe that leftover
     state rather than what the call under test actually did - and would pass
     even against a configure_logging() that never touched them.
+
+    Handlers are saved too: configure_logging() calls basicConfig(force=True),
+    which detaches every existing root handler - including pytest's capture
+    handler. Restoring only levels would leave later tests in the session
+    running against a root logger this fixture had quietly rewired.
     """
     names = [*WIRE_LOGGERS, "app", ""]
-    saved = {name: logging.getLogger(name).level for name in names}
+    saved_levels = {name: logging.getLogger(name).level for name in names}
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+
     for name in names:
         logging.getLogger(name).setLevel(logging.NOTSET)
-    yield
-    for name, level in saved.items():
-        logging.getLogger(name).setLevel(level)
+    try:
+        yield
+    finally:
+        for name, level in saved_levels.items():
+            logging.getLogger(name).setLevel(level)
+        root.handlers[:] = saved_handlers
 
 
 @pytest.mark.parametrize("log_level", ["DEBUG", "INFO", "WARNING"])

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,77 @@
+"""Tests for logging configuration.
+
+These guard a credential leak rather than a formatting preference.
+selenium.webdriver.remote.remote_connection logs every WebDriver command
+payload at DEBUG, including the send_keys body that fills the Walden login
+form. The muzzle used to be conditional on the app's own log level, so running
+with LOG_LEVEL=DEBUG (which is how this runs in production, to get
+BOOKING_DEBUG output) wrote the member number and password to Cloud Logging in
+cleartext on every booking run.
+"""
+
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+from app.main import configure_logging
+
+# Loggers that must never emit below WARNING, whatever LOG_LEVEL says.
+WIRE_LOGGERS = ["selenium", "urllib3", "websockets", "httpcore"]
+
+
+@pytest.fixture(autouse=True)
+def isolated_logging() -> Iterator[None]:
+    """Reset the loggers under test, then restore them afterwards.
+
+    app.main calls configure_logging() at import time, which already pins these
+    to WARNING. Without clearing them first a test would observe that leftover
+    state rather than what the call under test actually did - and would pass
+    even against a configure_logging() that never touched them.
+    """
+    names = [*WIRE_LOGGERS, "app", ""]
+    saved = {name: logging.getLogger(name).level for name in names}
+    for name in names:
+        logging.getLogger(name).setLevel(logging.NOTSET)
+    yield
+    for name, level in saved.items():
+        logging.getLogger(name).setLevel(level)
+
+
+@pytest.mark.parametrize("log_level", ["DEBUG", "INFO", "WARNING"])
+@pytest.mark.parametrize("wire_logger", WIRE_LOGGERS)
+def test_wire_loggers_never_emit_below_warning(
+    monkeypatch: pytest.MonkeyPatch, log_level: str, wire_logger: str
+) -> None:
+    """Wire loggers stay at WARNING even when the app is at DEBUG."""
+    monkeypatch.setattr("app.main.settings.log_level", log_level)
+
+    configure_logging()
+
+    assert logging.getLogger(wire_logger).level == logging.WARNING
+
+
+def test_selenium_command_payloads_are_not_logged_at_debug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact logger that leaked credentials is silenced at DEBUG.
+
+    remote_connection is a child of the "selenium" logger, so setting the
+    parent to WARNING must suppress its DEBUG records through inheritance.
+    """
+    monkeypatch.setattr("app.main.settings.log_level", "DEBUG")
+
+    configure_logging()
+
+    leaky = logging.getLogger("selenium.webdriver.remote.remote_connection")
+    assert not leaky.isEnabledFor(logging.DEBUG)
+    assert not leaky.isEnabledFor(logging.INFO)
+
+
+def test_app_loggers_still_honour_debug(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Silencing the wire loggers must not cost us BOOKING_DEBUG output."""
+    monkeypatch.setattr("app.main.settings.log_level", "DEBUG")
+
+    configure_logging()
+
+    assert logging.getLogger("app.providers.walden_provider").isEnabledFor(logging.DEBUG)


### PR DESCRIPTION
## What happened

A tee time confirmed at 3:20 PM on 2026-08-02 never reported back — no confirmation, no failure, nothing. Asking the bot "did you book it?" eleven minutes later listed only an unrelated booking.

From Cloud Run logs:

| Time (UTC) | Event |
|---|---|
| 20:20:38 | User sends "yes" |
| 20:20:40 | `=== STARTING BOOKING ATTEMPT === date=2026-08-08, requested_time=17:00, players=4` |
| 20:21:29 | Exact match found at 05:00 PM, clicks Reserve |
| 20:21:54 | **"Clicked Book Now button"** |
| 20:22:01 | `Memory limit of 1024 MiB exceeded with 1047 MiB used` — container killed |
| 20:22:15 | Discord gateway reconnects on a fresh container |

The process died 7 seconds after submitting the booking, while waiting for the confirmation page. This is the only OOM in the service's log history.

## Why one OOM produced total silence

Five defects compounded:

1. **1Gi was not enough.** Headless Chrome peaks around 1 GiB on a 150+ slot booking page, on top of the always-on FastAPI process and Discord gateway.
2. **The reply was held hostage to the booking.** Aug 8 was 6 days out, so its window (Aug 1, 6:30 AM) had already passed and `create_booking` ran `execute_booking` **inline**. The Discord gateway only sends its reply after the handler returns, so a ~75s Selenium run blocked it — and the crash took the reply with it.
3. **The status listing hid the booking.** It filtered to `PENDING`/`SCHEDULED`, so an `IN_PROGRESS` row was invisible.
4. **Nothing reconciled stuck rows.** The booking would have sat at `IN_PROGRESS` forever.
5. **Credentials were being written to Cloud Logging.** See below.

## Changes

**Memory 1Gi → 2Gi** in `variables.tf` and `terraform.tfvars.example`, documented as a floor rather than a preference.

**Immediate bookings run in the background.** `create_booking` marks the row `IN_PROGRESS`, spawns a tracked task, and returns immediately, so the user gets "On it — booking Saturday, August 08 at 05:00 PM for 4 players now…" within seconds. `execute_booking` already reports the outcome separately. Tasks are held in a set because asyncio only keeps weak references — otherwise a run could be garbage collected mid-attempt.

**Status listing includes `IN_PROGRESS` and `SUCCESS`,** plus a "Recent failures" section with error reasons, scoped to tee times that haven't happened yet so old failures don't accumulate.

**Startup reconciler.** No attempt survives a restart, so any `IN_PROGRESS` row at startup is orphaned by definition. Each is marked `FAILED` and the user notified. It runs as a background task that awaits `wait_until_ready()` on the Discord gateway first, so the notification has somewhere to go without blocking startup. The message says the reservation *may or may not* have gone through — after an interrupted attempt that is genuinely unknown, and claiming failure could cause a duplicate booking.

## Security: credentials in Cloud Logging

`configure_logging` only silenced the Selenium wire loggers when `LOG_LEVEL` was above `DEBUG`. Production runs at `DEBUG` to get `BOOKING_DEBUG` output (`log_level = "DEBUG"` in `terraform.tfvars.example`), so the muzzle never fired — and `selenium.webdriver.remote.remote_connection` logs every command payload, including the `send_keys` body that fills the login form. The Walden member number and password were written to Cloud Logging in cleartext on **every booking run**.

Those loggers are now pinned to `WARNING` unconditionally. App loggers still honour `DEBUG`. This also stops Selenium dumping whole pages of HTML into logs — one log query returned 200 KB of it.

**This change only stops further writes.** The password still needs rotating and the existing log entries purging.

## Testing

`665 passed, 3 skipped`. Ruff clean, mypy clean on `app/`, no new mypy errors in `tests/` (145 baseline, unchanged).

New coverage: status visibility for in-flight and failed bookings, reconciliation (including that a dead messaging channel still leaves the row resolved), background execution returning before the attempt completes, task lifetime, and the logging config.

Two verification notes:

- The logging tests were checked against the pre-fix code. The first version **passed while broken**, because `app.main` calls `configure_logging()` at import and had already pinned `selenium`. The fixture now resets to `NOTSET` first; against the old code 9 tests fail, including `test_selenium_command_payloads_are_not_logged_at_debug`.
- `test_handle_status_intent_with_bookings` was passing vacuously — its fixture date is in the past, and "upcoming bookings" appears in the empty-state message too. It now anchors `CTDateTime.now()` and asserts on real content.

## Follow-up not in this PR

- `terraform apply` for the 2Gi bump
- Rotate the Walden password, purge the affected log entries
- Booking `46e70d4a` (Aug 8, 5:00 PM) is still `IN_PROGRESS` in production. The Book Now click was submitted and acknowledged before the crash, so **the reservation may actually exist** — worth checking the club site before rebooking. The reconciler will mark it failed on deploy, but that reflects the bot's ignorance, not the club's records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Booking requests now receive immediate acknowledgements while processing continues in the background.
  * Booking status displays upcoming, completed, and failed bookings with actual scheduled times.
  * Interrupted bookings are automatically identified, marked as failed, and communicated appropriately.

* **Bug Fixes**
  * Improved shutdown handling to complete active bookings safely.
  * Suppressed sensitive wire-protocol and command details from logs.

* **Chores**
  * Increased the default service memory allocation and minimum supported setting to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->