### PR TITLE
fix: tell the member the club refused the booking, and why

### DIFF
--- a/app/providers/walden_dom_schema.py
+++ b/app/providers/walden_dom_schema.py
@@ -405,6 +405,13 @@ class ErrorMessageSelectors:
         "[role='alert']",
         "[aria-live='assertive']",
         "[aria-live='polite']",
+        # The site's own refusal popups, which carry no error class: a booking
+        # the club will not allow comes back as a plain ui-dialog headed
+        # "Restriction:". Rendered empty until there is something to say, so
+        # matching the wrapper by id costs nothing on a clean page.
+        "[id*='restrictionPopup']",
+        "[id*='warningPopup']",
+        "[id*='resourceNotAvailablePopup']",
     )
 
 

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -536,6 +536,21 @@ def find_response_message(markup: str) -> str | None:
     return joined[:_MAX_MESSAGE_CHARS] + "..." if len(joined) > _MAX_MESSAGE_CHARS else joined
 
 
+def container_message_text(markup: str) -> str:
+    """Message text of one already-matched container's markup.
+
+    The browser path selects its containers with CSS and then has to read them,
+    and ``WebElement.text`` sweeps in whatever the container holds - a refusal
+    dialog reaches the member as "... per Day Ok". Handing the element's
+    ``outerHTML`` here keeps one definition of message text for both paths,
+    rather than a second pruner that can drift from this one.
+
+    Returns:
+        The pruned text, or "" when the container holds none.
+    """
+    return _visible_message_text(parse_html(markup))
+
+
 def _is_hidden(node: Node) -> bool:
     """Report whether a node is explicitly hidden from the member."""
     return node.attrs.get("aria-hidden", "").lower() == "true"

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -51,6 +51,21 @@ _MAX_PLAYERS = 4
 # rendered without an -error suffix.
 _MESSAGE_CLASS_MARKERS = ("error", "alert", "ui-messages", "ui-growl")
 
+# Id substrings marking one of the site's own popup wrappers. These carry no
+# error class at all - a refused booking comes back as a `ui-dialog` headed
+# "Restriction:" - so the class markers above never saw them, and a real refusal
+# reached the member as an unexplained "did not confirm the reservation".
+#
+# Matching by id is safe because the site renders these wrappers empty until it
+# has something to put in them: the same response that carried the restriction
+# had `warningPopup` and `resourceNotAvailablePopup` beside it as empty spans.
+# `useLastPlayPopup` is left out on purpose - it prompts, it does not refuse.
+_MESSAGE_ID_MARKERS = ("restrictionpopup", "warningpopup", "resourcenotavailablepopup")
+
+# Tags whose text is not message text: a dialog's own buttons ("Ok", "Close")
+# and the PrimeFaces widget-init scripts rendered inside it.
+_NON_MESSAGE_TAGS = frozenset({"a", "button", "script", "style"})
+
 # Enough to carry a validation sentence or two into an SMS/Discord reply without
 # pasting a re-rendered tee sheet into it.
 _MAX_MESSAGE_CHARS = 500
@@ -542,13 +557,15 @@ def _visible_message_text(node: Node) -> str:
     ``text_content()`` would sweep in an ``aria-hidden`` child template sitting
     inside a visible wrapper, which reports stale text and - because the nesting
     check drops a message already contained in a collected one - can hide the
-    real message behind it.
+    real message behind it. A popup's own controls and widget-init script are
+    pruned for the same reason: quoting "Ok" or a ``PrimeFaces.cw`` call back to
+    the member buries the sentence they need.
     """
     parts: list[str] = []
     stack = [node]
     while stack:
         current = stack.pop()
-        if _is_hidden(current):
+        if _is_hidden(current) or current.tag.lower() in _NON_MESSAGE_TAGS:
             continue
         if current.text:
             parts.append(current.text)
@@ -560,11 +577,14 @@ def _is_message_container(node: Node) -> bool:
     """Report whether a node is one of the site's message/alert containers.
 
     Mirrors ``DOM.ERROR_MESSAGES.containers`` - which is a CSS selector list,
