### PR TITLE
docs: replace gsutil with gcloud storage in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ All GCP infrastructure is managed via Terraform in the `terraform/` directory.
 1. Create a GCS bucket for Terraform state:
    ```bash
    PROJECT_ID="teetime"
-   gsutil mb -p $PROJECT_ID gs://${PROJECT_ID}-terraform-state
-   gsutil versioning set on gs://${PROJECT_ID}-terraform-state
+   gcloud storage buckets create gs://${PROJECT_ID}-terraform-state --project=$PROJECT_ID
+   gcloud storage buckets update gs://${PROJECT_ID}-terraform-state --versioning
    ```
 
 2. Connect GitHub to Cloud Build (one-time, via console):


### PR DESCRIPTION
Closes #130.

Google is removing `gsutil` from the default Google Cloud CLI bundle in March 2027. After that, environments that replace themselves on update (Docker, Snap) lose the binary outright, and other install methods keep a frozen, unsupported copy.

## Change

The only `gsutil` usage in this repo is the Terraform state bucket bootstrap in `README.md`:

```diff
-gsutil mb -p $PROJECT_ID gs://${PROJECT_ID}-terraform-state
-gsutil versioning set on gs://${PROJECT_ID}-terraform-state
+gcloud storage buckets create gs://${PROJECT_ID}-terraform-state --project=$PROJECT_ID
+gcloud storage buckets update gs://${PROJECT_ID}-terraform-state --versioning
```

## Scope check

`deploy.sh`, `cloudbuild.yaml`, the `Dockerfile`, `terraform/`, `scripts/`, and the application code use only `gcloud` subcommands (`run`, `builds`, `artifacts`, `scheduler`, `services`, `logging`), none of which are affected by this deprecation. The Dockerfile does not pull the gcloud SDK image, so the Docker/Snap breakage path in Google's notice does not apply here either.

`grep -rn gsutil .` now returns nothing outside of git history.

## Testing

Docs-only change — no code paths touched, nothing to run. The replacement commands follow the current `gcloud storage` syntax from Google's [gsutil-to-gcloud-storage mapping](https://cloud.google.com/storage/docs/gsutil-to-gcloud-storage); they have not been executed against a live project, since doing so would create a real bucket.

---
_Generated by [Claude Code](https://claude.ai/code/session_014KxNYgCUY8qScM9ZfpHg9Y)_