### PR TITLE
fix: keep the response a blocked verdict was read from, and verify it

### DIFF
--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -2936,11 +2936,53 @@ class WaldenGolfProvider(ReservationProvider):
                     )
 
             if chain_result.get("blocked"):
-                # Slot was grabbed by another user at the same moment
+                # Another member took the slot at the same moment - or the chain
+                # read a popup as saying so. On the direct-HTTP path the verdict
+                # comes from a response the browser never received, so the
+                # browser photograph below cannot show the popup that produced
+                # it: the response is the only account of it there is.
+                blocked_phase = chain_result.get("phase", "unknown")
+                blocked_direct = chain_result.get("path") == DIRECT_HTTP_PATH
+                blocked_held: bool | None = None
+                if blocked_direct:
+                    blocked_markup = chain_result.get("finalMarkup")
+                    if blocked_markup:
+                        self._capture_response_artifact(
+                            f"direct_http_blocked_{blocked_phase}", blocked_markup
+                        )
+                # Before the reservations check, not after: that check navigates
+                # to the dashboard, and a screenshot taken on the way out would
+                # show that page instead of the state that failed.
                 self._capture_diagnostic_info(driver, "slot_blocked_by_other_user")
+                # A blocked verdict past the Reserve POST is a post-submit
+                # failure like any other - the request was accepted and the
+                # browser never saw what became of it. Ask the reservations page
+                # before writing the tee time off, or a member holding a slot is
+                # told they have none.
+                if blocked_direct and blocked_phase not in PRE_SUBMIT_PHASES:
+                    blocked_held = self._reservation_exists(driver, target_date, booked_time)
+                if blocked_held:
+                    logger.warning(
+                        "DIRECT_HTTP: Chain reported the slot blocked at %s but the "
+                        "reservation is on the member's reservations page; reporting success",
+                        blocked_phase,
+                    )
+                    return BookingResult(
+                        success=True,
+                        booked_time=booked_time,
+                        fallback_reason=fallback_reason,
+                        course_name=self.NORTHGATE_COURSE_NAME,
+                    )
+
                 return BookingResult(
                     success=False,
-                    error_message="Slot blocked by another user",
+                    error_message=self._member_facing_failure(
+                        site_message=None,
+                        technical="Slot blocked by another user",
+                        unchecked=blocked_held is None
+                        and blocked_direct
+                        and blocked_phase not in PRE_SUBMIT_PHASES,
+                    ),
                     booked_time=booked_time,
                     course_name=self.NORTHGATE_COURSE_NAME,
                 )

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -21,6 +21,7 @@ from app.providers.walden_dom_schema import DOM
 from app.providers.walden_http import DirectHttpError
 from app.providers.walden_http_booker import (
     DIRECT_HTTP_PATH,
+    PHASE_RESERVE_SENT,
     PHASE_RESERVE_STAGED,
     find_response_message,
 )
@@ -3195,6 +3196,157 @@ class TestUnconfirmedBookingResolution:
 
         assert result.success is False
         reservation_check.assert_not_called()