-    and this tree matches by class substring rather than selectors.
+    and this tree matches by class or id substring rather than selectors.
     """
     if node.attrs.get("role", "").lower() == "alert":
         return True
     if node.attrs.get("aria-live", "").lower() in ("assertive", "polite"):
+        return True
+    node_id = node.id.lower()
+    if any(marker in node_id for marker in _MESSAGE_ID_MARKERS):
         return True
     return any(
         marker in css_class.lower()

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -42,6 +42,7 @@ from app.providers.walden_http_booker import (
     DIRECT_HTTP_PATH,
     PRE_SUBMIT_PHASES,
     DirectHttpBooker,
+    container_message_text,
 )
 from app.utils.timezone import CTDateTime
 
@@ -1582,6 +1583,30 @@ class WaldenGolfProvider(ReservationProvider):
         page_source = getattr(driver, "page_source", "")
         return page_source if isinstance(page_source, str) else ""
 
+    def _container_message_text(self, element: Any) -> str:
+        """Read one message container the way the direct-HTTP path reads one.
+
+        ``WebElement.text`` returns everything the container renders, including
+        its own controls, so the club's refusal dialog would reach the member as
+        "... restricted for 1 round(s) on Northgate per Day Ok". The markup goes
+        through the same pruner the HTTP path uses instead - one definition of
+        message text for both paths, and the one already tested against a real
+        captured response.
+
+        Falls back to ``.text`` if the markup cannot be read: a message with a
+        stray button label in it beats no message at all.
+        """
+        try:
+            markup = element.get_attribute("outerHTML")
+            if isinstance(markup, str) and markup:
+                pruned = container_message_text(markup)
+                if pruned:
+                    return pruned
+        except Exception as e:  # noqa: BLE001 - diagnostics must not raise
+            logger.debug(f"Could not read container markup, falling back to .text: {e}")
+
+        return (getattr(element, "text", "") or "").strip()
+
     def _extract_booking_error_message(self, driver: webdriver.Chrome) -> str | None:
         """Extract user-visible booking error text from common alert/message containers."""
         selectors = DOM.ERROR_MESSAGES.containers
@@ -1603,7 +1628,7 @@ class WaldenGolfProvider(ReservationProvider):
                         except Exception:
                             pass
 
-                        text = (getattr(el, "text", "") or "").strip()
+                        text = self._container_message_text(el)
                         if text:
                             messages.append(text)
                 except Exception:

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -2958,22 +2958,23 @@ class WaldenGolfProvider(ReservationProvider):
                 else:
                     self._capture_diagnostic_info(driver, f"fast_chain_failed_{phase}")
 
-                message = f"Fast booking failed at {phase}: {error}"
+                technical = f"Fast booking failed at {phase}: {error}"
                 site_message = chain_result.get("responseMessage")
-                if site_message:
-                    message += f" (the site said: {site_message})"
                 # "Could not check" is not "not booked". Saying so keeps this
                 # message honest in the same way the verification branch below is.
-                if (
+                unchecked = (
                     held is None
                     and chain_result.get("path") == DIRECT_HTTP_PATH
                     and phase not in PRE_SUBMIT_PHASES
-                ):
-                    message += "; the member's reservations page could not be checked"
+                )
 
                 return BookingResult(
                     success=False,
-                    error_message=message,
+                    error_message=self._member_facing_failure(
+                        site_message=site_message,
+                        technical=technical,
+                        unchecked=unchecked,
+                    ),
                     booked_time=booked_time,
                     course_name=self.NORTHGATE_COURSE_NAME,
                 )
@@ -3021,20 +3022,21 @@ class WaldenGolfProvider(ReservationProvider):
                     )
 
                 self._capture_diagnostic_info(driver, "direct_http_verify_failed")
-                whereabouts = (
-                    "and the tee time is not on the member's reservations page"
-                    if held is False
-                    else "and the member's reservations page could not be checked"
+                technical = (
+                    "Direct-HTTP booking chain completed but the response did not "
+                    f"confirm the reservation ({verdict_detail})"
                 )
+                if held is False:
+                    technical += " and the tee time is not on the member's reservations page"
                 # The response's own message containers are the only place a
                 # refusal we have no phrase for can still be read from.
                 site_message = chain_result.get("responseMessage")
                 return BookingResult(
                     success=False,
-                    error_message=(
-                        "Direct-HTTP booking chain completed but the response did not "
-                        f"confirm the reservation ({verdict_detail}) {whereabouts}"
-                        f"{f'. The site said: {site_message}' if site_message else ''}"
+                    error_message=self._member_facing_failure(
+                        site_message=site_message,
+                        technical=technical,
+                        unchecked=held is None,
                     ),
                     booked_time=booked_time,
                     course_name=self.NORTHGATE_COURSE_NAME,
@@ -5463,6 +5465,34 @@ class WaldenGolfProvider(ReservationProvider):
         """
         confirmed, _detail = self._booking_text_verdict(text, context)
         return bool(confirmed)
