### PR TITLE
fix: run immediate multi-bookings as one batch, not one task each

### DIFF
--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -261,7 +261,10 @@ class BookingService:
         for request in session.pending_requests:
             try:
                 booking = await self.create_booking(
-                    session.phone_number, request, session.origin_channel_id
+                    session.phone_number,
+                    request,
+                    session.origin_channel_id,
+                    defer_execution=True,
                 )
                 successful_bookings.append(booking)
             except ValueError as e:
@@ -270,6 +273,19 @@ class BookingService:
         session.pending_requests = None
         session.pending_request = None
         session.state = ConversationState.IDLE
+
+        # Bookings whose window is already open run as ONE batch: a single
+        # driver, a single login, attempts made in sequence. Letting
+        # create_booking spawn its own task per booking put two headless Chromes
+        # on the club's login form ~80ms apart; the portal accepted one and left
+        # the other sitting on the login page, failing that booking outright.
+        immediate_booking_ids = [
+            booking.id
+            for booking in successful_bookings
+            if booking.status != BookingStatus.SCHEDULED and booking.id is not None
+        ]
+        if immediate_booking_ids:
+            self._spawn_bookings_batch_execution(immediate_booking_ids)
 
         response_parts = []
 
@@ -676,6 +692,7 @@ class BookingService:
         phone_number: str,
         request: TeeTimeRequest,
         origin_channel_id: str | None = None,
+        defer_execution: bool = False,
     ) -> TeeTimeBooking:
         """
         Create a new booking record and schedule it for execution.
@@ -699,6 +716,11 @@ class BookingService:
             origin_channel_id: Discord channel this booking was requested in, so
                 the success/failure notification replies there. None for SMS and
                 REST API callers.
+            defer_execution: Create the record and mark it IN_PROGRESS, but do
+                not start the attempt. Callers creating several bookings at once
+                set this so they can run the whole set as one batch instead of
+                one concurrent attempt per booking; they then own both starting
+                the work and reporting the outcome.
 
         Returns:
             The created TeeTimeBooking record.
@@ -759,7 +781,8 @@ class BookingService:
                 # it lands.
                 created_booking.status = BookingStatus.IN_PROGRESS
                 await database_service.update_booking(created_booking)
-                self._spawn_booking_execution(booking_id_opt)
+                if not defer_execution:
+                    self._spawn_booking_execution(booking_id_opt)
 
         return created_booking
 
@@ -783,6 +806,89 @@ class BookingService:
             await self.execute_booking(booking_id)
         except Exception:
             logger.exception("Background booking execution failed for %s", booking_id)
+
+    def _spawn_bookings_batch_execution(self, booking_ids: list[str]) -> None:
+        """Run several already-open bookings as one tracked background task."""
+        task = asyncio.create_task(
+            self._execute_bookings_batch_in_background(booking_ids),
+            name=f"execute-bookings-batch-{'-'.join(booking_ids)}",
+        )
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    async def _execute_bookings_batch_in_background(self, booking_ids: list[str]) -> None:
+        """Attempt a set of bookings in one session and report each outcome.
+
+        execute_bookings_batch deliberately leaves notification to its caller,
+        so this reports every booking itself. Each of these bookings has already
+        been acknowledged to the user, so every path out of here has to end in a
+        message per booking - silence would leave them waiting on a reply that
+        never comes.
+        """
+        bookings = [
+            booking
+            for booking in [await self.get_booking(booking_id) for booking_id in booking_ids]
+            if booking is not None
+        ]
+        if not bookings:
+            logger.error("Batch booking execution found no records for %s", booking_ids)
+            return
+
+        try:
+            results = await self.execute_bookings_batch(bookings, execute_at=None)
+        except Exception as e:
+            logger.exception("Background batch booking execution failed for %s", booking_ids)
+            for booking in bookings:
+                await self._notify_unreported_booking(booking, str(e))
+            return
+
+        reported: set[str] = set()
+        for booking_id, result in results:
+            attempted = await self.get_booking(booking_id)
+            if attempted is None:
+                continue
+            reported.add(booking_id)
+            await self._notify_booking_result(attempted, result)
+
+        # execute_bookings_batch appends a result per request on every path it
+        # returns from, so this is a backstop against a booking silently going
+        # unanswered rather than an expected branch.
+        for booking in bookings:
+            if booking.id is not None and booking.id not in reported:
+                await self._notify_unreported_booking(
+                    booking, "The booking attempt ended without reporting a result."
+                )
+
+    async def _notify_unreported_booking(self, booking: TeeTimeBooking, error: str) -> None:
+        """Report a booking the batch left unaccounted for.
+
+        The batch may have resolved and persisted the row before failing, so
+        this reports what was actually recorded and only invents a failure for
+        rows still sitting in IN_PROGRESS.
+        """
+        persisted = await self.get_booking(booking.id) if booking.id is not None else None
+        current = persisted or booking
+
+        if current.status == BookingStatus.SUCCESS:
+            await self._notify_booking_result(
+                current,
+                BookingResult(
+                    success=True,
+                    booked_time=current.actual_booked_time,
+                    confirmation_number=current.confirmation_number,
+                ),
+            )
+            return
+
+        if current.status != BookingStatus.FAILED:
+            current.status = BookingStatus.FAILED
+            current.error_message = error
+            await database_service.update_booking(current)
+
+        await self._notify_booking_result(
+            current,
+            BookingResult(success=False, error_message=current.error_message or error),
+        )
 
     async def wait_for_background_bookings(self, timeout: float | None = None) -> None:
         """Wait for all in-flight background booking attempts to finish.
