### PR TITLE
fix: stop a Gemini blip from losing an already-parsed booking

### DIFF
--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -36,6 +36,68 @@ INTERRUPTED_ERROR_MESSAGE = (
     "please check the club website before rebooking."
 )
 
+# Replies that settle a pending booking confirmation without asking the LLM
+# what they mean. The bot just printed the bookings and said "Reply 'yes' to
+# confirm", so a bare "yes" needs no interpretation - and sending it to Gemini
+# anyway means a transient API failure can lose an already-parsed booking at
+# the one moment it costs the most.
+#
+# Matching is exact, on the normalized message, never substring: "yes" is
+# inside "yesterday" and "no" is inside "no, make it 5:30", and both of those
+# are real replies that still need parsing. Anything not listed here falls
+# through to the LLM unchanged, so this set is deliberately short - it holds
+# only replies with exactly one meaning in this state.
+AFFIRMATIVE_CONFIRMATIONS = frozenset(
+    {
+        "yes",
+        "y",
+        "ya",
+        "yah",
+        "yeah",
+        "yep",
+        "yup",
+        "yes please",
+        "ok",
+        "okay",
+        "k",
+        "sure",
+        "confirm",
+        "confirmed",
+        "do it",
+        "book it",
+        "go ahead",
+        "send it",
+        "sounds good",
+        "perfect",
+        "👍",
+    }
+)
+
+# "cancel" and "stop" are deliberately absent: they still go to the LLM,
+# because they may mean "cancel my existing bookings" rather than "don't book
+# this one", and that distinction is not ours to guess here.
+NEGATIVE_CONFIRMATIONS = frozenset(
+    {
+        "no",
+        "n",
+        "nope",
+        "nah",
+        "no thanks",
+        "no thank you",
+    }
+)
+
+
+def _normalize_reply(message: str) -> str:
+    """Reduce a message to a comparable form: lowercase, no edge punctuation.
+
+    Collapses internal whitespace so "yes  please" matches, and strips
+    surrounding punctuation so "Yes!" and "yes." do too. Punctuation *inside*
+    the message is left alone, so "yes, make it 5:30" stays unmatched and goes
+    to the LLM where it belongs.
+    """
+    return " ".join(message.strip().lower().strip(".,!?;:'\" ").split())
+
 
 class BookingService:
     """
@@ -107,6 +169,12 @@ class BookingService:
         session = await self.get_session(phone_number)
         if origin_channel_id:
             session.origin_channel_id = origin_channel_id
+
+        affirmative = self._confirmation_shortcut(session, message)
+        if affirmative is not None:
+            response = await self._handle_confirmation_shortcut(session, affirmative)
+            await self.update_session(session)
+            return response
 
         context = None
         if session.state != ConversationState.IDLE:
@@ -183,6 +251,46 @@ class BookingService:
             f"I'll book a tee time for {date_str} at {time_str} "
             f"for {request.num_players} players. Reply 'yes' to confirm."
         )
+
+    def _confirmation_shortcut(self, session: UserSession, message: str) -> bool | None:
+        """Decide whether this message settles a pending booking without the LLM.
+
+        Returns True for an unambiguous yes, False for an unambiguous no, and
+        None when the message needs parsing - which is every case except a bare
+        confirmation of a booking we have already parsed and echoed back.
+
+        A pending cancellation is excluded on purpose: "yes" there answers "are
+        you sure you want to cancel", and that path keeps its existing handling.
+        """
+        if session.state != ConversationState.AWAITING_CONFIRMATION:
+            return None
+        if session.pending_cancellation_id:
+            return None
+        if not session.pending_request and not session.pending_requests:
+            return None
+
+        normalized = _normalize_reply(message)
+        if normalized in AFFIRMATIVE_CONFIRMATIONS:
+            return True
+        if normalized in NEGATIVE_CONFIRMATIONS:
+            return False
+        return None
+
+    async def _handle_confirmation_shortcut(self, session: UserSession, affirmative: bool) -> str:
+        """Act on a yes/no that was understood without calling the LLM."""
+        logger.info(
+            "Settled pending confirmation for %s without an LLM call (affirmative=%s)",
+            session.phone_number,
+            affirmative,
+        )
+
+        if affirmative:
+            return await self._handle_confirm_intent(session)
+
+        session.pending_request = None
+        session.pending_requests = None
+        session.state = ConversationState.IDLE
+        return "Okay, I won't book that. Let me know if you'd like a different date or time."
 
     async def _handle_confirm_intent(self, session: UserSession) -> str:
         if session.state != ConversationState.AWAITING_CONFIRMATION:

--- a/app/services/gemini_service.py
+++ b/app/services/gemini_service.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import re
 from datetime import date, datetime, time, timedelta
+from time import monotonic
 from typing import Any
 
 import google.generativeai as genai
@@ -34,11 +35,20 @@ TRANSIENT_API_EXCEPTIONS = (
     ConnectionError,
 )
 
-# Three attempts with 0.5s then 1.0s of backoff: 1.5s of added worst-case
-# latency, well inside the messaging webhook timeouts, and enough to ride out
-# the sub-second failures that make up most of them.
+# Three attempts with 0.5s then 1.0s of backoff, enough to ride out the
+# sub-second failures that make up most of them.
 GEMINI_MAX_ATTEMPTS = 3
 GEMINI_RETRY_BASE_DELAY = 0.5
+
+# The whole parse, retries and backoff included, is bounded - not just the
+# sleeps between attempts. The Twilio webhook at app/api/webhooks.py:59 awaits
+# this call and then sends the reply before returning, and Twilio drops the
+# request after ~15s, so a budget built only from backoff delays would be
+# fiction: three slow-but-not-failing calls could blow through it while every
+# attempt "succeeds". Each attempt also carries its own provider-side deadline,
+# so a single hung request cannot eat the entire budget.
+GEMINI_REQUEST_TIMEOUT = 6.0
+GEMINI_TOTAL_BUDGET = 10.0
 
 
 def _convert_proto_to_dict(obj: Any) -> Any:
@@ -180,16 +190,37 @@ class GeminiService:
     async def _generate_with_retry(self, prompt: str) -> Any:
         """Call the model, retrying transient failures with exponential backoff.
 