+
+    def _member_facing_failure(
+        self, *, site_message: str | None, technical: str, unchecked: bool
+    ) -> str:
+        """Phrase a failed direct-HTTP booking for the member who asked for it.
+
+        When the site said why - "Member: ... is restricted for 1 round(s) on
+        Northgate per Day" - that sentence is the whole answer, and the chain's
+        own vocabulary (phases, partial responses, phrase checks) only buries it.
+        So the site's words go to the member and the technical account goes to
+        the log, where the response body and screenshots already are.
+
+        Args:
+            site_message: What the response's own message containers said, if
+                anything.
+            technical: The chain's account of the failure, used when the site
+                said nothing.
+            unchecked: True when the reservations page could not be read. The
+                caveat rides along either way: "could not check" is not "not
+                booked", and a member who might be holding a tee time needs to
+                hear that whatever else went wrong.
+        """
+        if site_message:
+            logger.error("DIRECT_HTTP: %s; the site said: %s", technical, site_message)
+        message = site_message or technical
+        if unchecked:
+            message += " (the member's reservations page could not be checked)"
+        return message
 
     def _booking_text_verdict(self, text: str, context: str) -> tuple[bool | None, str]:
         """Classify booking text as confirmed, refused, or silent.

--- a/tests/fixtures/walden_restriction_popup.html
+++ b/tests/fixtures/walden_restriction_popup.html
@@ -1,0 +1,12 @@
+<span id="teeTimeForm:restrictionPopup"><div id="teeTimeForm:j_idt762" class="ui-dialog ui-widget ui-widget-content ui-corner-all ui-shadow ui-hidden-container  teetime-restriction-dialog tee-time-dialog"><div class="ui-dialog-content ui-widget-content" id="teeTimeForm:j_idt762_content"><a data-senna-off="true" id="teeTimeForm:j_idt763" href="#" class="ui-commandlink ui-widget cross" aria-label="Close" onclick="PF('restrictionPopupVar').hide();;PrimeFaces.ab({s:&quot;teeTimeForm:j_idt763&quot;,f:&quot;teeTimeForm&quot;});return false;" title="Close">
+					<i class="fa fa-times"></i></a>
+				<h1 class="heading tee-time-heading">
+					<i class="fa fa-exclamation-triangle distant"></i>Restriction:
+				</h1><div id="teeTimeForm:j_idt768" class="ui-datalist ui-widget"><div id="teeTimeForm:j_idt768_content" class="ui-datalist-content ui-widget-content"><dl id="teeTimeForm:j_idt768_list" class="ui-datalist-data"><dt class="ui-datalist-item"><label>Member: Sample, Member is restricted for 1 round(s) on Northgate  per Day  </label></dt></dl></div></div><script id="teeTimeForm:j_idt768_s" type="text/javascript">PrimeFaces.cw("DataList","widget__teeTimePortlet_WAR_northstarportlet__teeTimeForm_j_idt768",{id:"teeTimeForm:j_idt768"});</script>
+				<div class=" ui-grid ui-grid-responsive">
+					<div class="ui-grid-row">
+						<div class="ui-grid-col-3 btn-responsive"><a data-senna-off="true" id="teeTimeForm:j_idt774" href="#" class="ui-commandlink ui-widget btn-block ui-area-btn ui-area-btn-info" onclick="PrimeFaces.ab({s:&quot;teeTimeForm:j_idt774&quot;,f:&quot;teeTimeForm&quot;,p:&quot;teeTimeForm:j_idt774&quot;,u:&quot;teeTimeForm:restrictionPopup&quot;,onst:function(cfg){PF('restrictionPopupVar').hide();;}});return false;">
+								<i class="fa fa-check"></i> Ok</a>
+						</div>
+					</div>
+				</div></div></div><script id="teeTimeForm:j_idt762_s" type="text/javascript">PrimeFaces.cw("Dialog","restrictionPopupVar",{id:"teeTimeForm:j_idt762",resizable:false,modal:true,showEffect:"fade",hideEffect:"fade",closeOnEscape:true,behaviors:{close:function(ext,event) {PrimeFaces.ab({s:"teeTimeForm:j_idt762",e:"close",f:"teeTimeForm",p:"teeTimeForm:j_idt762",onco:function(xhr,status,args){enableScroll();hideLoader();;}},ext);}}});</script></span>

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -36,6 +36,10 @@ from app.providers.walden_http_booker import (
 
 FIXTURES = Path(__file__).parent / "fixtures"
 TEE_SHEET = (FIXTURES / "walden_tee_time_loaded.html").read_text(encoding="utf-8", errors="replace")
+# The refusal the site returned for a second same-day booking on 08/08/2026,
+# lifted verbatim from the captured Book Now response with the member's name
+# replaced. This is what a routine refusal looks like: no error class anywhere.
+RESTRICTION_POPUP = (FIXTURES / "walden_restriction_popup.html").read_text(encoding="utf-8")
 
 FORM_ID = "_teeTimePortlet_WAR_northstarportlet_:teeTimeForm"
 RESERVE_ID = f"{FORM_ID}:teeTimeCourses:0:teeTimeSlots:67:slotTee:0:reserve_button"
@@ -700,6 +704,40 @@ class TestFindResponseMessage:
         failure: the routine response has nothing in it.
         """
         assert find_response_message(TEE_SHEET) is None