+
+
+class TestBlockedSlotResolution:
+    """What a blocked verdict on the direct-HTTP path is allowed to conclude.
+
+    The verdict is read out of a response the browser never received, and it is
+    reached with the Reserve request already accepted. So the browser photograph
+    cannot show the popup that produced it - only the response can - and the
+    chain's own account says nothing about whether the tee time is ours. Both
+    gaps put a member in front of a starter with no slot, or send them away from
+    one they hold.
+    """
+
+    SLOT = dict(TestDirectHttpBookingWiring.SLOT)
+    TARGET_DATE = date(2026, 8, 12)
+    BLOCKED_MARKUP = (
+        '<div id="teeSheetValidationErrorPopup" aria-hidden="false">'
+        "This slot is blocked by another user</div>"
+    )
+
+    def _book(
+        self,
+        provider: WaldenGolfProvider,
+        monkeypatch: pytest.MonkeyPatch,
+        chain_result: dict[str, object],
+        reservation_exists: bool | None,
+    ) -> tuple[BookingResult, MagicMock, MagicMock]:
+        """Run one booking whose chain came back blocked."""
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        monkeypatch.setattr(
+            provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
+        )
+        monkeypatch.setattr(
+            provider, "_try_direct_http_booking", MagicMock(return_value=chain_result)
+        )
+        monkeypatch.setattr(provider, "_capture_diagnostic_info", MagicMock())
+        artifact_capture = MagicMock()
+        monkeypatch.setattr(provider, "_capture_response_artifact", artifact_capture)
+        reservation_check = MagicMock(return_value=reservation_exists)
+        monkeypatch.setattr(provider, "_reservation_exists", reservation_check)
+
+        result = provider._find_and_book_time_slot_sync(
+            MagicMock(),
+            target_time=time(8, 42),
+            num_players=4,
+            fallback_window_minutes=32,
+            skip_scroll=True,
+            use_fast_js=True,
+            target_date=self.TARGET_DATE,
+        )
+        return result, reservation_check, artifact_capture
+
+    def _blocked_chain(self, **overrides: object) -> dict[str, object]:
+        """A direct-HTTP chain that stopped on the blocked popup."""
+        chain: dict[str, object] = {
+            "success": False,
+            "blocked": True,
+            "phase": PHASE_RESERVE_SENT,
+            "error": "Slot blocked by another user (blocked by another user)",
+            "timing": {},
+            "finalMarkup": self.BLOCKED_MARKUP,
+            "path": DIRECT_HTTP_PATH,
+        }
+        chain.update(overrides)
+        return chain
+
+    def test_the_response_that_produced_the_verdict_is_kept(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The regression: the one artifact that can explain the block, discarded.
+
+        The browser is still on the pre-booking tee sheet, so its photograph
+        shows the slot sitting there available - which is what a member reading
+        it afterwards sees, and it answers nothing.
+        """
+        _, _, artifact_capture = self._book(
+            provider, monkeypatch, self._blocked_chain(), reservation_exists=False
+        )
+
+        artifact_capture.assert_called_once_with(
+            f"direct_http_blocked_{PHASE_RESERVE_SENT}", self.BLOCKED_MARKUP
+        )
+        provider._capture_diagnostic_info.assert_called_once_with(ANY, "slot_blocked_by_other_user")
+
+    def test_a_tee_time_we_hold_is_not_reported_as_blocked(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reserve was accepted before the popup was read, so ask the site."""
+        result, reservation_check, _ = self._book(
+            provider, monkeypatch, self._blocked_chain(), reservation_exists=True
+        )
+
+        assert result.success is True
+        assert result.booked_time == time(8, 42)
+        reservation_check.assert_called_once_with(ANY, self.TARGET_DATE, time(8, 42))
+
+    def test_a_confirmed_block_still_reaches_the_member_as_one(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Checking the page does not change what a real block is called."""
+        result, _, _ = self._book(
+            provider, monkeypatch, self._blocked_chain(), reservation_exists=False
+        )
+
+        assert result.success is False
+        assert result.error_message == "Slot blocked by another user"
+
+    def test_an_unreadable_reservations_page_is_admitted(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A member who might be holding the tee time has to hear that."""
+        result, _, _ = self._book(
+            provider, monkeypatch, self._blocked_chain(), reservation_exists=None
+        )
+
+        assert result.success is False
+        assert result.error_message is not None
+        assert result.error_message.startswith("Slot blocked by another user")
+        assert "could not be checked" in result.error_message
+
+    def test_a_block_before_reserve_was_sent_does_not_check(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nothing reached the server, so there is nothing to look up."""
+        result, reservation_check, _ = self._book(
+            provider,
+            monkeypatch,
+            self._blocked_chain(phase=PHASE_RESERVE_STAGED),
+            reservation_exists=True,
+        )
+
+        assert result.success is False
+        assert result.error_message == "Slot blocked by another user"
+        reservation_check.assert_not_called()
+
+    def test_a_js_chain_block_answers_from_the_browser(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The JS chain saw the popup itself; there is no response to keep."""
+        chain = self._blocked_chain(phase="blocked_check")
+        del chain["path"]
+        del chain["finalMarkup"]
+
+        result, reservation_check, artifact_capture = self._book(
+            provider, monkeypatch, chain, reservation_exists=True
+        )
+
+        assert result.success is False
+        assert result.error_message == "Slot blocked by another user"
+        reservation_check.assert_not_called()
+        artifact_capture.assert_not_called()
 
 
 class TestBrowserErrorMessageExtraction:


### PR DESCRIPTION
This morning's 6:30 booking for Aug 12 at 11:08 came back "Slot blocked by another user". A minute later the member's own screenshot showed 11:08 - and the six slots after it - still open with a Reserve button.

## What was kept, and why none of it could answer

The failure saved a screenshot and `page.html` of the browser. On the direct-HTTP path the browser never sent the Reserve request and never received the response, so it was still sitting on the pre-booking tee sheet: the captured page has no `teeSheetValidationErrorPopup` in it at all, and the screenshot is the page header. Neither could show the popup the verdict was read from, because neither was ever in a position to.

The response that carried it was on the chain result as `finalMarkup` the whole time. The blocked branch returned before the branch that keeps it.

## What it concluded without asking

The blocked branch also returned before the reservations check. It is reached at `reserve_sent`, which is not in `PRE_SUBMIT_PHASES`: the request was accepted and the browser saw nothing of what became of it. That is the same position every other post-submit failure is in, and the reason that check exists - a member told their slot was blocked while holding it is sent away from a tee time they have.

## The change

The branch now does what the failure branch below it already does: keep the response, photograph the browser, then ask the reservations page before writing the tee time off.

A real block reaches the member unchanged as `Slot blocked by another user`. The only new wording is the unchecked caveat, on the same terms as everywhere else. The JS chain is left alone - it reads the popup off a live DOM it is already looking at, so there is no response to keep and nothing the browser cannot answer.

Nothing here is on the critical path. Every line runs after the Reserve POST has returned and the attempt is already decided.

## Tests

`TestBlockedSlotResolution` covers the response being kept under the phase that produced it, a held tee time reported as success rather than blocked, a confirmed block still reaching the member as one, an unreadable reservations page admitted rather than read as a no, a pre-submit block skipping the lookup, and a JS-chain block doing neither.

## Still open

Whether the club really said this. It cannot be settled from what was kept, and the 06:31 screenshot is equally consistent with a real block whose holder abandoned their cart and with a misread popup - the chain stops before selecting players either way, so the slot goes back on the sheet looking untouched. #136 has the case for a false positive and the fix it would need; it is blocked on one live capture, which this makes possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of blocked booking attempts by verifying whether the reservation was actually created.
  * Provides clearer outcomes for confirmed blocks and cases where reservation status cannot be verified.
  * Preserves relevant booking response details for improved troubleshooting.
  * Avoids unnecessary reservation checks before the booking submission stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->