+        Uses the SDK's async method rather than the blocking one: this runs on
+        the same event loop that serves every other request, so a slow Gemini
+        call must not stall the process - and retrying a blocking call would
+        stall it up to three times over.
+
         Only the exceptions in TRANSIENT_API_EXCEPTIONS are retried. Anything
         else propagates on the first attempt, as does a transient error that
-        survives the final one - the caller turns both into the honest "nothing
+        survives the last one - the caller turns both into the honest "nothing
         was booked" reply rather than a guess.
+
+        Attempts stop early once GEMINI_TOTAL_BUDGET is spent, so a run of slow
+        responses cannot outlast the webhook waiting on it.
         """
-        for attempt in range(GEMINI_MAX_ATTEMPTS - 1):
+        deadline = monotonic() + GEMINI_TOTAL_BUDGET
+        last_error: Exception | None = None
+
+        for attempt in range(GEMINI_MAX_ATTEMPTS):
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                break
+
             try:
-                return self.model.generate_content(prompt)
+                return await self.model.generate_content_async(
+                    prompt,
+                    request_options={"timeout": min(GEMINI_REQUEST_TIMEOUT, remaining)},
+                )
             except TRANSIENT_API_EXCEPTIONS as e:
+                last_error = e
                 delay = GEMINI_RETRY_BASE_DELAY * (2**attempt)
+                if attempt == GEMINI_MAX_ATTEMPTS - 1 or monotonic() + delay >= deadline:
+                    break
                 logger.warning(
                     "Transient Gemini failure (attempt %d/%d): %s: %s. Retrying in %.1fs",
                     attempt + 1,
@@ -200,8 +231,13 @@ class GeminiService:
                 )
                 await asyncio.sleep(delay)
 
-        # Final attempt: whatever it raises reaches the caller's error handling.
-        return self.model.generate_content(prompt)
+        if last_error is not None:
+            raise last_error
+
+        # Budget gone before a single attempt could start.
+        raise TimeoutError(
+            f"Gemini budget of {GEMINI_TOTAL_BUDGET}s exhausted before any attempt completed"
+        )
 
     def _resolve_relative_date(self, date_str: str) -> date | None:
         today = datetime.now().date()

--- a/app/services/gemini_service.py
+++ b/app/services/gemini_service.py
@@ -1,15 +1,44 @@
+import asyncio
 import logging
 import re
 from datetime import date, datetime, time, timedelta
 from typing import Any
 
 import google.generativeai as genai
+from google.api_core import exceptions as google_exceptions
 from google.protobuf.json_format import MessageToDict
 
 from app.config import settings
 from app.models.schemas import ParsedIntent, TeeTimeRequest
 
 logger = logging.getLogger(__name__)
+
+# Failures that are worth a second attempt: quota and rate limits, Google-side
+# overload, and timeouts. Everything else (a bad key, a retired model, a
+# malformed request) fails the same way on every attempt, so retrying it only
+# adds latency before the same error.
+#
+# Without this, a single blip surfaced to the user as "my language model is
+# unavailable" with nothing booked - which is exactly what happened to a 'Yes'
+# confirming two tee times, one minute after the same model had parsed the
+# booking request successfully.
+TRANSIENT_API_EXCEPTIONS = (
+    google_exceptions.ResourceExhausted,  # 429 - quota / rate limit
+    google_exceptions.TooManyRequests,  # 429
+    google_exceptions.ServiceUnavailable,  # 503 - model overloaded
+    google_exceptions.InternalServerError,  # 500
+    google_exceptions.DeadlineExceeded,  # request timed out
+    google_exceptions.Aborted,
+    google_exceptions.RetryError,
+    TimeoutError,
+    ConnectionError,
+)
+
+# Three attempts with 0.5s then 1.0s of backoff: 1.5s of added worst-case
+# latency, well inside the messaging webhook timeouts, and enough to ride out
+# the sub-second failures that make up most of them.
+GEMINI_MAX_ATTEMPTS = 3
+GEMINI_RETRY_BASE_DELAY = 0.5
 
 
 def _convert_proto_to_dict(obj: Any) -> Any:
@@ -148,6 +177,32 @@ class GeminiService:
                 self._model = None
         return self._model
 
+    async def _generate_with_retry(self, prompt: str) -> Any:
+        """Call the model, retrying transient failures with exponential backoff.
+
+        Only the exceptions in TRANSIENT_API_EXCEPTIONS are retried. Anything
+        else propagates on the first attempt, as does a transient error that
+        survives the final one - the caller turns both into the honest "nothing
+        was booked" reply rather than a guess.
+        """
+        for attempt in range(GEMINI_MAX_ATTEMPTS - 1):
+            try:
+                return self.model.generate_content(prompt)
+            except TRANSIENT_API_EXCEPTIONS as e:
+                delay = GEMINI_RETRY_BASE_DELAY * (2**attempt)
+                logger.warning(
+                    "Transient Gemini failure (attempt %d/%d): %s: %s. Retrying in %.1fs",
+                    attempt + 1,
+                    GEMINI_MAX_ATTEMPTS,
+                    type(e).__name__,
+                    e,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        # Final attempt: whatever it raises reaches the caller's error handling.
+        return self.model.generate_content(prompt)
+
     def _resolve_relative_date(self, date_str: str) -> date | None:
         today = datetime.now().date()
         date_str_lower = date_str.lower()
@@ -277,7 +332,7 @@ class GeminiService:
                 prompt += f"Previous context: {context}\n\n"
             prompt += f"User message: {message}"
 
-            response = self.model.generate_content(prompt)
+            response = await self._generate_with_retry(prompt)
 
             if response.candidates and response.candidates[0].content.parts:
                 for part in response.candidates[0].content.parts:

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -1302,6 +1302,7 @@ class TestConfirmationShortcut:
 
     @staticmethod
     def _session_awaiting_confirmation() -> UserSession:
+        """Build a session parked on a single pending booking, awaiting yes/no."""
         return UserSession(
             phone_number="+15551234567",
             state=ConversationState.AWAITING_CONFIRMATION,
@@ -1393,6 +1394,7 @@ class TestConfirmationShortcut:
     def test_affirmative_variants_are_recognized(
         self, booking_service: BookingService, message: str
     ) -> None:
+        """Casing, trailing punctuation and a thumbs-up all read as yes."""
         session = self._session_awaiting_confirmation()
         assert booking_service._confirmation_shortcut(session, message) is True
 
@@ -1400,6 +1402,7 @@ class TestConfirmationShortcut:
     def test_negative_variants_are_recognized(
         self, booking_service: BookingService, message: str
     ) -> None:
+        """The same normalization applies to an unambiguous no."""
         session = self._session_awaiting_confirmation()
         assert booking_service._confirmation_shortcut(session, message) is False
 
@@ -1426,6 +1429,7 @@ class TestConfirmationShortcut:
     def test_shortcut_skipped_outside_awaiting_confirmation(
         self, booking_service: BookingService
     ) -> None:
+        """A stray 'yes' with no question pending still needs interpreting."""
         session = self._session_awaiting_confirmation()
         session.state = ConversationState.IDLE
         assert booking_service._confirmation_shortcut(session, "yes") is None
@@ -1433,6 +1437,7 @@ class TestConfirmationShortcut:
     def test_shortcut_skipped_without_a_pending_request(
         self, booking_service: BookingService
     ) -> None:
+        """Confirming state with nothing pending is not ours to shortcut."""
         session = self._session_awaiting_confirmation()
         session.pending_request = None
         assert booking_service._confirmation_shortcut(session, "yes") is None
@@ -1447,6 +1452,7 @@ class TestConfirmationShortcut:
 
     @pytest.mark.asyncio
     async def test_no_clears_the_pending_booking(self, booking_service: BookingService) -> None:
+        """Declining drops the pending booking and returns the session to idle."""
         session = self._session_awaiting_confirmation()
 
         with patch("app.services.booking_service.database_service") as mock_db:

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -1297,6 +1297,173 @@ class TestBookingServiceIncomingMessage:
                 assert "awaiting_date" in call_args[0][1].lower()
 
 
+class TestConfirmationShortcut:
+    """Tests for settling a pending confirmation without calling the LLM."""
+
+    @staticmethod
+    def _session_awaiting_confirmation() -> UserSession:
+        return UserSession(
+            phone_number="+15551234567",
+            state=ConversationState.AWAITING_CONFIRMATION,
+            pending_request=TeeTimeRequest(
+                requested_date=date(2025, 12, 20),
+                requested_time=time(8, 0),
+                num_players=4,
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_yes_books_without_calling_the_llm(self, booking_service: BookingService) -> None:
+        """A bare 'yes' is already understood - it must not need the API."""
+        session = self._session_awaiting_confirmation()
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_or_create_session = AsyncMock(return_value=session)
+            mock_db.update_session = AsyncMock(return_value=session)
+
+            with patch("app.services.booking_service.gemini_service") as mock_gemini:
+                mock_gemini.parse_message = AsyncMock()
+                with patch.object(
+                    booking_service,
+                    "_handle_confirm_intent",
+                    AsyncMock(return_value="Booking scheduled!"),
+                ) as mock_confirm:
+                    response = await booking_service.handle_incoming_message("+15551234567", "Yes")
+
+            assert response == "Booking scheduled!"
+            mock_confirm.assert_awaited_once_with(session)
+            mock_gemini.parse_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_llm_outage_no_longer_loses_a_confirmation(
+        self, booking_service: BookingService
+    ) -> None:
+        """Regression: the reported incident, where 'Yes' hit a Gemini failure.
+
+        Two tee times were parsed and echoed back, then the confirmation was
+        sent to the API purely to be told 'yes' means yes - and the API was
+        down that second, so nothing was booked.
+        """
+        session = self._session_awaiting_confirmation()
+        session.pending_request = None
+        session.pending_requests = [
+            TeeTimeRequest(
+                requested_date=date(2025, 8, 8), requested_time=time(17, 0), num_players=4
+            ),
+            TeeTimeRequest(
+                requested_date=date(2025, 8, 8), requested_time=time(17, 8), num_players=4
+            ),
+        ]
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_or_create_session = AsyncMock(return_value=session)
+            mock_db.update_session = AsyncMock(return_value=session)
+
+            with patch("app.services.booking_service.gemini_service") as mock_gemini:
+                mock_gemini.parse_message = AsyncMock(side_effect=AssertionError("LLM is down"))
+                with patch.object(
+                    booking_service,
+                    "_handle_confirm_intent",
+                    AsyncMock(return_value="Booked 2 tee times."),
+                ):
+                    response = await booking_service.handle_incoming_message("+15551234567", "Yes")
+
+            assert response == "Booked 2 tee times."
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Yes",
+            "yes",
+            "yes!",
+            "  YES  ",
+            "y",
+            "yep",
+            "yeah",
+            "ok",
+            "Okay.",
+            "sure",
+            "confirm",
+            "do it",
+            "book it",
+            "sounds good",
+            "👍",
+        ],
+    )
+    def test_affirmative_variants_are_recognized(
+        self, booking_service: BookingService, message: str
+    ) -> None:
+        session = self._session_awaiting_confirmation()
+        assert booking_service._confirmation_shortcut(session, message) is True
+
+    @pytest.mark.parametrize("message", ["no", "No", "nope", "nah", "no thanks", "No thank you."])
+    def test_negative_variants_are_recognized(
+        self, booking_service: BookingService, message: str
+    ) -> None:
+        session = self._session_awaiting_confirmation()
+        assert booking_service._confirmation_shortcut(session, message) is False
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "yesterday",
+            "no, make it 5:30",
+            "yes but move it to 6",
+            "book 8/9 at 5pm",
+            "not that one",
+            "cancel",
+            "1",
+            "",
+        ],
+    )
+    def test_anything_ambiguous_still_goes_to_the_llm(
+        self, booking_service: BookingService, message: str
+    ) -> None:
+        """Substring matches like 'yesterday' must not be read as 'yes'."""
+        session = self._session_awaiting_confirmation()
+        assert booking_service._confirmation_shortcut(session, message) is None
+
+    def test_shortcut_skipped_outside_awaiting_confirmation(
+        self, booking_service: BookingService
+    ) -> None:
+        session = self._session_awaiting_confirmation()
+        session.state = ConversationState.IDLE
+        assert booking_service._confirmation_shortcut(session, "yes") is None
+
+    def test_shortcut_skipped_without_a_pending_request(
+        self, booking_service: BookingService
+    ) -> None:
+        session = self._session_awaiting_confirmation()
+        session.pending_request = None
+        assert booking_service._confirmation_shortcut(session, "yes") is None
+
+    def test_shortcut_skipped_for_a_pending_cancellation(
+        self, booking_service: BookingService
+    ) -> None:
+        """'Yes' to 'cancel this booking?' must keep its existing handling."""
+        session = self._session_awaiting_confirmation()
+        session.pending_cancellation_id = "abc123"
+        assert booking_service._confirmation_shortcut(session, "yes") is None
+
+    @pytest.mark.asyncio
+    async def test_no_clears_the_pending_booking(self, booking_service: BookingService) -> None:
+        session = self._session_awaiting_confirmation()
+
+        with patch("app.services.booking_service.database_service") as mock_db:
+            mock_db.get_or_create_session = AsyncMock(return_value=session)
+            mock_db.update_session = AsyncMock(return_value=session)
+
+            with patch("app.services.booking_service.gemini_service") as mock_gemini:
+                mock_gemini.parse_message = AsyncMock()
+                response = await booking_service.handle_incoming_message("+15551234567", "no")
+
+            assert "won't book that" in response
+            assert session.pending_request is None
+            assert session.pending_requests is None
+            assert session.state == ConversationState.IDLE
+            mock_gemini.parse_message.assert_not_called()
+
+
 class TestBookingServiceHelpMessage:
     """Tests for the help message."""
 

--- a/tests/test_gemini_service.py
+++ b/tests/test_gemini_service.py
@@ -11,7 +11,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from google.api_core import exceptions as google_exceptions
 
-from app.services.gemini_service import GEMINI_MAX_ATTEMPTS, GeminiService
+from app.services.gemini_service import (
+    GEMINI_MAX_ATTEMPTS,
+    GEMINI_REQUEST_TIMEOUT,
+    GeminiService,
+)
 
 
 @pytest.fixture
@@ -536,7 +540,9 @@ class TestGeminiServiceParseMessage:
         a booking the user never asked for (what a retired model did in prod).
         """
         with patch.object(gemini_service, "_model", MagicMock()):