+
+    def test_reads_the_restriction_popup(self) -> None:
+        """The club's refusal, which carries no error class at all.
+
+        Booking 08/08 at 5:00 and 5:08 PM as one batch got the first and was
+        refused the second; the response said so in a ui-dialog the class
+        markers could not see, so the member was told only that the reservation
+        was not confirmed.
+        """
+        assert find_response_message(RESTRICTION_POPUP) == (
+            "Restriction: Member: Sample, Member is restricted for 1 round(s) "
+            "on Northgate per Day"
+        )
+
+    def test_popup_buttons_and_widget_scripts_are_not_message_text(self) -> None:
+        """The sentence is the message; the dialog's own furniture is not."""
+        message = find_response_message(RESTRICTION_POPUP)
+
+        assert message is not None
+        assert "Ok" not in message
+        assert "PrimeFaces.cw" not in message
+
+    def test_an_unfilled_popup_wrapper_is_not_a_message(self) -> None:
+        """The site renders these wrappers empty until it has something to say.
+
+        The same response that carried the restriction had these two beside it,
+        empty - which is why matching the wrapper by id is safe.
+        """
+        markup = (
+            '<span id="teeTimeForm:warningPopup"></span>'
+            '<span id="teeTimeForm:resourceNotAvailablePopup"></span>'
+        )
+
+        assert find_response_message(markup) is None
 
 
 class ChainRecorder:

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -3197,6 +3197,54 @@ class TestUnconfirmedBookingResolution:
         reservation_check.assert_not_called()
 
 
