### PR TITLE
fix: settle an unreadable direct-HTTP booking, and say why it was refused

### DIFF
--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -44,6 +44,11 @@ logger = logging.getLogger(__name__)
 # chain there is no fixed inter-click delay to pay here.
 _MAX_PLAYERS = 4
 
+# Marks a chain result as this path's. The provider handles both this and the JS
+# chain's results through the same branches, but only this one leaves the browser
+# DOM untouched, so only this one needs the outcome resolved against the site.
+DIRECT_HTTP_PATH = "direct-http"
+
 # Chain phases. These are a cross-module contract: the provider decides whether
 # a Selenium retry is safe by looking at which phase the chain stopped in, so
 # the names live here and are imported there rather than duplicated.
@@ -91,6 +96,7 @@ class DirectBookingResult:
             "error": self.error,
             "timing": self.timing,
             "finalMarkup": self.final_markup,
+            "path": DIRECT_HTTP_PATH,
         }
 
 

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -501,10 +501,11 @@ def find_response_message(markup: str) -> str | None:
         if not _is_message_container(node):
             continue
         # Hidden containers are templates PrimeFaces renders on every page, not
-        # something the member was shown.
-        if node.attrs.get("aria-hidden", "").lower() == "true":
+        # something the member was shown - and a container inside a hidden
+        # dialog is just as unseen as one hidden itself.
+        if _is_hidden(node) or _has_hidden_ancestor(node):
             continue
-        text = " ".join(node.text_content().split())
+        text = _visible_message_text(node)
         if not text or text.lower() in seen:
             continue
         # A container nested inside one already collected would repeat its text.
@@ -518,6 +519,41 @@ def find_response_message(markup: str) -> str | None:
 
     joined = "; ".join(messages)
     return joined[:_MAX_MESSAGE_CHARS] + "..." if len(joined) > _MAX_MESSAGE_CHARS else joined
+
+
+def _is_hidden(node: Node) -> bool:
+    """Report whether a node is explicitly hidden from the member."""
+    return node.attrs.get("aria-hidden", "").lower() == "true"
+
+
+def _has_hidden_ancestor(node: Node) -> bool:
+    """Report whether any ancestor hides this node."""
+    current = node.parent
+    while current is not None:
+        if _is_hidden(current):
+            return True
+        current = current.parent
+    return False
+
+
+def _visible_message_text(node: Node) -> str:
+    """Text of a node's subtree with hidden branches pruned.
+
+    ``text_content()`` would sweep in an ``aria-hidden`` child template sitting
+    inside a visible wrapper, which reports stale text and - because the nesting
+    check drops a message already contained in a collected one - can hide the
+    real message behind it.
+    """
+    parts: list[str] = []
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        if _is_hidden(current):
+            continue
+        if current.text:
+            parts.append(current.text)
+        stack.extend(reversed(current.children))
+    return " ".join(" ".join(parts).split())
 
 
 def _is_message_container(node: Node) -> bool:

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -44,6 +44,17 @@ logger = logging.getLogger(__name__)
 # chain there is no fixed inter-click delay to pay here.
 _MAX_PLAYERS = 4
 
+# Class-name substrings marking a message/alert container, the tree-matching
+# equivalent of the CSS selectors in DOM.ERROR_MESSAGES.containers. "error"
+# covers ui-messages-error, ui-message-error, ui-growl-message-error and plain
+# .error/.errors; the PrimeFaces widget classes catch a validation message
+# rendered without an -error suffix.
+_MESSAGE_CLASS_MARKERS = ("error", "alert", "ui-messages", "ui-growl")
+
+# Enough to carry a validation sentence or two into an SMS/Discord reply without
+# pasting a re-rendered tee sheet into it.
+_MAX_MESSAGE_CHARS = 500
+
 # Marks a chain result as this path's. The provider handles both this and the JS
 # chain's results through the same branches, but only this one leaves the browser
 # DOM untouched, so only this one needs the outcome resolved against the site.
@@ -78,6 +89,12 @@ class DirectBookingResult:
     branch on both identically, plus ``final_markup`` - the last response body,
     which is the only record of the booking outcome, since the browser DOM is
     untouched by this path.