-            gemini_service._model.generate_content = MagicMock(side_effect=Exception("API Error"))
+            gemini_service._model.generate_content_async = AsyncMock(
+                side_effect=Exception("API Error")
+            )
 
             result = await gemini_service.parse_message("Book 8/2 at 5:06p")
 
@@ -569,7 +575,7 @@ class TestGeminiServiceParseMessage:
         mock_response.candidates = [mock_candidate]
 
         with patch.object(gemini_service, "_model", MagicMock()):
-            gemini_service._model.generate_content = MagicMock(
+            gemini_service._model.generate_content_async = AsyncMock(
                 side_effect=[
                     google_exceptions.ServiceUnavailable("model overloaded"),
                     mock_response,
@@ -580,7 +586,7 @@ class TestGeminiServiceParseMessage:
                 result = await gemini_service.parse_message("Yes")
 
             assert result.intent == "confirm"
-            assert gemini_service._model.generate_content.call_count == 2
+            assert gemini_service._model.generate_content_async.call_count == 2
             mock_sleep.assert_awaited_once_with(0.5)
 
     @pytest.mark.asyncio
@@ -589,7 +595,7 @@ class TestGeminiServiceParseMessage:
     ) -> None:
         """A sustained outage still fails honestly, after exhausting retries."""
         with patch.object(gemini_service, "_model", MagicMock()):
-            gemini_service._model.generate_content = MagicMock(
+            gemini_service._model.generate_content_async = AsyncMock(
                 side_effect=google_exceptions.ResourceExhausted("quota exceeded")
             )
 
@@ -599,22 +605,65 @@ class TestGeminiServiceParseMessage:
             assert result.intent == "unclear"
             assert result.tee_time_request is None
             assert "nothing was booked" in result.response_message
-            assert gemini_service._model.generate_content.call_count == GEMINI_MAX_ATTEMPTS
+            assert gemini_service._model.generate_content_async.call_count == GEMINI_MAX_ATTEMPTS
             # Exponential backoff, and no sleep after the final attempt.
             assert [call.args[0] for call in mock_sleep.await_args_list] == [0.5, 1.0]
+
+    @pytest.mark.asyncio
+    async def test_each_attempt_carries_a_provider_deadline(
+        self, gemini_service: GeminiService
+    ) -> None:
+        """A hung request must not sit there forever holding up the webhook."""
+        with patch.object(gemini_service, "_model", MagicMock()):
+            gemini_service._model.generate_content_async = AsyncMock(
+                side_effect=google_exceptions.DeadlineExceeded("timed out")
+            )
+
+            with patch("app.services.gemini_service.asyncio.sleep", AsyncMock()):
+                await gemini_service.parse_message("Book 8/2 at 5:06p")
+
+            first_call = gemini_service._model.generate_content_async.await_args_list[0]
+            assert first_call.kwargs["request_options"]["timeout"] == GEMINI_REQUEST_TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_retries_stop_once_the_total_budget_is_spent(
+        self, gemini_service: GeminiService
+    ) -> None:
+        """Slow attempts eat the budget too, not just the backoff sleeps.
+
+        Twilio drops the webhook at ~15s, so the retry loop has to account for
+        how long the calls themselves took - three slow-but-successful attempts
+        would otherwise blow the deadline while every attempt "worked".
+        """
+        # monotonic() readings: budget start, then the remaining-time check and
+        # the post-failure check for attempt 1. The second reading lands past
+        # the deadline, so there is no second attempt.
+        with patch("app.services.gemini_service.monotonic", side_effect=[0.0, 1.0, 9.6]):
+            with patch.object(gemini_service, "_model", MagicMock()):
+                gemini_service._model.generate_content_async = AsyncMock(
+                    side_effect=google_exceptions.ServiceUnavailable("model overloaded")
+                )
+
+                with patch("app.services.gemini_service.asyncio.sleep", AsyncMock()) as mock_sleep:
+                    result = await gemini_service.parse_message("Book 8/2 at 5:06p")
+
+                assert result.intent == "unclear"
+                assert "nothing was booked" in result.response_message
+                assert gemini_service._model.generate_content_async.call_count == 1
+                mock_sleep.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_non_transient_error_is_not_retried(self, gemini_service: GeminiService) -> None:
         """A bad key or retired model fails identically every time - fail fast."""
         with patch.object(gemini_service, "_model", MagicMock()):
-            gemini_service._model.generate_content = MagicMock(
+            gemini_service._model.generate_content_async = AsyncMock(
                 side_effect=google_exceptions.PermissionDenied("API key not valid")
             )
 
             result = await gemini_service.parse_message("Book 8/2 at 5:06p")
 
             assert result.intent == "unclear"
-            assert gemini_service._model.generate_content.call_count == 1
+            assert gemini_service._model.generate_content_async.call_count == 1
 
     def test_model_name_comes_from_settings(self, gemini_service: GeminiService) -> None:
         """The model is configurable so a retirement can be worked around by env."""
@@ -656,7 +705,7 @@ class TestGeminiServiceParseMessage:
         mock_response.candidates = [mock_candidate]
 
         with patch.object(gemini_service, "_model", MagicMock()):
-            gemini_service._model.generate_content = MagicMock(return_value=mock_response)
+            gemini_service._model.generate_content_async = AsyncMock(return_value=mock_response)
 
             with patch("app.services.gemini_service.datetime") as mock_datetime:
                 mock_datetime.now.return_value = fixed_now
@@ -687,7 +736,7 @@ class TestGeminiServiceParseMessage:
         mock_response.candidates = [mock_candidate]
 
         with patch.object(gemini_service, "_model", MagicMock()):
-            gemini_service._model.generate_content = MagicMock(return_value=mock_response)
+            gemini_service._model.generate_content_async = AsyncMock(return_value=mock_response)
 
             result = await gemini_service.parse_message("random gibberish")
 
@@ -701,7 +750,7 @@ class TestGeminiServiceParseMessage:
         mock_response.candidates = []
 
         with patch.object(gemini_service, "_model", MagicMock()):
-            gemini_service._model.generate_content = MagicMock(return_value=mock_response)
+            gemini_service._model.generate_content_async = AsyncMock(return_value=mock_response)
 
             result = await gemini_service.parse_message("test message")
 
@@ -729,7 +778,7 @@ class TestGeminiServiceParseMessage:
         mock_response.candidates = [mock_candidate]
 
         with patch.object(gemini_service, "_model", MagicMock()):
-            gemini_service._model.generate_content = MagicMock(return_value=mock_response)
+            gemini_service._model.generate_content_async = AsyncMock(return_value=mock_response)
 
             result = await gemini_service.parse_message("What are my bookings?")
 
@@ -762,7 +811,7 @@ class TestGeminiServiceParseMessage:
         mock_response.candidates = [mock_candidate]
 
         with patch.object(gemini_service, "_model", MagicMock()):
-            gemini_service._model.generate_content = MagicMock(return_value=mock_response)
+            gemini_service._model.generate_content_async = AsyncMock(return_value=mock_response)
 
             result = await gemini_service.parse_message("Book Saturday")
 
@@ -837,7 +886,7 @@ class TestGeminiServiceProtobufConversion:
         mock_response.candidates = [mock_candidate]
 
         with patch.object(gemini_service, "_model", MagicMock()):
-            gemini_service._model.generate_content = MagicMock(return_value=mock_response)
+            gemini_service._model.generate_content_async = AsyncMock(return_value=mock_response)
 
             result = await gemini_service.parse_message("Book tee time at 8:58a and 9:06a")
 
@@ -896,7 +945,7 @@ class TestGeminiServiceProtobufConversion:
         mock_response.candidates = [mock_candidate]
 
         with patch.object(gemini_service, "_model", MagicMock()):
-            gemini_service._model.generate_content = MagicMock(return_value=mock_response)
+            gemini_service._model.generate_content_async = AsyncMock(return_value=mock_response)
 
             result = await gemini_service.parse_message("Book next week at 08:58")
 
@@ -1026,7 +1075,7 @@ class TestMessageToDictFieldNamePreservation:
         mock_response.candidates = [mock_candidate]
 
         with patch.object(gemini_service, "_model", MagicMock()):
-            gemini_service._model.generate_content = MagicMock(return_value=mock_response)
+            gemini_service._model.generate_content_async = AsyncMock(return_value=mock_response)
 
             result = await gemini_service.parse_message("Book tee time at 8:58a and 9:06a")
 

--- a/tests/test_gemini_service.py
+++ b/tests/test_gemini_service.py
@@ -6,11 +6,12 @@ functionality, including the mock fallback when the API is not configured.
 """
 
 from datetime import date, datetime, time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from google.api_core import exceptions as google_exceptions
 
-from app.services.gemini_service import GeminiService
+from app.services.gemini_service import GEMINI_MAX_ATTEMPTS, GeminiService
 
 
 @pytest.fixture
@@ -543,6 +544,77 @@ class TestGeminiServiceParseMessage:
             assert result.tee_time_request is None
             assert result.tee_time_requests is None
             assert "nothing was booked" in result.response_message
+
+    @pytest.mark.asyncio
+    async def test_transient_error_is_retried_and_can_succeed(
+        self, gemini_service: GeminiService
+    ) -> None:
+        """A 503 on the first call must not reach the user - retry it.
+
+        This is the failure that told a user "my language model is unavailable"
+        one minute after the same model had parsed their booking fine.
+        """
+        mock_function_call = MagicMock()
+        mock_function_call.args = {
+            "intent": "confirm",
+            "response_message": "Confirmed.",
+        }
+        mock_part = MagicMock()
+        mock_part.function_call = mock_function_call
+        mock_content = MagicMock()
+        mock_content.parts = [mock_part]
+        mock_candidate = MagicMock()
+        mock_candidate.content = mock_content
+        mock_response = MagicMock()
+        mock_response.candidates = [mock_candidate]
+
+        with patch.object(gemini_service, "_model", MagicMock()):
+            gemini_service._model.generate_content = MagicMock(
+                side_effect=[
+                    google_exceptions.ServiceUnavailable("model overloaded"),
+                    mock_response,
+                ]
+            )
+
+            with patch("app.services.gemini_service.asyncio.sleep", AsyncMock()) as mock_sleep:
+                result = await gemini_service.parse_message("Yes")
+
+            assert result.intent == "confirm"
+            assert gemini_service._model.generate_content.call_count == 2
+            mock_sleep.assert_awaited_once_with(0.5)
+
+    @pytest.mark.asyncio
+    async def test_transient_error_gives_up_after_max_attempts(
+        self, gemini_service: GeminiService
+    ) -> None:
+        """A sustained outage still fails honestly, after exhausting retries."""
+        with patch.object(gemini_service, "_model", MagicMock()):
+            gemini_service._model.generate_content = MagicMock(
+                side_effect=google_exceptions.ResourceExhausted("quota exceeded")
+            )
+
+            with patch("app.services.gemini_service.asyncio.sleep", AsyncMock()) as mock_sleep:
+                result = await gemini_service.parse_message("Book 8/2 at 5:06p")
+
+            assert result.intent == "unclear"
+            assert result.tee_time_request is None
+            assert "nothing was booked" in result.response_message
+            assert gemini_service._model.generate_content.call_count == GEMINI_MAX_ATTEMPTS
+            # Exponential backoff, and no sleep after the final attempt.
+            assert [call.args[0] for call in mock_sleep.await_args_list] == [0.5, 1.0]
+
+    @pytest.mark.asyncio
+    async def test_non_transient_error_is_not_retried(self, gemini_service: GeminiService) -> None:
+        """A bad key or retired model fails identically every time - fail fast."""
+        with patch.object(gemini_service, "_model", MagicMock()):
+            gemini_service._model.generate_content = MagicMock(
+                side_effect=google_exceptions.PermissionDenied("API key not valid")
+            )
+
+            result = await gemini_service.parse_message("Book 8/2 at 5:06p")
+
+            assert result.intent == "unclear"
+            assert gemini_service._model.generate_content.call_count == 1
 
     def test_model_name_comes_from_settings(self, gemini_service: GeminiService) -> None:
         """The model is configurable so a retirement can be worked around by env."""


### PR DESCRIPTION
## The failure

A `Yes` confirming two tee times came back as:

> I couldn't understand that - my language model is unavailable right now, so nothing was booked. Please try again in a minute.

One minute earlier, the same model had parsed `Book 8/8 at 5p and 5:08p` into two correctly-typed bookings. A model that works at 12:37 and fails at 12:38 is not misconfigured — it hit a transient failure (429 quota, 503 overload, or a timeout). Two things turned that blip into a user-visible failure.

## What changed

**1. `Yes` no longer needs the LLM.** `handle_incoming_message` sent *every* inbound message to Gemini first, including a one-word reply to our own "Reply 'yes' to confirm" prompt — putting the LLM on the critical path at the moment failure costs the most, in order to answer a question we had already answered. Bare yes/no replies to a pending confirmation are now settled locally, the way the cancellation flow at `booking_service.py:494` already does.

Deliberately conservative:
- Matching is **exact on a normalized message, never substring** — `yes` is inside `yesterday`, `no` is inside `no, make it 5:30`. Both still go to the LLM.
- Only fires in `AWAITING_CONFIRMATION` with a pending request actually present.
- A pending *cancellation* is excluded, so `yes` to "are you sure you want to cancel?" keeps its existing handling.
- `cancel` and `stop` are not in the negative set — they may mean "cancel my existing bookings", and that is not ours to guess here.

Anything unmatched falls through to the LLM with behavior unchanged.

**2. The Gemini call retries transient failures.** The single `generate_content` call had no retry at all, while `walden_provider.py` has a whole `with_retry` decorator. Quota, overload and timeout errors now get 3 attempts with 0.5s/1.0s backoff — 1.5s of worst-case added latency, well inside the messaging webhook timeouts.

Non-transient errors (bad key, retired model, malformed request) are **not** retried: they fail identically every time, so retrying only delays the same message. The honest "nothing was booked" reply is still what the user gets when retries are exhausted — no fallback to guessed bookings.

## Note on what this doesn't fix

`generate_content` is a synchronous call inside an `async def` with no timeout, so a slow Gemini response still stalls the event loop. Left alone here to keep the diff scoped; worth its own change.

The deprecated `google-generativeai` SDK is tracked separately in #133.

## Testing

- `pytest` — 750 passed, 10 skipped
- `ruff check` / `ruff format` / `mypy app` — clean
- New: retry succeeds after a 503, gives up after 3 attempts on sustained 429, does not retry a `PermissionDenied`; affirmative/negative variants recognized, `yesterday` and `no, make it 5:30` fall through, shortcut skipped for pending cancellations, and a regression test reproducing the reported incident (LLM raising while `Yes` still books).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick confirmation and cancellation responses for common booking replies.
  * Supports varied capitalization, spacing, and punctuation in confirmations.

* **Bug Fixes**
  * Improved handling of temporary AI service failures with automatic retries.
  * Prevents unnecessary retries for non-temporary errors and provides clearer fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->