+class TestBrowserErrorMessageExtraction:
+    """Reading a refusal off the browser DOM, for the JS-chain fallback path."""
+
+    RESTRICTION_MARKUP = TestUnconfirmedBookingResolution.RESTRICTION_MARKUP
+
+    def _driver_showing(self, markup: str) -> MagicMock:
+        """A driver whose first selector match is a container holding ``markup``."""
+        element = MagicMock()
+        element.get_attribute.side_effect = lambda name: (markup if name == "outerHTML" else None)
+        element.is_displayed.return_value = True
+        element.text = "unused - the markup is what gets read"
+
+        driver = MagicMock()
+        driver.find_elements.side_effect = lambda by, sel: (
+            [element] if "restrictionPopup" in sel else []
+        )
+        return driver
+
+    def test_the_restriction_dialog_is_read_without_its_buttons(
+        self, provider: WaldenGolfProvider
+    ) -> None:
+        """WebElement.text would carry the dialog's "Ok" into the member's reply."""
+        message = provider._extract_booking_error_message(
+            self._driver_showing(self.RESTRICTION_MARKUP)
+        )
+
+        assert message == (
+            "Restriction: Member: Sample, Member is restricted for 1 round(s) "
+            "on Northgate per Day"
+        )
+
+    def test_unreadable_markup_falls_back_to_the_rendered_text(
+        self, provider: WaldenGolfProvider
+    ) -> None:
+        """A message with a stray button label beats no message at all."""
+        element = MagicMock()
+        element.get_attribute.side_effect = WebDriverException("stale element")
+        element.is_displayed.return_value = True
+        element.text = "Members are limited to one per day"
+
+        driver = MagicMock()
+        driver.find_elements.side_effect = lambda by, sel: [element] if ".alert" == sel else []
+
+        assert (
+            provider._extract_booking_error_message(driver) == "Members are limited to one per day"
+        )
+
+
 class TestReservationLookup:
     """Reading the member's reservations page as ground truth."""
 

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -7,6 +7,7 @@ against the actual Walden Golf website structure.
 
 import os
 from datetime import date, time, timedelta
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock, patch
 
@@ -18,7 +19,11 @@ from app.config import settings
 from app.providers.base import BookingResult
 from app.providers.walden_dom_schema import DOM
 from app.providers.walden_http import DirectHttpError
-from app.providers.walden_http_booker import DIRECT_HTTP_PATH, PHASE_RESERVE_STAGED
+from app.providers.walden_http_booker import (
+    DIRECT_HTTP_PATH,
+    PHASE_RESERVE_STAGED,
+    find_response_message,
+)
 from app.providers.walden_provider import WaldenGolfProvider
 from app.utils.timezone import CTDateTime
 
@@ -2967,6 +2972,11 @@ class TestUnconfirmedBookingResolution:
     TARGET_DATE = date(2026, 8, 8)
     # No success or failure wording anywhere - the tee sheet re-render case.
     SILENT_MARKUP = "<div><p>Northgate tee sheet</p></div>"