@@ -936,16 +1042,9 @@ class BookingService:
             booking.error_message = "Reservation provider not configured"
             await database_service.update_booking(booking)
 
-            # Build booking details string for the failure message
-            date_str = booking.request.requested_date.strftime("%A, %B %d")
-            time_str = booking.request.requested_time.strftime("%I:%M %p")
-            booking_details = f"{date_str} at {time_str} for {booking.request.num_players} players"
-
-            await sms_service.send_booking_failure(
-                booking.phone_number,
-                "System not configured for booking",
-                booking_details=booking_details,
-                origin_channel_id=booking.origin_channel_id,
+            await self._notify_booking_result(
+                booking,
+                BookingResult(success=False, error_message="System not configured for booking"),
             )
             return False
 
@@ -966,40 +1065,14 @@ class BookingService:
                 booking.confirmation_number = result.confirmation_number
                 await database_service.update_booking(booking)
 
-                date_str = booking.request.requested_date.strftime("%A, %B %d")
-                time_str = (result.booked_time or booking.request.requested_time).strftime(
-                    "%I:%M %p"
-                )
-                details = f"{date_str} at {time_str} for {booking.request.num_players} players"
-                if result.confirmation_number:
-                    details += f" (Confirmation: {result.confirmation_number})"
-
-                if result.fallback_reason:
-                    details += f"\n\nNote: {result.fallback_reason}"
-
-                await sms_service.send_booking_confirmation(
-                    booking.phone_number, details, booking.origin_channel_id
-                )
+                await self._notify_booking_result(booking, result)
                 return True
             else:
                 booking.status = BookingStatus.FAILED
                 booking.error_message = result.error_message
                 await database_service.update_booking(booking)
 
-                # Build booking details string for the failure message
-                date_str = booking.request.requested_date.strftime("%A, %B %d")
-                time_str = booking.request.requested_time.strftime("%I:%M %p")
-                booking_details = (
-                    f"{date_str} at {time_str} for {booking.request.num_players} players"
-                )
-
-                await sms_service.send_booking_failure(
-                    booking.phone_number,
-                    result.error_message or "Unknown error",
-                    result.alternatives,
-                    booking_details,
-                    booking.origin_channel_id,
-                )
+                await self._notify_booking_result(booking, result)
                 return False
 
         except Exception as e:
@@ -1007,18 +1080,44 @@ class BookingService:
             booking.error_message = str(e)
             await database_service.update_booking(booking)
 
-            # Build booking details string for the failure message
-            date_str = booking.request.requested_date.strftime("%A, %B %d")
-            time_str = booking.request.requested_time.strftime("%I:%M %p")
-            booking_details = f"{date_str} at {time_str} for {booking.request.num_players} players"
-
-            await sms_service.send_booking_failure(
-                booking.phone_number,
-                str(e),
-                booking_details=booking_details,
-                origin_channel_id=booking.origin_channel_id,
+            await self._notify_booking_result(
+                booking, BookingResult(success=False, error_message=str(e))
             )
             return False
+
+    async def _notify_booking_result(self, booking: TeeTimeBooking, result: BookingResult) -> None:
+        """Tell the user how a finished booking attempt turned out.
+
+        Shared by every path that runs an attempt, so an ad-hoc booking reads
+        the same to the user whether it ran alone or as part of a batch.
+        """
+        date_str = booking.request.requested_date.strftime("%A, %B %d")
+        num_players = booking.request.num_players
+
+        if result.success:
+            time_str = (result.booked_time or booking.request.requested_time).strftime("%I:%M %p")
+            details = f"{date_str} at {time_str} for {num_players} players"
+            if result.confirmation_number:
+                details += f" (Confirmation: {result.confirmation_number})"
+
+            if result.fallback_reason:
+                details += f"\n\nNote: {result.fallback_reason}"
+
+            await sms_service.send_booking_confirmation(
+                booking.phone_number, details, booking.origin_channel_id
+            )
+            return
+
+        time_str = booking.request.requested_time.strftime("%I:%M %p")
+        booking_details = f"{date_str} at {time_str} for {num_players} players"
+
+        await sms_service.send_booking_failure(
+            booking.phone_number,
+            result.error_message or "Unknown error",
+            result.alternatives,
+            booking_details,
+            booking.origin_channel_id,
+        )
 
     async def get_pending_bookings(self) -> list[TeeTimeBooking]:
         return await database_service.get_bookings(status=BookingStatus.SCHEDULED)

--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -811,19 +811,32 @@ class BookingService:
         """Run several already-open bookings as one tracked background task."""
         task = asyncio.create_task(
             self._execute_bookings_batch_in_background(booking_ids),
-            name=f"execute-bookings-batch-{'-'.join(booking_ids)}",
+            name=f"execute-bookings-batch-{len(booking_ids)}-from-{booking_ids[0]}",
         )
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
     async def _execute_bookings_batch_in_background(self, booking_ids: list[str]) -> None:
-        """Attempt a set of bookings in one session and report each outcome.
+        """Attempt a set of bookings in one session, ensuring failures are logged.
+
+        Mirrors _execute_booking_in_background: the work itself reports its own
+        outcomes, and this wrapper only stops an exception from escaping into an
+        unretrieved task result, where it would vanish silently.
+        """
+        try:
+            await self._run_bookings_batch(booking_ids)
+        except Exception:
+            logger.exception("Background batch booking execution failed for %s", booking_ids)
+
+    async def _run_bookings_batch(self, booking_ids: list[str]) -> None:
+        """Book a set of tee times in one session and report each outcome.
 
         execute_bookings_batch deliberately leaves notification to its caller,
         so this reports every booking itself. Each of these bookings has already
         been acknowledged to the user, so every path out of here has to end in a
         message per booking - silence would leave them waiting on a reply that
-        never comes.
+        never comes. That is also why each notification is isolated: one booking
+        whose message fails to send must not strand the rest of the batch.
         """
         bookings = [
             booking
@@ -837,9 +850,9 @@ class BookingService:
         try:
             results = await self.execute_bookings_batch(bookings, execute_at=None)
         except Exception as e:
-            logger.exception("Background batch booking execution failed for %s", booking_ids)
+            logger.exception("Batch booking attempt failed for %s", booking_ids)
             for booking in bookings:
-                await self._notify_unreported_booking(booking, str(e))
+                await self._try_notify_unreported_booking(booking, str(e))
             return
 
         reported: set[str] = set()
@@ -848,16 +861,32 @@ class BookingService:
             if attempted is None:
                 continue
             reported.add(booking_id)
-            await self._notify_booking_result(attempted, result)
+            await self._try_notify_booking_result(attempted, result)
 
         # execute_bookings_batch appends a result per request on every path it
         # returns from, so this is a backstop against a booking silently going
         # unanswered rather than an expected branch.
         for booking in bookings:
             if booking.id is not None and booking.id not in reported:
-                await self._notify_unreported_booking(
+                await self._try_notify_unreported_booking(
                     booking, "The booking attempt ended without reporting a result."
                 )
+
+    async def _try_notify_booking_result(
+        self, booking: TeeTimeBooking, result: BookingResult
+    ) -> None:
+        """Report one outcome, keeping a send failure from stranding the batch."""
+        try:
+            await self._notify_booking_result(booking, result)
+        except Exception:
+            logger.exception("Could not report the outcome of booking %s", booking.id)
+
+    async def _try_notify_unreported_booking(self, booking: TeeTimeBooking, error: str) -> None:
+        """Same, for a booking the batch never accounted for."""
+        try:
+            await self._notify_unreported_booking(booking, error)
+        except Exception:
+            logger.exception("Could not report unaccounted booking %s", booking.id)
 
     async def _notify_unreported_booking(self, booking: TeeTimeBooking, error: str) -> None:
         """Report a booking the batch left unaccounted for.
@@ -880,10 +909,13 @@ class BookingService:
             )
             return
 
+        # Only write back a row that is still there to write to; update_booking
+        # raises on a missing record, and the message matters more than the row.
         if current.status != BookingStatus.FAILED:
             current.status = BookingStatus.FAILED
             current.error_message = error
-            await database_service.update_booking(current)
+            if persisted is not None:
+                await database_service.update_booking(current)
 
         await self._notify_booking_result(
             current,

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -2093,16 +2093,22 @@ class TestImmediateMultiBookingRunsAsOneBatch:
 
     @staticmethod
     def _fake_database(mock_db: MagicMock) -> dict[str, TeeTimeBooking]:
-        """Back the mocked database_service with a dict keyed by booking id."""
+        """Back the mocked database_service with a dict keyed by booking id.
+
+        Rows are copied in and out so that what `stored` holds is only what was
+        actually written. Handing back the service's own instance would let an
+        in-place mutation satisfy a status assertion that no write ever made.
+        """
         stored: dict[str, TeeTimeBooking] = {}
 
         async def save(booking: TeeTimeBooking) -> TeeTimeBooking:
             if booking.id is not None:
-                stored[booking.id] = booking
+                stored[booking.id] = booking.model_copy(deep=True)
             return booking
 
         async def load(booking_id: str) -> TeeTimeBooking | None:
-            return stored.get(booking_id)
+            found = stored.get(booking_id)
+            return found.model_copy(deep=True) if found is not None else None
 
         mock_db.create_booking = AsyncMock(side_effect=save)
         mock_db.update_booking = AsyncMock(side_effect=save)
@@ -2176,6 +2182,56 @@ class TestImmediateMultiBookingRunsAsOneBatch:
         mock_sms.send_booking_failure.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_one_undeliverable_message_does_not_strand_the_other_booking(
+        self, booking_service: BookingService
+    ) -> None:
+        """A send that raises must not cut the reporting loop short."""
+        import pytz
+
+        from app.providers.base import BatchBookingItemResult, BatchBookingResult
+
+        session = self._session()
+
+        async def book_multiple(
+            target_date: date, requests: list, execute_at: datetime | None = None
+        ) -> BatchBookingResult:
+            return BatchBookingResult(
+                results=[
+                    BatchBookingItemResult(
+                        booking_id=item.booking_id,
+                        result=BookingResult(success=True, booked_time=item.target_time),
+                    )
+                    for item in requests
+                ],
+                total_succeeded=len(requests),
+            )
+
+        provider = MagicMock()
+        provider.book_tee_time = AsyncMock()
+        provider.book_multiple_tee_times = AsyncMock(side_effect=book_multiple)
+        booking_service.set_reservation_provider(provider)
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            self._fake_database(mock_db)
+
+            with patch("app.services.booking_service.sms_service") as mock_sms:
+                mock_sms.send_booking_confirmation = AsyncMock(
+                    side_effect=RuntimeError("Discord is down")
+                )
+                mock_sms.send_booking_failure = AsyncMock()
+
+                with patch.object(CTDateTime, "now") as mock_ct_now:
+                    mock_ct_now.return_value = pytz.timezone("America/Chicago").localize(
+                        self.NOW_CT
+                    )
+
+                    await booking_service._handle_confirm_intent(session)
+                    await booking_service.wait_for_background_bookings()
+
+        # The second booking was still attempted even though the first raised.
+        assert mock_sms.send_booking_confirmation.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_a_batch_that_raises_still_reports_every_booking(
         self, booking_service: BookingService
     ) -> None:
@@ -2245,7 +2301,7 @@ class TestImmediateMultiBookingRunsAsOneBatch:
         booking_service.set_reservation_provider(provider)
 
         with patch("app.services.booking_service.database_service") as mock_db:
-            self._fake_database(mock_db)
+            stored = self._fake_database(mock_db)
 
             with patch("app.services.booking_service.sms_service") as mock_sms:
                 mock_sms.send_booking_confirmation = AsyncMock()
@@ -2261,6 +2317,11 @@ class TestImmediateMultiBookingRunsAsOneBatch:
 
         assert mock_sms.send_booking_confirmation.await_count == 1
         assert mock_sms.send_booking_failure.await_count == 1
+
+        # The omitted booking is written off as failed, not left mid-attempt.
+        assert sorted(booking.status for booking in stored.values()) == sorted(
+            [BookingStatus.FAILED, BookingStatus.SUCCESS]
+        )
 
 
 class TestStatusIntentVisibility:

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -1182,7 +1182,9 @@ class TestBookingServiceExecuteBooking:
                 mock_sms.send_booking_failure.assert_called_once()
                 call_kwargs = mock_sms.send_booking_failure.call_args
                 args, kwargs = call_kwargs
-                booking_details = kwargs.get("booking_details")
+                booking_details = kwargs.get("booking_details") or (
+                    args[3] if len(args) > 3 else None
+                )
                 assert booking_details is not None
                 assert "4 players" in booking_details
 
@@ -1210,7 +1212,9 @@ class TestBookingServiceExecuteBooking:
                 mock_sms.send_booking_failure.assert_called_once()
                 call_kwargs = mock_sms.send_booking_failure.call_args
                 args, kwargs = call_kwargs
-                booking_details = kwargs.get("booking_details")
+                booking_details = kwargs.get("booking_details") or (
+                    args[3] if len(args) > 3 else None
+                )
                 assert booking_details is not None
                 assert "4 players" in booking_details
 
@@ -1653,7 +1657,10 @@ class TestMultipleBookings:
         )
 
         async def create_booking_side_effect(
-            phone_number: str, request: TeeTimeRequest, origin_channel_id: str | None = None
+            phone_number: str,
+            request: TeeTimeRequest,
+            origin_channel_id: str | None = None,
+            defer_execution: bool = False,
         ) -> TeeTimeBooking:
             return TeeTimeBooking(
                 id="test123",
@@ -1699,7 +1706,10 @@ class TestMultipleBookings:
         call_count = 0
 
         async def create_booking_side_effect(
-            phone_number: str, request: TeeTimeRequest, origin_channel_id: str | None = None
+            phone_number: str,
+            request: TeeTimeRequest,
+            origin_channel_id: str | None = None,
+            defer_execution: bool = False,
         ) -> TeeTimeBooking:
             nonlocal call_count
             call_count += 1
@@ -1768,7 +1778,10 @@ class TestMultipleBookings:
         )
 
         async def create_booking_side_effect(
-            phone_number: str, request: TeeTimeRequest, origin_channel_id: str | None = None
+            phone_number: str,
+            request: TeeTimeRequest,
+            origin_channel_id: str | None = None,
+            defer_execution: bool = False,
         ) -> TeeTimeBooking:
             raise ValueError("Multi-player bookings within 48 hours")
 
@@ -1931,7 +1944,10 @@ class TestOriginChannelRouting:
         )
 
         async def create_booking_side_effect(
-            phone_number: str, request: TeeTimeRequest, origin_channel_id: str | None = None
+            phone_number: str,
+            request: TeeTimeRequest,
+            origin_channel_id: str | None = None,
+            defer_execution: bool = False,
         ) -> TeeTimeBooking:
             return TeeTimeBooking(
                 id="test1234",
@@ -1971,7 +1987,10 @@ class TestOriginChannelRouting:
         )
 
         async def create_booking_side_effect(
-            phone_number: str, request: TeeTimeRequest, origin_channel_id: str | None = None
+            phone_number: str,
+            request: TeeTimeRequest,
+            origin_channel_id: str | None = None,
+            defer_execution: bool = False,
         ) -> TeeTimeBooking:
             return TeeTimeBooking(
                 id="test1234",
@@ -2035,6 +2054,213 @@ class TestOriginChannelRouting:
                 await booking_service.execute_booking(sample_booking.id)
 
         assert mock_sms.send_booking_failure.await_args.args[4] == "778899"
+
+
+class TestImmediateMultiBookingRunsAsOneBatch:
+    """Several already-open bookings share one browser session.
+
+    Each booking used to spawn its own background task, so confirming two
+    ad-hoc bookings drove two headless Chromes onto the club's login form
+    ~80ms apart. The portal let one through and left the other sitting on the
+    login page, failing that booking outright. They now run as a single batch:
+    one driver, one login, attempts made in sequence.
+    """
+
+    REQUESTED_DATE = date(2025, 12, 29)
+    # 6:30am CT on the 22nd is when the window for the 29th opens, so a "now"
+    # later that morning puts both bookings past their execution time.
+    NOW_CT = datetime(2025, 12, 22, 10, 0)
+
+    @staticmethod
+    def _session() -> UserSession:
+        return UserSession(
+            phone_number="+15551234567",
+            state=ConversationState.AWAITING_CONFIRMATION,
+            origin_channel_id="778899",
+            pending_requests=[
+                TeeTimeRequest(
+                    requested_date=TestImmediateMultiBookingRunsAsOneBatch.REQUESTED_DATE,
+                    requested_time=time(17, 0),
+                    num_players=4,
+                ),
+                TeeTimeRequest(
+                    requested_date=TestImmediateMultiBookingRunsAsOneBatch.REQUESTED_DATE,
+                    requested_time=time(17, 8),
+                    num_players=4,
+                ),
+            ],
+        )
+
+    @staticmethod
+    def _fake_database(mock_db: MagicMock) -> dict[str, TeeTimeBooking]:
+        """Back the mocked database_service with a dict keyed by booking id."""
+        stored: dict[str, TeeTimeBooking] = {}
+
+        async def save(booking: TeeTimeBooking) -> TeeTimeBooking:
+            if booking.id is not None:
+                stored[booking.id] = booking
+            return booking
+
+        async def load(booking_id: str) -> TeeTimeBooking | None:
+            return stored.get(booking_id)
+
+        mock_db.create_booking = AsyncMock(side_effect=save)
+        mock_db.update_booking = AsyncMock(side_effect=save)
+        mock_db.get_booking = AsyncMock(side_effect=load)
+        return stored
+
+    @pytest.mark.asyncio
+    async def test_both_bookings_run_in_a_single_batched_attempt(
+        self, booking_service: BookingService
+    ) -> None:
+        """One background task, one batch call carrying both tee times."""
+        import pytz
+
+        from app.providers.base import BatchBookingItemResult, BatchBookingResult
+
+        session = self._session()
+
+        async def book_multiple(
+            target_date: date, requests: list, execute_at: datetime | None = None
+        ) -> BatchBookingResult:
+            return BatchBookingResult(
+                results=[
+                    BatchBookingItemResult(
+                        booking_id=item.booking_id,
+                        result=BookingResult(success=True, booked_time=item.target_time),
+                    )
+                    for item in requests
+                ],
+                total_succeeded=len(requests),
+            )
+
+        provider = MagicMock()
+        provider.book_tee_time = AsyncMock()
+        provider.book_multiple_tee_times = AsyncMock(side_effect=book_multiple)
+        booking_service.set_reservation_provider(provider)
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            self._fake_database(mock_db)
+
+            with patch("app.services.booking_service.sms_service") as mock_sms:
+                mock_sms.send_booking_confirmation = AsyncMock()
+                mock_sms.send_booking_failure = AsyncMock()
+
+                with patch.object(CTDateTime, "now") as mock_ct_now:
+                    mock_ct_now.return_value = pytz.timezone("America/Chicago").localize(
+                        self.NOW_CT
+                    )
+
+                    await booking_service._handle_confirm_intent(session)
+
+                    # The regression: two bookings, one task. Checked before
+                    # awaiting, while the task set is still populated.
+                    assert len(booking_service._background_tasks) == 1
+
+                    await booking_service.wait_for_background_bookings()
+
+        # One session, not one per booking.
+        provider.book_tee_time.assert_not_called()
+        assert provider.book_multiple_tee_times.await_count == 1
+
+        batch_requests = provider.book_multiple_tee_times.await_args.kwargs["requests"]
+        assert [item.target_time for item in batch_requests] == [time(17, 0), time(17, 8)]
+        # Off-race, so nothing to wait for before firing.
+        assert provider.book_multiple_tee_times.await_args.kwargs["execute_at"] is None
+
+        # Both outcomes still reach the user, in the channel they asked from.
+        assert mock_sms.send_booking_confirmation.await_count == 2
+        assert all(
+            call.args[2] == "778899" for call in mock_sms.send_booking_confirmation.await_args_list
+        )
+        mock_sms.send_booking_failure.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_batch_that_raises_still_reports_every_booking(
+        self, booking_service: BookingService
+    ) -> None:
+        """Both bookings were acknowledged, so both must get an answer."""
+        import pytz
+
+        session = self._session()
+
+        provider = MagicMock()
+        provider.book_tee_time = AsyncMock()
+        provider.book_multiple_tee_times = AsyncMock(side_effect=RuntimeError("driver died"))
+        booking_service.set_reservation_provider(provider)
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            stored = self._fake_database(mock_db)
+
+            with patch("app.services.booking_service.sms_service") as mock_sms:
+                mock_sms.send_booking_confirmation = AsyncMock()
+                mock_sms.send_booking_failure = AsyncMock()
+
+                with patch.object(CTDateTime, "now") as mock_ct_now:
+                    mock_ct_now.return_value = pytz.timezone("America/Chicago").localize(
+                        self.NOW_CT
+                    )
+
+                    await booking_service._handle_confirm_intent(session)
+                    await booking_service.wait_for_background_bookings()
+
+        assert mock_sms.send_booking_failure.await_count == 2
+        assert all(
+            call.args[4] == "778899" for call in mock_sms.send_booking_failure.await_args_list
+        )
+        mock_sms.send_booking_confirmation.assert_not_called()
+
+        # Nothing is left claiming to still be running.
+        assert len(stored) == 2
+        assert all(b.status == BookingStatus.FAILED for b in stored.values())
+        assert all("driver died" in (b.error_message or "") for b in stored.values())
+
+    @pytest.mark.asyncio
+    async def test_a_booking_missing_from_the_batch_result_is_still_answered(
+        self, booking_service: BookingService
+    ) -> None:
+        """A result the provider never reported must not become silence."""
+        import pytz
+
+        from app.providers.base import BatchBookingItemResult, BatchBookingResult
+
+        session = self._session()
+
+        async def book_only_the_first(
+            target_date: date, requests: list, execute_at: datetime | None = None
+        ) -> BatchBookingResult:
+            return BatchBookingResult(
+                results=[
+                    BatchBookingItemResult(
+                        booking_id=requests[0].booking_id,
+                        result=BookingResult(success=True, booked_time=requests[0].target_time),
+                    )
+                ],
+                total_succeeded=1,
+            )
+
+        provider = MagicMock()
+        provider.book_tee_time = AsyncMock()
+        provider.book_multiple_tee_times = AsyncMock(side_effect=book_only_the_first)
+        booking_service.set_reservation_provider(provider)
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            self._fake_database(mock_db)
+
+            with patch("app.services.booking_service.sms_service") as mock_sms:
+                mock_sms.send_booking_confirmation = AsyncMock()
+                mock_sms.send_booking_failure = AsyncMock()
+
+                with patch.object(CTDateTime, "now") as mock_ct_now:
+                    mock_ct_now.return_value = pytz.timezone("America/Chicago").localize(
+                        self.NOW_CT
+                    )
+
+                    await booking_service._handle_confirm_intent(session)
+                    await booking_service.wait_for_background_bookings()
+
+        assert mock_sms.send_booking_confirmation.await_count == 1
+        assert mock_sms.send_booking_failure.await_count == 1
 
 
 class TestStatusIntentVisibility:


### PR DESCRIPTION
Confirming two ad-hoc bookings in one message failed one of them:

```
00:06:21.344  === STARTING BOOKING ATTEMPT === requested_time=17:00 ...
00:06:21.396  === STARTING BOOKING ATTEMPT === requested_time=17:08 ...   <- 52ms later
00:06:35.59   Entering credentials...   (driver A)
00:06:35.67   Entering credentials...   (driver B)
00:06:47.90   Login successful. -> books 17:00
00:06:53.09   ERROR Login failed. Still on URL: .../web/pages/login
```

Two headless Chromes hit the club's login form ~80ms apart. The portal accepted
one and left the other on `/login` until the 15s `url_changes` wait expired, so
the 5:08 PM booking came back as "Failed to log in to Walden Golf". Which
booking loses is a coin flip.

## Root cause

#125 changed `create_booking` from `await self.execute_booking(...)` to
`self._spawn_booking_execution(...)`. That was the right call for the OOM
problem it solved, but the `await` was also the only thing serializing
`_handle_confirm_multiple_bookings`' loop over `session.pending_requests`. Since
then every booking in a multi-booking request has started its own driver at the
same moment.

Only the ad-hoc path was affected. The scheduled 6:30 job goes through
`execute_bookings_batch` -> `book_multiple_tee_times`, which has always been one
driver working sequentially.

## The fix

Immediate bookings now pass `defer_execution=True`, so `create_booking` still
creates the record and marks it IN_PROGRESS but does not spawn. After the loop,
they go into **one** spawned task calling `execute_bookings_batch` — the same
one-driver, one-login, sequential path the 6:30 job already uses. #125's reason
for spawning is preserved: the Discord reply is still not blocked, and a crash
mid-attempt still cannot take the reply down with it.

`execute_bookings_batch` deliberately leaves notification to its caller, so the
new runner reports each outcome itself. Every booking here has already been
acknowledged to the user, so no path out may end in silence:

- batch raises -> each booking reported from its persisted state, so rows the
  batch had already resolved to SUCCESS report success instead of being
  clobbered to FAILED
- booking missing from the results -> explicit failure rather than nothing

The three duplicated (and subtly inconsistent) notification bodies in
`execute_booking` collapse into a shared `_notify_booking_result`, so an ad-hoc
booking reads identically to the user whether it ran alone or in a batch.

## Tests

New `TestImmediateMultiBookingRunsAsOneBatch` covers one task and one
`book_multiple_tee_times` call carrying both tee times with `execute_at=None`;
a batch that raises still messaging both bookings in the right channel and
leaving nothing stuck IN_PROGRESS; and a booking absent from the results still
being answered.

Verified they bite: reverting only the `defer_execution` flag fails all three,
the key one with `assert 3 == 1` on the background-task count — exactly the old
per-booking-task behavior.

Two existing tests changed. They read `booking_details` only from kwargs, while
a third already read it as kwarg-or-positional. The old code passed it as a
keyword in two branches and positionally in a third; now that all three share a
call site, those two use the same read the third already did.

Full suite: 682 passed, 3 skipped. ruff and mypy clean.

## Notes for review

- Sequencing: this lands before #127. With ad-hoc *multi* bookings now on the
  batch provider path, only *single* ad-hoc bookings still use
  `_book_tee_time_sync` — which is exactly what #127 collapses. It also means
  #127's "one ad-hoc booking run end to end" test is unambiguous; validating it
  with two bookings before this fix would have hit the login collision and
  looked like the refactor broke something.
- Still unknown: whether Walden enforces one session per member. The failure is
  equally explained by CPU contention (`cpu=1`, two Chromes; every phase ran
  1.4-1.9x slower than the same booking run alone, and the winner took 12.3s
  against a 15s timeout). This fix makes it moot for correctness, but the answer
  decides whether parallelizing for speed is ever on the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Immediate bookings can now be processed together, improving efficiency for multiple bookings.
  * Booking requests return promptly while processing continues in the background.
  * Each booking receives an individual success or failure notification.
  * Booking status more accurately reflects in-progress, completed, failed, and interrupted bookings.
* **Bug Fixes**
  * Improved reporting when booking attempts fail, time out, or produce incomplete results.
  * Added recovery for interrupted bookings and clearer handling of provider or notification errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->