+
+    ``success`` here means every step of the chain ran without erroring - the
+    four POSTs went out and each response yielded the element the next step
+    needed. It is not evidence that a reservation exists: a completed chain
+    whose tee time never appeared on the member's reservations page is exactly
+    what prompted this field's documentation. The provider verifies separately.
     """
 
     success: bool = False
@@ -86,6 +103,10 @@ class DirectBookingResult:
     error: str | None = None
     timing: dict[str, Any] = field(default_factory=dict)
     final_markup: str = ""
+    # Visible validation/message text found in the final response, if any. The
+    # direct path's counterpart to _extract_booking_error_message, which reads
+    # the browser DOM this path never touches.
+    response_message: str | None = None
 
     def as_chain_result(self) -> dict[str, Any]:
         """Render as the dict shape ``_run_booking_chain_js`` returns."""
@@ -96,6 +117,7 @@ class DirectBookingResult:
             "error": self.error,
             "timing": self.timing,
             "finalMarkup": self.final_markup,
+            "responseMessage": self.response_message,
             "path": DIRECT_HTTP_PATH,
         }
 
@@ -180,7 +202,16 @@ class DirectHttpBooker:
             return self._run_chain(num_players, target_timestamp_ms, result)
         except DirectHttpError as exc:
             result.error = str(exc)
-            logger.warning("DIRECT_HTTP: Chain failed in phase %s: %s", result.phase, exc)
+            # A step that could not find the element it needed is often a step
+            # the site refused; the reason, if it gave one, is in the response
+            # that step was reading.
+            result.response_message = find_response_message(result.final_markup)
+            logger.warning(
+                "DIRECT_HTTP: Chain failed in phase %s: %s%s",
+                result.phase,
+                exc,
+                f" (site message: {result.response_message})" if result.response_message else "",
+            )
             return result
         except Exception as exc:  # noqa: BLE001 - this path must never abort a booking run
             # An unexpected error here is a bug in this module, not a booking
@@ -244,10 +275,32 @@ class DirectHttpBooker:
             result.final_markup = response.markup
             result.timing["tbdGuestsMs"] = elapsed_ms()
 
+            blocked_reason = _find_blocked_message(response)
+            if blocked_reason is not None:
+                result.blocked = True
+                result.error = blocked_reason
+                return result
+
         result.phase = PHASE_BOOK_NOW
         response = self._click_book_now(response)
         result.final_markup = response.markup
         result.timing["bookNowMs"] = elapsed_ms()
+
+        # The submit step can be refused like any other, and until now this was
+        # the one step whose response nobody examined: the chain went straight
+        # to COMPLETE. A booking the club turned down at Book Now was therefore
+        # indistinguishable from one it accepted, because neither says anything
+        # the phrase check recognizes.
+        blocked_reason = _find_blocked_message(response)
+        if blocked_reason is not None:
+            result.blocked = True
+            result.error = blocked_reason
+            return result
+
+        # Whatever the site rendered in its message containers rides along, so a
+        # refusal for a reason we have no pattern for still reaches the member
+        # instead of being reported as an unexplained non-confirmation.
+        result.response_message = find_response_message(response.markup)
 
         result.phase = PHASE_COMPLETE
         result.success = True
@@ -422,6 +475,66 @@ def _find_book_now(document: Node) -> Node | None:
         if node.text_content().strip().lower() in ("book now", "book"):
             return node
     return None
+
+
+def find_response_message(markup: str) -> str | None:
+    """Extract visible validation/message text from a partial response.
+
+    The direct-HTTP counterpart of ``_extract_booking_error_message``, which
+    reads the same kind of containers off the browser DOM. This path has no DOM,
+    so a refusal the phrase check has no pattern for used to reach the member as
+    an unexplained "did not confirm the reservation" - true, but useless.
+
+    This is diagnostic text only: nothing branches on it. That is deliberate.
+    A full tee sheet re-render carries hidden message templates, so treating a
+    match as a refusal would fail bookings that succeeded. Reporting the text
+    alongside an outcome decided elsewhere costs nothing if it is noise.
+
+    Returns:
+        The collected message text, or None when the response carries none.
+    """
+    document = parse_html(markup)
+    seen: set[str] = set()
+    messages: list[str] = []
+
+    for node in document.descendants():
+        if not _is_message_container(node):
+            continue
+        # Hidden containers are templates PrimeFaces renders on every page, not
+        # something the member was shown.
+        if node.attrs.get("aria-hidden", "").lower() == "true":
+            continue
+        text = " ".join(node.text_content().split())
+        if not text or text.lower() in seen:
+            continue
+        # A container nested inside one already collected would repeat its text.
+        if any(text in collected for collected in messages):
+            continue
+        seen.add(text.lower())
+        messages.append(text)
+
+    if not messages:
+        return None
+
+    joined = "; ".join(messages)
+    return joined[:_MAX_MESSAGE_CHARS] + "..." if len(joined) > _MAX_MESSAGE_CHARS else joined
+
+
+def _is_message_container(node: Node) -> bool:
+    """Report whether a node is one of the site's message/alert containers.
+
+    Mirrors ``DOM.ERROR_MESSAGES.containers`` - which is a CSS selector list,
+    and this tree matches by class substring rather than selectors.
+    """
+    if node.attrs.get("role", "").lower() == "alert":
+        return True
+    if node.attrs.get("aria-live", "").lower() in ("assertive", "polite"):
+        return True
+    return any(
+        marker in css_class.lower()
+        for css_class in node.classes
+        for marker in _MESSAGE_CLASS_MARKERS
+    )
 
 
 def _find_blocked_message(response: PartialResponse) -> str | None:

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -2923,21 +2923,27 @@ class WaldenGolfProvider(ReservationProvider):
             if not chain_result.get("success"):
                 phase = chain_result.get("phase", "unknown")
                 error = chain_result.get("error", "Unknown error in fast booking chain")
+                held: bool | None = None
                 if chain_result.get("path") == DIRECT_HTTP_PATH:
                     partial_markup = chain_result.get("finalMarkup")
                     if partial_markup:
                         self._capture_response_artifact(
                             f"direct_http_failed_{phase}", partial_markup
                         )
+                    # Before the reservations check, not after: that check
+                    # navigates to the dashboard, and a screenshot taken on the
+                    # way out would show that page instead of the state that
+                    # failed.
+                    self._capture_diagnostic_info(driver, f"fast_chain_failed_{phase}")
                     # Past the Reserve POST the chain's own failure says nothing
                     # about the reservation: the browser never saw the booking,
                     # and the step that would have confirmed it is the one that
                     # broke. Ask the reservations page before writing the tee
                     # time off - reporting a booking we hold as failed sends the
                     # member to a course thinking they have no slot.
-                    if phase not in PRE_SUBMIT_PHASES and self._reservation_exists(
-                        driver, target_date, booked_time
-                    ):
+                    if phase not in PRE_SUBMIT_PHASES:
+                        held = self._reservation_exists(driver, target_date, booked_time)
+                    if held:
                         logger.warning(
                             "DIRECT_HTTP: Chain failed at %s but the reservation is on the "
                             "member's reservations page; reporting success",
@@ -2949,14 +2955,25 @@ class WaldenGolfProvider(ReservationProvider):
                             fallback_reason=fallback_reason,
                             course_name=self.NORTHGATE_COURSE_NAME,
                         )
-                self._capture_diagnostic_info(driver, f"fast_chain_failed_{phase}")
+                else:
+                    self._capture_diagnostic_info(driver, f"fast_chain_failed_{phase}")
+
+                message = f"Fast booking failed at {phase}: {error}"
                 site_message = chain_result.get("responseMessage")
+                if site_message:
+                    message += f" (the site said: {site_message})"
+                # "Could not check" is not "not booked". Saying so keeps this
+                # message honest in the same way the verification branch below is.
+                if (
+                    held is None
+                    and chain_result.get("path") == DIRECT_HTTP_PATH
+                    and phase not in PRE_SUBMIT_PHASES
+                ):
+                    message += "; the member's reservations page could not be checked"
+
                 return BookingResult(
                     success=False,
-                    error_message=(
-                        f"Fast booking failed at {phase}: {error}"
-                        f"{f' (the site said: {site_message})' if site_message else ''}"
-                    ),
+                    error_message=message,
                     booked_time=booked_time,
                     course_name=self.NORTHGATE_COURSE_NAME,
                 )
@@ -5774,8 +5791,13 @@ class WaldenGolfProvider(ReservationProvider):
             target_time.strftime("%I:%M%p").lstrip("0"),
             target_time.strftime("%I:%M %p"),
         )
+        # The hour must not be preceded by another digit. A bare substring test
+        # lets a row rendering "12:08 PM" satisfy a search for "2:08 PM", which
+        # would report a tee time the member never booked as held - the exact
+        # false confirmation this whole check exists to rule out.
         return any(
-            variation.lower() in lowered or variation in row_text for variation in time_variations
+            re.search(rf"(?<!\d){re.escape(variation)}", row_text, re.IGNORECASE)
+            for variation in time_variations
         )
 
     def _reservation_exists(

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -2950,9 +2950,13 @@ class WaldenGolfProvider(ReservationProvider):
                             course_name=self.NORTHGATE_COURSE_NAME,
                         )
                 self._capture_diagnostic_info(driver, f"fast_chain_failed_{phase}")
+                site_message = chain_result.get("responseMessage")
                 return BookingResult(
                     success=False,
-                    error_message=f"Fast booking failed at {phase}: {error}",
+                    error_message=(
+                        f"Fast booking failed at {phase}: {error}"
+                        f"{f' (the site said: {site_message})' if site_message else ''}"
+                    ),
                     booked_time=booked_time,
                     course_name=self.NORTHGATE_COURSE_NAME,
                 )
@@ -3005,11 +3009,15 @@ class WaldenGolfProvider(ReservationProvider):
                     if held is False
                     else "and the member's reservations page could not be checked"
                 )
+                # The response's own message containers are the only place a
+                # refusal we have no phrase for can still be read from.
+                site_message = chain_result.get("responseMessage")
                 return BookingResult(
                     success=False,
                     error_message=(
                         "Direct-HTTP booking chain completed but the response did not "
                         f"confirm the reservation ({verdict_detail}) {whereabouts}"
+                        f"{f'. The site said: {site_message}' if site_message else ''}"
                     ),
                     booked_time=booked_time,
                     course_name=self.NORTHGATE_COURSE_NAME,

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -38,7 +38,11 @@ from app.providers.base import (
 from app.providers.wait_helper import WaitStrategy
 from app.providers.walden_dom_schema import DOM
 from app.providers.walden_http import PrimeFacesSession, visible_text
-from app.providers.walden_http_booker import PRE_SUBMIT_PHASES, DirectHttpBooker
+from app.providers.walden_http_booker import (
+    DIRECT_HTTP_PATH,
+    PRE_SUBMIT_PHASES,
+    DirectHttpBooker,
+)
 from app.utils.timezone import CTDateTime
 
 logger = logging.getLogger(__name__)
@@ -857,6 +861,7 @@ class WaldenGolfProvider(ReservationProvider):
                 fallback_window_minutes,
                 tee_time_interval_minutes=tee_time_interval_minutes,
                 use_fast_js=use_fast_js,
+                target_date=target_date,
             )
 
             logger.info(
@@ -1211,6 +1216,7 @@ class WaldenGolfProvider(ReservationProvider):
                         use_fast_js=use_fast_booking,
                         prelocated_slot=prelocated_slots.get(req.booking_id),
                         execute_at_timestamp_ms=use_timed_for_this_booking,
+                        target_date=target_date,
                     )
 
                     results.append(
@@ -2746,6 +2752,7 @@ class WaldenGolfProvider(ReservationProvider):
         use_fast_js: bool = False,
         prelocated_slot: dict[str, Any] | None = None,
         execute_at_timestamp_ms: int | None = None,
+        target_date: date | None = None,
     ) -> BookingResult:
         """
         Find an available time slot and book it.