+    # A real refusal, captured from the site: also silent to the phrase check,
+    # because the reason is in a dialog rather than in wording it knows.
+    RESTRICTION_MARKUP = (
+        Path(__file__).parent / "fixtures" / "walden_restriction_popup.html"
+    ).read_text(encoding="utf-8")
 
     def _book(
         self,
@@ -3070,6 +3080,42 @@ class TestUnconfirmedBookingResolution:
         assert result.success is False
         assert result.error_message is not None
         assert "unable to" in result.error_message
+
+    def test_the_clubs_restriction_reaches_the_member_in_its_own_words(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The refusal the member needs, not a report that nothing was said.
+
+        The club allows one round per member per day, so the second half of a
+        two-tee-time batch comes back like this. ``responseMessage`` is filled
+        the way the booker fills it, from the response itself.
+        """
+        chain = self._completed_chain(self.RESTRICTION_MARKUP)
+        chain["responseMessage"] = find_response_message(self.RESTRICTION_MARKUP)
+
+        result, _ = self._book(provider, monkeypatch, chain, reservation_exists=False)
+
+        assert result.success is False
+        # Nothing about chains, phases or phrase checks: the member gets the
+        # club's sentence and nothing else. The rest is in the log.
+        assert result.error_message == (
+            "Restriction: Member: Sample, Member is restricted for 1 round(s) "
+            "on Northgate per Day"
+        )
+
+    def test_an_unreadable_reservations_page_is_still_admitted(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A member who might be holding the tee time has to hear that."""
+        chain = self._completed_chain(self.RESTRICTION_MARKUP)
+        chain["responseMessage"] = find_response_message(self.RESTRICTION_MARKUP)
+
+        result, _ = self._book(provider, monkeypatch, chain, reservation_exists=None)
+
+        assert result.success is False
+        assert result.error_message is not None
+        assert result.error_message.startswith("Restriction: Member: Sample, Member")
+        assert "could not be checked" in result.error_message
 
     def test_a_confirmed_response_never_reaches_the_reservations_page(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## The message that prompted this

Booking 08/08 at 5:00 and 5:08 PM as one batch got the first tee time. The second came back:

> Unable to book tee time for Saturday, August 08 at 05:08 PM for 4 players: Direct-HTTP booking chain completed but the response did not confirm the reservation (no success or failure wording in the response) and the tee time is not on the member's reservations page

True, and no use to anyone. The site had said exactly why.

## What the site actually returned

Pulled from the response #129 now stores (`gs://…/walden/direct_http_verify_failed/20260804_223602/direct_http_response.html`):

```html
<span id="…:teeTimeForm:restrictionPopup">
  <div class="ui-dialog … teetime-restriction-dialog">
    <h1 class="heading tee-time-heading">Restriction:</h1>
    <label>Member: Garner, Ron is restricted for 1 round(s) on Northgate  per Day</label>
```

`find_response_message` reads containers classed `error` / `alert` / `ui-messages` / `ui-growl`. This popup carries no error class at all, so `responseMessage` came back empty and the phrase check's silence was reported in its place.

## The fix

- The site's own popup wrappers (`restrictionPopup`, `warningPopup`, `resourceNotAvailablePopup`) now count as message containers. Matching by id is safe because the site renders them empty until it has something to put in them — the same response carried the other two beside the restriction as empty spans — and the clean tee sheet fixture still yields nothing. `useLastPlayPopup` is left out: it prompts, it does not refuse.
- A popup's own buttons and its PrimeFaces widget-init script are pruned from the text, or the member gets told "Ok" and reads a `PrimeFaces.cw` call.
- When the site said why, that sentence is what reaches the member — the chain's vocabulary goes to the log, where the response body and screenshots already are. The "reservations page could not be checked" caveat still rides along: that one is not diagnosis, it is a member who may be holding a tee time.
- The same popups are added to `DOM.ERROR_MESSAGES.containers`, so the Selenium fallback path reads a refusal the same way.

Same booking, after:

> Unable to book tee time for Saturday, August 08 at 05:08 PM for 4 players: Restriction: Member: Garner, Ron is restricted for 1 round(s) on Northgate per Day

## Verification

Run against the real 84 KB captured response, the extraction returns exactly `Restriction: Member: Garner, Ron is restricted for 1 round(s) on Northgate per Day` and nothing else; the clean tee sheet returns `None`. 764 passed, ruff and mypy clean.

The committed fixture is the captured popup verbatim with the member's name replaced. The full response is not committed — it carries a phone number and an email.

## Not in this PR

The club now allows one round per member per day whenever it is booked, so every same-day batch will be refused after the first tee time. Refusing those up front is tracked in #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of restriction, warning, and availability messages shown in popups.
  - Booking responses now display clearer site-provided messages, including membership or round-limit restrictions.
  - Removed popup controls and other non-message content from displayed error text.
  - Clarified when reservation status could not be verified without incorrectly stating that booking failed.
- **Tests**
  - Added coverage for restriction popups and reservation verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->