@@ -2786,6 +2793,9 @@ class WaldenGolfProvider(ReservationProvider):
                             When provided, uses _stage_timed_booking_chain_js which busy-waits
                             in JavaScript until the exact timestamp before clicking Reserve.
                             This eliminates Python→Selenium→JS handoff latency at 6:30 AM.
+            target_date: The date being booked. Only needed to resolve a
+                            direct-HTTP outcome against the member's reservations
+                            page; without it an unreadable response stays unresolved.
 
         Returns:
             BookingResult with booking outcome
@@ -2913,6 +2923,32 @@ class WaldenGolfProvider(ReservationProvider):
             if not chain_result.get("success"):
                 phase = chain_result.get("phase", "unknown")
                 error = chain_result.get("error", "Unknown error in fast booking chain")
+                if chain_result.get("path") == DIRECT_HTTP_PATH:
+                    partial_markup = chain_result.get("finalMarkup")
+                    if partial_markup:
+                        self._capture_response_artifact(
+                            f"direct_http_failed_{phase}", partial_markup
+                        )
+                    # Past the Reserve POST the chain's own failure says nothing
+                    # about the reservation: the browser never saw the booking,
+                    # and the step that would have confirmed it is the one that
+                    # broke. Ask the reservations page before writing the tee
+                    # time off - reporting a booking we hold as failed sends the
+                    # member to a course thinking they have no slot.
+                    if phase not in PRE_SUBMIT_PHASES and self._reservation_exists(
+                        driver, target_date, booked_time
+                    ):
+                        logger.warning(
+                            "DIRECT_HTTP: Chain failed at %s but the reservation is on the "
+                            "member's reservations page; reporting success",
+                            phase,
+                        )
+                        return BookingResult(
+                            success=True,
+                            booked_time=booked_time,
+                            fallback_reason=fallback_reason,
+                            course_name=self.NORTHGATE_COURSE_NAME,
+                        )
                 self._capture_diagnostic_info(driver, f"fast_chain_failed_{phase}")
                 return BookingResult(
                     success=False,
@@ -2929,7 +2965,10 @@ class WaldenGolfProvider(ReservationProvider):
             if direct_markup:
                 page_text = visible_text(direct_markup)
                 confirmation_number = self._extract_confirmation_number_from_text(page_text)
-                if self._verify_booking_success_text(page_text, "direct HTTP response"):
+                confirmed, verdict_detail = self._booking_text_verdict(
+                    page_text, "direct HTTP response"
+                )
+                if confirmed:
                     return BookingResult(
                         success=True,
                         booked_time=booked_time,
@@ -2937,12 +2976,40 @@ class WaldenGolfProvider(ReservationProvider):
                         fallback_reason=fallback_reason,
                         course_name=self.NORTHGATE_COURSE_NAME,
                     )
+
+                # The Book Now response is a PrimeFaces partial update, not a
+                # confirmation page: it can carry the reservation without saying
+                # so in words the phrase check recognizes. Treating that silence
+                # as a failure is how a booked tee time gets reported as lost, so
+                # the response is kept for diagnosis and the outcome is settled
+                # against the member's reservations page instead.
+                self._capture_response_artifact("direct_http_verify_failed", direct_markup)
+                held = self._reservation_exists(driver, target_date, booked_time)
+                if held:
+                    logger.info(
+                        "DIRECT_HTTP: Response was unreadable (%s) but the reservation is on "
+                        "the member's reservations page; reporting success",
+                        verdict_detail,
+                    )
+                    return BookingResult(
+                        success=True,
+                        booked_time=booked_time,
+                        confirmation_number=confirmation_number,
+                        fallback_reason=fallback_reason,
+                        course_name=self.NORTHGATE_COURSE_NAME,
+                    )
+
                 self._capture_diagnostic_info(driver, "direct_http_verify_failed")
+                whereabouts = (
+                    "and the tee time is not on the member's reservations page"
+                    if held is False
+                    else "and the member's reservations page could not be checked"
+                )
                 return BookingResult(
                     success=False,
                     error_message=(
                         "Direct-HTTP booking chain completed but the response did not "
-                        "confirm the reservation"
+                        f"confirm the reservation ({verdict_detail}) {whereabouts}"
                     ),
                     booked_time=booked_time,
                     course_name=self.NORTHGATE_COURSE_NAME,
@@ -4934,6 +5001,39 @@ class WaldenGolfProvider(ReservationProvider):
         except Exception as e:
             logger.warning(f"Failed to capture diagnostic info: {e}")
 
+    def _capture_response_artifact(self, context: str, markup: str) -> None:
+        """Record a direct-HTTP response body for diagnosis.
+
+        _capture_diagnostic_info photographs the browser, which on this path is
+        still showing the pre-booking tee sheet - it cannot explain a response
+        the browser never received. The response is the only account of what the
+        server did, so it is logged as a text excerpt and stored on its own.
+        """
+        if not markup:
+            return
+
+        try:
+            excerpt = visible_text(markup)[:1000]
+        except Exception as e:  # noqa: BLE001 - diagnostics must not fail a booking
+            excerpt = f"<unparseable: {e}>"
+        logger.error("DIRECT_HTTP: %s - response text: %r", context, excerpt)
+
+        bucket_name = os.getenv("DEBUG_ARTIFACTS_BUCKET")
+        if not bucket_name:
+            return
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        try:
+            uri = self._upload_bytes_to_gcs(
+                bucket_name=bucket_name,
+                object_name=f"walden/{context}/{timestamp}/direct_http_response.html",
+                content_type="text/html; charset=utf-8",
+                data=markup.encode("utf-8", errors="replace"),
+            )
+            logger.info(f"Saved direct-HTTP response to {uri}")
+        except Exception as e:  # noqa: BLE001 - see above
+            logger.warning(f"Failed to upload direct-HTTP response artifact: {e}")
+
     def _upload_bytes_to_gcs(
         self, *, bucket_name: str, object_name: str, content_type: str, data: bytes
     ) -> str:
@@ -5336,6 +5436,23 @@ class WaldenGolfProvider(ReservationProvider):
         Returns:
             True only on positive confirmation; ambiguity is treated as failure.
         """
+        confirmed, _detail = self._booking_text_verdict(text, context)
+        return bool(confirmed)
+
+    def _booking_text_verdict(self, text: str, context: str) -> tuple[bool | None, str]:
+        """Classify booking text as confirmed, refused, or silent.
+
+        The three-way answer is what separates "the site said no" from "the site
+        said nothing we recognize". Both are failures when the browser DOM is the
+        source - the DOM would be showing a confirmation if there were one - but
+        on the direct-HTTP path silence is routine, and the caller resolves it
+        against the reservations page rather than reporting a loss.
+
+        Returns:
+            (True, matched success phrases) on confirmation, (False, matched
+            failure phrases) on refusal, (None, reason) when neither appears.
+            The detail is phrased for a user-facing error message.
+        """
         try:
             logger.info(f"BOOKING_DEBUG: Verifying booking success. Source: {context}")
             page_text = text.lower()
@@ -5367,7 +5484,7 @@ class WaldenGolfProvider(ReservationProvider):
 
             if found_failures:
                 logger.error(f"BOOKING_DEBUG: Found failure indicator(s): {found_failures}")
-                return False
+                return False, f"the response reported: {', '.join(found_failures)}"
 
             # Check for success indicators
             found_successes = []
@@ -5377,17 +5494,17 @@ class WaldenGolfProvider(ReservationProvider):
 
             if found_successes:
                 logger.debug(f"BOOKING_DEBUG: Found success indicator(s): {found_successes}")
-                return True
+                return True, f"confirmed by: {', '.join(found_successes)}"
 
             logger.warning(
                 f"BOOKING_DEBUG: No clear success or failure indicators found - treating as failure. "
                 f"Source: {context}"
             )
-            return False
+            return None, "no success or failure wording in the response"
 
         except Exception as e:
             logger.error(f"BOOKING_DEBUG: Error verifying booking: {e}")
-            return False
+            return False, f"the response could not be read: {e}"
 
     async def get_available_times(self, target_date: date) -> list[time]:
         """
@@ -5560,53 +5677,12 @@ class WaldenGolfProvider(ReservationProvider):
             return False
 
         try:
-            reservations_form = None
-            try:
-                reservations_form = driver.find_element(
-                    By.CSS_SELECTOR, DOM.CANCELLATION.reservations_form
-                )
-                logger.info("Found reservations form, scoping search to it")
-            except NoSuchElementException:
-                logger.warning("Reservations form not found, searching entire page")
-
-            if reservations_form:
-                reservation_rows = reservations_form.find_elements(
-                    By.CSS_SELECTOR, "table tbody tr"
-                )
-            else:
-                reservation_rows = driver.find_elements(By.CSS_SELECTOR, "table tbody tr")
-
+            reservation_rows = self._find_reservation_rows(driver)
             logger.info(f"Found {len(reservation_rows)} potential reservation rows")
 
             for row in reservation_rows:
                 try:
-                    row_text = row.text.lower()
-
-                    if "tee time" not in row_text:
-                        continue
-
-                    date_match = False
-                    time_match = False
-
-                    if display_date in row.text:
-                        date_match = True
-                    else:
-                        alt_date = target_date.strftime("%m/%d/%y")
-                        if alt_date in row.text:
-                            date_match = True
-
-                    time_variations = [
-                        display_time_12h,
-                        target_time.strftime("%H:%M"),
-                        target_time.strftime("%I:%M%p").lstrip("0"),
-                        target_time.strftime("%I:%M %p"),
-                    ]
-                    for time_var in time_variations:
-                        if time_var.lower() in row_text or time_var in row.text:
-                            time_match = True
-                            break
-
-                    if date_match and time_match:
+                    if self._reservation_row_matches(row, target_date, target_time):
                         logger.info(f"Found matching reservation row: {row.text[:100]}...")
 
                         cancel_link = None
@@ -5646,6 +5722,114 @@ class WaldenGolfProvider(ReservationProvider):
         except Exception as e:
             logger.error(f"Error finding reservation: {e}")
             return False
+
+    def _find_reservation_rows(self, driver: webdriver.Chrome) -> list[Any]:
+        """Return the rows of the member's reservations table.
+
+        Scoped to the reservations form when it is present; the whole page is
+        the fallback, since a missed row reads as "no reservation".
+        """
+        try:
+            reservations_form = driver.find_element(
+                By.CSS_SELECTOR, DOM.CANCELLATION.reservations_form
+            )
+            logger.info("Found reservations form, scoping search to it")
+            return list(
+                reservations_form.find_elements(By.CSS_SELECTOR, DOM.CANCELLATION.reservation_rows)
+            )
+        except NoSuchElementException:
+            logger.warning("Reservations form not found, searching entire page")
+            return list(driver.find_elements(By.CSS_SELECTOR, DOM.CANCELLATION.reservation_rows))
+
+    def _reservation_row_matches(self, row: Any, target_date: date, target_time: time) -> bool:
+        """Report whether a reservations-table row is this tee time.
+
+        Both the date and the time have to match, in any of the formats the page
+        has been seen to render them in.
+        """
+        row_text = row.text
+        lowered = row_text.lower()
+
+        if "tee time" not in lowered:
+            return False
+
+        date_variations = (
+            target_date.strftime("%m/%d/%Y"),
+            target_date.strftime("%m/%d/%y"),
+        )
+        if not any(variation in row_text for variation in date_variations):
+            return False
+
+        time_variations = (
+            target_time.strftime("%I:%M %p").lstrip("0"),
+            target_time.strftime("%H:%M"),
+            target_time.strftime("%I:%M%p").lstrip("0"),
+            target_time.strftime("%I:%M %p"),
+        )
+        return any(
+            variation.lower() in lowered or variation in row_text for variation in time_variations
+        )
+
+    def _reservation_exists(
+        self,
+        driver: webdriver.Chrome,
+        target_date: date | None,
+        booked_time: time,
+    ) -> bool | None:
+        """Ask the member's reservations page whether a tee time was actually booked.
+
+        The direct-HTTP path leaves the browser on the pre-booking tee sheet, so
+        when its final response is unreadable there is nothing local left to
+        consult. The reservations page is the site's own answer, and it is the
+        only one that can tell a booking that landed from one that did not.
+
+        Navigating away costs the tee sheet, so this runs only on the paths that
+        are already about to return - the batch loop reloads and re-selects
+        course and date before the next booking either way.
+
+        Returns:
+            True when the reservation is listed, False when the page was read and
+            it is not there, None when the page could not be read at all.
+        """
+        if target_date is None:
+            logger.warning(
+                "RESERVATION_CHECK: No target date available; cannot check the "
+                "reservations page for %s",
+                booked_time.strftime("%I:%M %p"),
+            )
+            return None
+
+        try:
+            logger.info(
+                "RESERVATION_CHECK: Looking for %s at %s on the member's reservations page",
+                target_date.strftime("%m/%d/%Y"),
+                booked_time.strftime("%I:%M %p"),
+            )
+            driver.get(self.DASHBOARD_URL)
+            WebDriverWait(driver, 15).until(
+                expected_conditions.presence_of_element_located(
+                    (By.CSS_SELECTOR, DOM.CANCELLATION.dashboard_presence)
+                )
+            )
+            self.wait_strategy.wait_after_action(driver, fixed_duration=2.0)
+
+            for row in self._find_reservation_rows(driver):
+                try:
+                    if self._reservation_row_matches(row, target_date, booked_time):
+                        logger.info("RESERVATION_CHECK: Reservation found - %s", row.text[:100])
+                        return True
+                except StaleElementReferenceException:
+                    continue
+
+            logger.info("RESERVATION_CHECK: No reservation listed for this tee time")
+            return False
+
+        except Exception as e:
+            # Unknown is its own answer here: reporting "not booked" because the
+            # page would not load could send the member to a slot they hold, or
+            # away from one they do.
+            logger.warning(f"RESERVATION_CHECK: Could not read the reservations page: {e}")
+            return None
 
     def _confirm_cancellation_sync(
         self,

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -892,6 +892,20 @@ class TestFinalMarkup:
 
         assert "Booking confirmed" in chain_result["finalMarkup"]
 
+    def test_chain_result_identifies_the_path_it_came_from(self) -> None:
+        """The provider resolves only this path's outcomes against the site.
+
+        A JS-chain result leaves the browser sitting on the booking's own
+        response, so the DOM answers for it. Nothing in the shape of the dict
+        says which chain produced it, so the path is named in it.
+        """
+        from app.providers.walden_http_booker import DIRECT_HTTP_PATH
+
+        recorder = ChainRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        chain_result = make_booker(recorder).book(1).as_chain_result()
+
+        assert chain_result["path"] == DIRECT_HTTP_PATH
+
 
 class TestPrepare:
     """Staging the Reserve request off the real tee sheet."""

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -647,6 +647,31 @@ class TestFindResponseMessage:
 
         assert find_response_message(markup) == "Real message"
 
+    def test_hidden_child_template_inside_a_visible_wrapper_is_pruned(self) -> None:
+        """A visible wrapper must not carry its hidden template's text.
+
+        The hidden text would be reported as the site's message, and because a
+        message already contained in a collected one is dropped as nested, it
+        would take the real child message down with it.
+        """
+        markup = (
+            '<div class="ui-messages">'
+            '<div class="ui-message-error" aria-hidden="true">Stale template text</div>'
+            '<div class="ui-message-error">Members are limited to one per day.</div>'
+            "</div>"
+        )
+
+        assert find_response_message(markup) == "Members are limited to one per day."
+
+    def test_container_inside_a_hidden_dialog_is_skipped(self) -> None:
+        """A visible container the member cannot see is still not a message."""
+        markup = (
+            '<div class="ui-dialog" aria-hidden="true">'
+            '<div class="ui-messages-error">Hidden dialog text</div></div>'
+        )
+
+        assert find_response_message(markup) is None
+
     def test_empty_containers_report_nothing(self) -> None:
         """An unfilled message container is not a message."""
         assert find_response_message('<div class="ui-messages-error"></div>') is None

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -27,9 +27,11 @@ from app.providers.walden_http import (
     visible_text,
 )
 from app.providers.walden_http_booker import (
+    PHASE_BOOK_NOW,
     PHASE_RESERVE_SENT,
     PRE_SUBMIT_PHASES,
     DirectHttpBooker,
+    find_response_message,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -599,6 +601,81 @@ BLOCKED_PAGE = (
     "This slot is blocked by another user</div></form>"
 )
 
+# What a refusal we have no phrase for looks like: the response says no in a
+# message container, using none of the words the phrase check knows.
+REFUSED_PAGE = (
+    f'<form id="{FORM_ID}" action="/post">'
+    '<div class="ui-messages-error">'
+    "Members are limited to one tee time per day.</div></form>"
+)
+
+# The same refusal raised through the blocked popup at Book Now rather than at
+# Reserve - the step whose response nothing used to examine.
+BLOCKED_AT_BOOK_NOW = (
+    f'<form id="{FORM_ID}" action="/post">'
+    '<div id="teeSheetValidationErrorPopup" aria-hidden="false">'
+    "That time is already reserved</div></form>"
+)
+
+
+class TestFindResponseMessage:
+    """Reading the site's own message containers out of a partial response."""
+
+    def test_reads_a_primefaces_error_message(self) -> None:
+        """The container class the site uses for validation errors."""
+        message = find_response_message(
+            '<div class="ui-messages-error">Members are limited to one per day.</div>'
+        )
+
+        assert message == "Members are limited to one per day."
+
+    def test_reads_role_alert_and_aria_live(self) -> None:
+        """Not every message container is spelled with a class."""
+        assert find_response_message('<div role="alert">Slot unavailable</div>') == (
+            "Slot unavailable"
+        )
+        assert find_response_message('<span aria-live="assertive">Try again</span>') == (
+            "Try again"
+        )
+
+    def test_skips_hidden_template_containers(self) -> None:
+        """PrimeFaces renders empty message templates on every page."""
+        markup = (
+            '<div class="ui-messages-error" aria-hidden="true">Stale template text</div>'
+            '<div class="ui-messages-error">Real message</div>'
+        )
+
+        assert find_response_message(markup) == "Real message"
+
+    def test_empty_containers_report_nothing(self) -> None:
+        """An unfilled message container is not a message."""
+        assert find_response_message('<div class="ui-messages-error"></div>') is None
+
+    def test_nested_containers_are_not_repeated(self) -> None:
+        """A wrapper and its child would otherwise both carry the same text."""
+        markup = (
+            '<div class="ui-messages"><div class="ui-messages-error">'
+            "Only one per day</div></div>"
+        )
+
+        assert find_response_message(markup) == "Only one per day"
+
+    def test_long_text_is_truncated(self) -> None:
+        """A re-rendered tee sheet must not be pasted into an SMS reply."""
+        message = find_response_message(f'<div role="alert">{"x" * 900}</div>')
+
+        assert message is not None
+        assert len(message) <= 503
+        assert message.endswith("...")
+
+    def test_a_clean_tee_sheet_yields_nothing(self) -> None:
+        """The real page carries no message text to mistake for a refusal.
+
+        This is what makes the extraction safe to report alongside every
+        failure: the routine response has nothing in it.
+        """
+        assert find_response_message(TEE_SHEET) is None
+
 
 class ChainRecorder:
     """Serves canned responses in order, recording each request's source."""
@@ -709,6 +786,59 @@ class TestDirectHttpBooker:
 
         assert result.success, result.error
         assert bodies[1]["players"] == "1"
+
+    def test_blocked_slot_is_detected_at_book_now(self) -> None:
+        """The submit step's response is examined like every other step's.
+
+        Regression: the chain went straight from Book Now to COMPLETE, so a
+        booking refused at the last step was reported the same as one accepted.
+        """
+        recorder = ChainRecorder(
+            [PLAYER_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, BLOCKED_AT_BOOK_NOW]
+        )
+        result = make_booker(recorder).book(4)
+
+        assert not result.success
+        assert result.blocked
+        assert result.phase == PHASE_BOOK_NOW
+        assert result.error is not None and "already reserved" in result.error
+
+    def test_book_now_refusal_text_is_carried_off_the_chain(self) -> None:
+        """A refusal with no known phrase still reaches the caller as words.
+
+        The chain completes - every step found what it needed - but the site
+        said no in a message container, and that is the only readable record of
+        why no reservation exists.
+        """
+        recorder = ChainRecorder(
+            [PLAYER_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, REFUSED_PAGE]
+        )
+        result = make_booker(recorder).book(4)
+
+        assert result.phase == "complete"
+        assert result.response_message is not None
+        assert "one tee time per day" in result.response_message
+        assert result.as_chain_result()["responseMessage"] == result.response_message
+
+    def test_confirmed_response_carries_no_message(self) -> None:
+        """A clean confirmation has nothing to report."""
+        recorder = ChainRecorder(
+            [PLAYER_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, ROWS_PAGE, BOOKED_PAGE]
+        )
+        result = make_booker(recorder).book(4)
+
+        assert result.success, result.error
+        assert result.response_message is None
+
+    def test_failed_step_carries_the_message_it_was_reading(self) -> None:
+        """A step that cannot find its element reports what the site said."""
+        recorder = ChainRecorder([REFUSED_PAGE])
+        result = make_booker(recorder).book(4)
+
+        assert not result.success
+        assert result.phase == "player_count"
+        assert result.response_message is not None
+        assert "one tee time per day" in result.response_message
 
     def test_missing_player_selector_fails_in_that_phase(self) -> None:
         """A response without the selector fails in player_count."""

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -8,14 +8,17 @@ against the actual Walden Golf website structure.
 import os
 from datetime import date, time, timedelta
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
 
 from app.config import settings
+from app.providers.base import BookingResult
 from app.providers.walden_dom_schema import DOM
 from app.providers.walden_http import DirectHttpError
+from app.providers.walden_http_booker import DIRECT_HTTP_PATH, PHASE_RESERVE_STAGED
 from app.providers.walden_provider import WaldenGolfProvider
 from app.utils.timezone import CTDateTime
 
@@ -2948,6 +2951,296 @@ class TestDirectHttpBookingWiring:
         assert result.success is True
         timed_chain.assert_not_called()
         fast_chain.assert_not_called()
+
+
+class TestUnconfirmedBookingResolution:
+    """What happens when the direct-HTTP response does not say either way.
+
+    Book Now returns a PrimeFaces partial update, not a confirmation page, and
+    the browser never sees it - so a response with no recognizable wording is
+    routine rather than evidence of a lost slot. The member's reservations page
+    is the only thing that can settle it, and reporting a tee time we hold as
+    failed is the expensive mistake.
+    """
+
+    SLOT = dict(TestDirectHttpBookingWiring.SLOT)
+    TARGET_DATE = date(2026, 8, 8)
+    # No success or failure wording anywhere - the tee sheet re-render case.
+    SILENT_MARKUP = "<div><p>Northgate tee sheet</p></div>"
+
+    def _book(
+        self,
+        provider: WaldenGolfProvider,
+        monkeypatch: pytest.MonkeyPatch,
+        chain_result: dict[str, object],
+        reservation_exists: bool | None,
+    ) -> tuple[BookingResult, MagicMock]:
+        """Run one booking whose direct chain returned ``chain_result``."""
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        monkeypatch.setattr(
+            provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
+        )
+        monkeypatch.setattr(
+            provider, "_try_direct_http_booking", MagicMock(return_value=chain_result)
+        )
+        monkeypatch.setattr(provider, "_capture_diagnostic_info", MagicMock())
+        monkeypatch.setattr(provider, "_capture_response_artifact", MagicMock())
+        reservation_check = MagicMock(return_value=reservation_exists)
+        monkeypatch.setattr(provider, "_reservation_exists", reservation_check)
+
+        result = provider._find_and_book_time_slot_sync(
+            MagicMock(),
+            target_time=time(8, 42),
+            num_players=4,
+            fallback_window_minutes=32,
+            skip_scroll=True,
+            use_fast_js=True,
+            target_date=self.TARGET_DATE,
+        )
+        return result, reservation_check
+
+    def _completed_chain(self, markup: str) -> dict[str, object]:
+        return {
+            "success": True,
+            "blocked": False,
+            "phase": "complete",
+            "error": None,
+            "timing": {},
+            "finalMarkup": markup,
+            "path": DIRECT_HTTP_PATH,
+        }
+
+    def test_silent_response_with_the_reservation_on_file_is_a_success(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The regression: a booked tee time reported as lost."""
+        result, reservation_check = self._book(
+            provider,
+            monkeypatch,
+            self._completed_chain(self.SILENT_MARKUP),
+            reservation_exists=True,
+        )
+
+        assert result.success is True
+        assert result.booked_time == time(8, 42)
+        reservation_check.assert_called_once_with(ANY, self.TARGET_DATE, time(8, 42))
+
+    def test_silent_response_with_no_reservation_says_where_it_looked(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failure the member can act on names what was checked."""
+        result, _ = self._book(
+            provider,
+            monkeypatch,
+            self._completed_chain(self.SILENT_MARKUP),
+            reservation_exists=False,
+        )
+
+        assert result.success is False
+        assert result.error_message is not None
+        assert "did not confirm" in result.error_message
+        assert "not on the member's reservations page" in result.error_message
+
+    def test_unreachable_reservations_page_is_not_read_as_a_no(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unchecked page is reported as unchecked, not as an empty one."""
+        result, _ = self._book(
+            provider,
+            monkeypatch,
+            self._completed_chain(self.SILENT_MARKUP),
+            reservation_exists=None,
+        )
+
+        assert result.success is False
+        assert result.error_message is not None
+        assert "could not be checked" in result.error_message
+
+    def test_refusal_wording_is_carried_into_the_error(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """What the site said is worth more than that it said no."""
+        result, _ = self._book(
+            provider,
+            monkeypatch,
+            self._completed_chain("<div><p>Unable to complete this reservation.</p></div>"),
+            reservation_exists=False,
+        )
+
+        assert result.success is False
+        assert result.error_message is not None
+        assert "unable to" in result.error_message
+
+    def test_a_confirmed_response_never_reaches_the_reservations_page(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The check costs the tee sheet, so it only runs when it is needed."""
+        result, reservation_check = self._book(
+            provider,
+            monkeypatch,
+            self._completed_chain("<div><h2>Your tee time is booked</h2></div>"),
+            reservation_exists=False,
+        )
+
+        assert result.success is True
+        reservation_check.assert_not_called()
+
+    def test_failure_after_reserve_was_sent_checks_the_reservations_page(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The chain breaking mid-flight does not mean the booking did."""
+        result, reservation_check = self._book(
+            provider,
+            monkeypatch,
+            {
+                "success": False,
+                "blocked": False,
+                "phase": "book_now",
+                "error": "Book Now button not found in response",
+                "timing": {},
+                "finalMarkup": self.SILENT_MARKUP,
+                "path": DIRECT_HTTP_PATH,
+            },
+            reservation_exists=True,
+        )
+
+        assert result.success is True
+        assert result.booked_time == time(8, 42)
+        reservation_check.assert_called_once()
+
+    def test_failure_before_reserve_was_sent_does_not_check(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nothing reached the server, so there is nothing to look up."""
+        result, reservation_check = self._book(
+            provider,
+            monkeypatch,
+            {
+                "success": False,
+                "blocked": False,
+                "phase": PHASE_RESERVE_STAGED,
+                "error": "prepare() must be called before book()",
+                "timing": {},
+                "finalMarkup": "",
+                "path": DIRECT_HTTP_PATH,
+            },
+            reservation_exists=True,
+        )
+
+        assert result.success is False
+        reservation_check.assert_not_called()
+
+    def test_a_js_chain_failure_does_not_check(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The JS chain leaves the browser on its own response; the DOM answers."""
+        result, reservation_check = self._book(
+            provider,
+            monkeypatch,
+            {
+                "success": False,
+                "blocked": False,
+                "phase": "book_now",
+                "error": "Book Now click failed",
+                "timing": {},
+            },
+            reservation_exists=True,
+        )
+
+        assert result.success is False
+        reservation_check.assert_not_called()
+
+
+class TestReservationLookup:
+    """Reading the member's reservations page as ground truth."""
+
+    def _driver_with_rows(self, rows: list[str]) -> MagicMock:
+        driver = MagicMock()
+        form = MagicMock()
+        form.find_elements.return_value = [SimpleNamespace(text=row_text) for row_text in rows]
+        driver.find_element.return_value = form
+        return driver
+
+    @pytest.fixture(autouse=True)
+    def _no_settle_sleep(self, provider: WaldenGolfProvider) -> None:
+        """The page-settle wait is a real sleep; tests do not need to serve it."""
+        provider.wait_strategy = MagicMock()
+
+    def test_matching_reservation_is_found(self, provider: WaldenGolfProvider) -> None:
+        """The row the site renders for a booking we hold."""
+        driver = self._driver_with_rows(["08/08/2026 - Tee Time - 5:08 PM - Northgate - 4 players"])
+
+        assert provider._reservation_exists(driver, date(2026, 8, 8), time(17, 8)) is True
+
+    def test_reservation_for_another_time_is_not_ours(self, provider: WaldenGolfProvider) -> None:
+        """The first booking of a batch must not vouch for the second."""
+        driver = self._driver_with_rows(["08/08/2026 - Tee Time - 5:00 PM - Northgate"])
+
+        assert provider._reservation_exists(driver, date(2026, 8, 8), time(17, 8)) is False
+
+    def test_reservation_on_another_date_is_not_ours(self, provider: WaldenGolfProvider) -> None:
+        """Same time, different day - a standing weekly booking would match."""
+        driver = self._driver_with_rows(["08/15/2026 - Tee Time - 5:08 PM - Northgate"])
+
+        assert provider._reservation_exists(driver, date(2026, 8, 8), time(17, 8)) is False
+
+    def test_two_digit_year_and_24_hour_rows_still_match(
+        self, provider: WaldenGolfProvider
+    ) -> None:
+        """The page has been seen rendering both; neither is a miss."""
+        driver = self._driver_with_rows(["08/08/26 Tee Time 17:08 Northgate"])
+
+        assert provider._reservation_exists(driver, date(2026, 8, 8), time(17, 8)) is True
+
+    def test_non_tee_time_rows_are_ignored(self, provider: WaldenGolfProvider) -> None:
+        """Dining and event rows share the table."""
+        driver = self._driver_with_rows(["08/08/2026 - Dining Reservation - 5:08 PM"])
+
+        assert provider._reservation_exists(driver, date(2026, 8, 8), time(17, 8)) is False
+
+    def test_an_unreadable_page_answers_unknown(self, provider: WaldenGolfProvider) -> None:
+        """False would mean 'not booked', which is more than the page said."""
+        driver = MagicMock()
+        driver.get.side_effect = WebDriverException("session died")
+
+        assert provider._reservation_exists(driver, date(2026, 8, 8), time(17, 8)) is None
+
+    def test_without_a_date_there_is_nothing_to_match_on(
+        self, provider: WaldenGolfProvider
+    ) -> None:
+        """A time alone would match the same slot on any day."""
+        driver = MagicMock()
+
+        assert provider._reservation_exists(driver, None, time(17, 8)) is None
+        driver.get.assert_not_called()
+
+
+class TestBookingTextVerdict:
+    """Three answers, because silence and refusal are not the same thing."""
+
+    def test_confirmation_wording_is_a_yes(self, provider: WaldenGolfProvider) -> None:
+        confirmed, detail = provider._booking_text_verdict("Your tee time is booked", "test")
+
+        assert confirmed is True
+        assert "booked" in detail
+
+    def test_refusal_wording_is_a_no(self, provider: WaldenGolfProvider) -> None:
+        confirmed, detail = provider._booking_text_verdict("Unable to reserve", "test")
+
+        assert confirmed is False
+        assert "unable to" in detail
+
+    def test_neither_is_neither(self, provider: WaldenGolfProvider) -> None:
+        """The case the reservations-page check exists for."""
+        confirmed, detail = provider._booking_text_verdict("Northgate tee sheet", "test")
+
+        assert confirmed is None
+        assert "no success or failure wording" in detail
+
+    def test_the_boolean_wrapper_still_fails_closed(self, provider: WaldenGolfProvider) -> None:
+        """Callers reading the browser DOM keep the pessimistic answer."""
+        assert provider._verify_booking_success_text("Northgate tee sheet", "test") is False
+        assert provider._verify_booking_success_text("Booking confirmed", "test") is True
 
 
 class TestBookingPathDefaults:

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -3178,6 +3178,33 @@ class TestReservationLookup:
 
         assert provider._reservation_exists(driver, date(2026, 8, 8), time(17, 8)) is False
 
+    def test_shorter_time_does_not_match_inside_a_longer_one(
+        self, provider: WaldenGolfProvider
+    ) -> None:
+        """"2:08 PM" must not be found inside a row rendering "12:08 PM".
+
+        A member can hold both on one date, and a substring match would vouch
+        for a 2:08 PM tee time that was never booked - the false confirmation
+        this whole check exists to rule out.
+        """
+        driver = self._driver_with_rows(["08/08/2026 - Tee Time - 12:08 PM - Northgate"])
+
+        assert provider._reservation_exists(driver, date(2026, 8, 8), time(14, 8)) is False
+
+    def test_am_hour_does_not_match_inside_a_longer_one(
+        self, provider: WaldenGolfProvider
+    ) -> None:
+        """The same trap on the morning side: "1:08 AM" inside "11:08 AM"."""
+        driver = self._driver_with_rows(["08/08/2026 - Tee Time - 11:08 AM - Northgate"])
+
+        assert provider._reservation_exists(driver, date(2026, 8, 8), time(1, 8)) is False
+
+    def test_the_longer_time_still_matches_itself(self, provider: WaldenGolfProvider) -> None:
+        """Anchoring the hour must not stop a genuine 12:08 PM from matching."""
+        driver = self._driver_with_rows(["08/08/2026 - Tee Time - 12:08 PM - Northgate"])
+
+        assert provider._reservation_exists(driver, date(2026, 8, 8), time(12, 8)) is True
+
     def test_reservation_on_another_date_is_not_ours(self, provider: WaldenGolfProvider) -> None:
         """Same time, different day - a standing weekly booking would match."""
         driver = self._driver_with_rows(["08/15/2026 - Tee Time - 5:08 PM - Northgate"])

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -3181,7 +3181,7 @@ class TestReservationLookup:
     def test_shorter_time_does_not_match_inside_a_longer_one(
         self, provider: WaldenGolfProvider
     ) -> None:
-        """"2:08 PM" must not be found inside a row rendering "12:08 PM".
+        """A 2:08 PM search must not be satisfied by a row rendering 12:08 PM.
 
         A member can hold both on one date, and a substring match would vouch
         for a 2:08 PM tee time that was never booked - the false confirmation
@@ -3191,9 +3191,7 @@ class TestReservationLookup:
 
         assert provider._reservation_exists(driver, date(2026, 8, 8), time(14, 8)) is False
 
-    def test_am_hour_does_not_match_inside_a_longer_one(
-        self, provider: WaldenGolfProvider
-    ) -> None:
+    def test_am_hour_does_not_match_inside_a_longer_one(self, provider: WaldenGolfProvider) -> None:
         """The same trap on the morning side: "1:08 AM" inside "11:08 AM"."""
         driver = self._driver_with_rows(["08/08/2026 - Tee Time - 11:08 AM - Northgate"])
 


### PR DESCRIPTION
## Correction to the original description

This PR originally said the 5:08 PM tee time "may in fact be booked — worth checking the reservations page." It was checked. **It was not booked.** The rest of this description is rewritten around that; the original framing (a booking we held but reported as lost) was wrong.

## What happened

Booking 8/8 at 5:00 PM and 5:08 PM — a date inside the 7-day window, so both ran immediately as one batch (the #128 path). The first was confirmed. The second came back:

> Unable to book tee time for Saturday, August 08 at 05:08 PM for 4 players: Direct-HTTP booking chain completed but the response did not confirm the reservation

That message is the direct-HTTP verification branch in `_find_and_book_time_slot_sync`. Reaching it means the chain ran all four steps — Reserve → player count → TBD guests → Book Now — so the Book Now request was posted and its response came back.

The reservations page says no tee time exists at 5:08. So the request was made and the club did not create the reservation. **We still do not know why**, and that is the actual defect: nothing in that run recorded a reason, and nothing in the code was capable of reporting one.

Two gaps account for that:

1. **The submit step's response was never examined.** The chain checked for a refusal after Reserve and after the player count, then went straight from Book Now to `COMPLETE`. A booking the club turned down at the last request looked exactly like one it accepted.
2. **The direct path had no counterpart to `_extract_booking_error_message`.** The Selenium paths read the site's message containers off the DOM to explain a failure. This path never touches the browser, so a refusal phrased in words the success/failure phrase check has no pattern for — a per-day limit, a guest rule — arrived as an unexplained non-confirmation.

The phrase check itself is not the problem, and the fixture evidence in the original description still holds: a tee sheet re-render carries none of `confirmed` / `booked` / `your tee time` / `thank you`, nor any failure wording. Silence on this path is routine. It just isn't the whole story.

## The fix

**Settling the outcome** (unchanged from the original push, and still correct — with it, this run would have reported a clean failure instead of an ambiguous one):

- When the direct-HTTP response neither confirms nor refuses, the outcome is settled against the member's reservations page — the same table the cancellation flow already reads. The row lookup and row matcher move out of `_find_and_cancel_reservation_sync` so both use one matcher.
- The same check covers a direct-HTTP chain that failed *after* Reserve was sent. Pre-submit failures still fall back to the JS chain untouched, and JS-chain failures don't run the check at all — the browser is on its own response there, so the DOM answers.
- `_verify_booking_success_text` keeps its pessimistic boolean for DOM-reading callers, but is now a wrapper over a three-way verdict (confirmed / refused / silent).
- The direct-HTTP response body is logged as a text excerpt and stored beside the screenshots, so the next occurrence is diagnosable without the browser.

**Saying why** (added after the reservations page came back empty):

- The blocked check now runs after Book Now, and after the TBD guest step — every step's response is examined, not just the first two.
- `find_response_message` reads the containers `DOM.ERROR_MESSAGES` lists out of the response markup, matching by class substring since this tree has no CSS selectors. Hidden containers are skipped: PrimeFaces renders empty message templates on every page.
- That text rides along on `DirectBookingResult` and into the failure message on both the completed-but-unconfirmed and failed-after-submit paths.
- It is **diagnostic only — nothing branches on it.** Treating a match as a refusal would fail bookings that succeeded. It is reported beside an outcome the reservations page decides. On the captured tee sheet the extractor finds nothing at all, which is what makes it safe to attach to every failure.
- `DirectBookingResult.success` is documented for what it is: four POSTs that did not raise. This booking proves that is compatible with no reservation existing.

## What this does not fix

The 5:08 PM booking failed for a reason we still cannot name. This change makes the next occurrence explain itself; it does not explain this one, and it does not make the booking succeed. If the club limits a member to one tee time per day, no amount of error reporting will book the second one — that is worth confirming before treating this as a code defect.

## Testing

`707 passed, 10 skipped` (`poetry run pytest tests/`), ruff and mypy clean.

Covering the settle path: a silent response with the reservation on file reported as success; a silent response with no reservation naming where it looked; an unreachable page reported as unchecked rather than as a no; refusal wording carried into the error; a confirmed response never paying for the check; post-submit failure checking and pre-submit failure not; JS-chain results skipping it; reservation row matching across date/time formats, wrong date, wrong time, and non-tee-time rows; and the three-way verdict.

Covering the message path: a refusal detected at Book Now rather than at Reserve; refusal text with no known phrase carried off a completed chain; a confirmed response carrying no message; a failed step reporting the text it was reading; and, for the extractor itself, PrimeFaces error classes, `role="alert"` / `aria-live`, hidden templates skipped, empty containers ignored, nested containers not repeated, truncation, and **the real captured tee sheet yielding nothing**.

## Risk

The reservations-page check navigates away from the tee sheet, so it runs only on paths that are already returning — the batch loop reloads and re-selects course and date before the next booking either way. It costs a page load during the 6:30 race, but only in the branch where we otherwise report a booking we might hold as lost.

The message extraction runs on markup already in memory and only on failure paths, so it costs nothing on a successful booking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Booking results now include visible messages returned by the booking site.
  * Booking responses are verified against reservations when the outcome is unclear.
* **Bug Fixes**
  * Improved detection of blocked, refused, or unavailable bookings at the final submission step.
  * Prevented uncertain bookings from being incorrectly reported as confirmed.
  * Improved handling of booking failures before submission and preserved relevant site messages for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->