### PR TITLE
fix: arrive as the window opens, and keep asking after a refusal

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -57,17 +57,27 @@ class Settings(BaseSettings):
     # Re-render the tee sheet at 6:30:00 and fire Reserve against that render,
     # instead of against the one the request was staged from ~60s earlier.
     #
-    # The staged view is a sheet on which nothing is reservable yet, and the
-    # club refuses a Reserve against it with "This slot is blocked by another
-    # user" - the same message it uses when a human genuinely beat us. Two
-    # mornings were read as lost races before the captured response showed the
-    # slot still free and the club's own countdown still running in it.
+    # Off, having been tried and found to buy nothing. It was built on the
+    # reading that the club refuses a Reserve staged before the window for being
+    # stale. On 2026-08-07 it worked perfectly - fresh sheet, countdown gone, 86
+    # of 87 rows offering a Reserve - and the club refused anyway, returning the
+    # same ViewState and component id the staged request already held. It cost
+    # 730ms of a race decided in the first second and changed no byte of the
+    # request. Kept behind the flag rather than deleted, because it is the only
+    # way back if a future morning does show a stale-view refusal.
+    walden_refresh_view_at_window: bool = False
+
+    # Probe the club's clock during staging, and send the Reserve early enough
+    # to *arrive* as the booking window opens rather than to leave then.
     #
-    # Costs ~200ms off the front of the race: ~115ms round trip measured
-    # against the site, plus ~85ms to parse the re-rendered sheet and find the
-    # slot in it. On, because losing 200ms to a sheet the club will act on
-    # beats winning the race to one it will not. Timed bookings only.
-    walden_refresh_view_at_window: bool = True
+    # Two things sit between us and the window and both run against us: the
+    # club's clock reaches 06:30:00 before ours does, and the request still has
+    # to fly there. Firing at our own 06:30:00.000 has been putting the Reserve
+    # on the club's desk something like half a second into a window members have
+    # been clicking into since it opened. The lead is measured, never assumed,
+    # and is clamped in the booker; a failed measurement sends unled. Timed
+    # bookings only - an immediate one has no instant to hit.
+    walden_measure_clock_skew: bool = True
 
     # Whether a booking uses the fast chain (JS, or direct HTTP when the flag
     # above is on) instead of the original Selenium flow. This is deliberately

--- a/app/providers/walden_http.py
+++ b/app/providers/walden_http.py
@@ -47,8 +47,12 @@ session is adopted *from* a live, already-navigated WebDriver
 (:meth:`PrimeFacesSession.from_selenium`), inheriting its cookies and the exact
 form state the browser had built up.
 
-The booking window itself is unchanged: the reserve POST is fired at the same
-target timestamp the JS chain would have clicked at, never earlier.
+The booking window itself is timed by *arrival*, not by departure. The reserve
+POST leaves early by the club's measured clock offset plus the outbound flight
+time, so that it lands as the window opens rather than however long after it
+those two happen to add up to. See :meth:`PrimeFacesSession.measure_clock_skew`.
+(This is a change: it used to fire at our own target and never earlier, which
+put it on the club's desk around half a second late.)
 
 Every step after Reserve is derived from the markup the server just returned, by
 parsing the same ``PrimeFaces.ab({...})`` handler the browser would have
@@ -56,6 +60,7 @@ executed. Nothing about the request sequence is hardcoded, so a component id
 churning from ``j_idt1076`` to ``j_idt1082`` does not break the chain.
 """
 
+import datetime
 import email.utils
 import logging
 import re
@@ -144,7 +149,14 @@ def _median(values: list[float]) -> float:
 
 
 def _parse_http_date(header: str | None) -> int | None:
-    """Read an HTTP ``Date`` header as whole epoch seconds, or None."""
+    """Read an HTTP ``Date`` header as whole epoch seconds, or None.
+
+    A ``-0000`` offset comes back from :mod:`email.utils` as a *naive* datetime,
+    and ``timestamp()`` would then read it in whatever timezone the process
+    happens to run in. The header is UTC either way, so say so: read in local
+    time it would put the club's clock hours out, and the skew that produced
+    would still look like an ordinary number in the log.
+    """
     if not header:
         return None
     try:
@@ -153,6 +165,8 @@ def _parse_http_date(header: str | None) -> int | None:
         return None
     if parsed is None:
         return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.UTC)
     return int(parsed.timestamp())
 
 

--- a/app/providers/walden_http.py
+++ b/app/providers/walden_http.py
@@ -56,6 +56,7 @@ executed. Nothing about the request sequence is hardcoded, so a component id
 churning from ``j_idt1076`` to ``j_idt1082`` does not break the chain.
 """
 
+import email.utils
 import logging
 import re
 import time as time_module
@@ -97,6 +98,62 @@ DEFAULT_TIMEOUT_S = 10.0
 # Final busy-wait before the target timestamp, mirroring the JS chain's 25 ms
 # spin. Python only needs a couple of ms since there is no DOM work left to do.
 _SPIN_WINDOW_MS = 3
+
+# Clock-skew probing. The `Date` header is the club's own clock, but at one
+# second of resolution, so a single sample says nothing better than "somewhere
+# in this second". What is readable is the *transition*: probe faster than the
+# second ticks, and the local time at which the header increments is a server
+# second boundary observed directly. Spacing bounds the error (+-40 ms here);
+# the count has to span more than a second so at least one transition is
+# guaranteed to fall inside the run.
+_SKEW_PROBE_COUNT = 16
+_SKEW_PROBE_SPACING_S = 0.08
+# A probe is only usable if its own round trip is short enough that the header
+# was stamped near the midpoint we ascribe to it. A stalled probe is dropped
+# rather than allowed to drag the estimate.
+_SKEW_MAX_PROBE_RTT_S = 1.0
+
+
+@dataclass(frozen=True)
+class ClockSkew:
+    """How far the club's clock and the network sit between us and the window.
+
+    ``offset_ms`` is the club's clock minus ours: positive means the club gets
+    to 06:30:00 before we do. ``one_way_ms`` is the outbound flight time. Their
+    sum is how early a request has to leave to arrive as the window opens.
+    """
+
+    offset_ms: float
+    one_way_ms: float
+    probes: int
+    transitions: int
+
+    @property
+    def lead_ms(self) -> float:
+        """How far ahead of our own target a request should be sent."""
+        return self.offset_ms + self.one_way_ms
+
+
+def _median(values: list[float]) -> float:
+    """Median of a non-empty list, without pulling in a dependency for it."""
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    return (ordered[middle - 1] + ordered[middle]) / 2
+
+
+def _parse_http_date(header: str | None) -> int | None:
+    """Read an HTTP ``Date`` header as whole epoch seconds, or None."""
+    if not header:
+        return None
+    try:
+        parsed = email.utils.parsedate_to_datetime(header)
+    except (TypeError, ValueError):
+        return None
+    if parsed is None:
+        return None
+    return int(parsed.timestamp())
 
 
 class DirectHttpError(RuntimeError):
@@ -573,6 +630,11 @@ class PrimeFacesSession:
         """
         self.form_state = form_state
         self.base_url = base_url
+        # Filled in by warm_up/measure_clock_skew during staging. None means not
+        # measured, which the booker treats as "do not lead" rather than
+        # guessing - a wrong lead fires into a window the club has not opened.
+        self.warm_up_rtt_ms: float | None = None
+        self.clock_skew: ClockSkew | None = None
         headers = {
             "User-Agent": user_agent,
             # PrimeFaces sets these on every AJAX request; the bridge uses
@@ -685,7 +747,104 @@ class PrimeFacesSession:
             response.status_code,
             rtt_ms,
         )
+        self.warm_up_rtt_ms = rtt_ms
         return rtt_ms
+
+    def measure_clock_skew(self) -> ClockSkew | None:
+        """Measure the club's clock against ours, and how long a request takes.
+
+        Both halves of the same question: at what local instant should a request
+        leave so that it *arrives* as the window opens. Firing at our own
+        06:30:00.000 answers a different question, and answers it late twice
+        over - once for the offset between the two clocks, once for the flight
+        time.
+
+        Sampling is NTP-shaped but built around a one-second header. Each probe
+        pairs a local midpoint with the second the server stamped; where two
+        adjacent probes straddle an increment, the boundary between them is a
+        server second boundary, and the local time of that boundary is the
+        offset. Several transitions are usually visible, and the median of them
+        is what survives one slow probe.
+
+        Returns:
+            The measurement, or None when it could not be taken - a header the
+            site does not send, a clock frozen by a cache, every probe failing.
+            None means "do not lead", not "lead by zero on purpose"; the caller
+            distinguishes them.
+        """
+        samples: list[tuple[float, int]] = []
+        round_trips: list[float] = []
+        for probe in range(_SKEW_PROBE_COUNT):
+            if probe:
+                time_module.sleep(_SKEW_PROBE_SPACING_S)
+            sent = time_module.time()
+            try:
+                response = self._client.head(self.base_url)
+            except httpx.HTTPError as exc:
+                # One failed probe is not worth abandoning the measurement, and
+                # is not worth a warning each: the summary below reports how
+                # many landed, which is the number that matters.
+                logger.debug("DIRECT_HTTP: Clock probe %d failed (%s)", probe, exc)
+                continue
+            received = time_module.time()
+
+            round_trip = received - sent
+            if round_trip > _SKEW_MAX_PROBE_RTT_S:
+                continue
+            server_second = _parse_http_date(response.headers.get("Date"))
+            if server_second is None:
+                continue
+            round_trips.append(round_trip)
+            samples.append(((sent + received) / 2, server_second))
+
+        if len(samples) < 2:
+            logger.warning(
+                "DIRECT_HTTP: Clock skew unmeasurable - %d usable probe(s) of %d",
+                len(samples),
+                _SKEW_PROBE_COUNT,
+            )
+            return None
+
+        offsets = [
+            # The increment happened between these two probes, so the server's
+            # own second boundary sits at their midpoint by our clock. Its
+            # distance from the whole second the server reported is the offset.
+            later_second - (earlier_mid + later_mid) / 2
+            for (earlier_mid, earlier_second), (later_mid, later_second) in zip(
+                samples, samples[1:]
+            )
+            # Exactly one tick. A wider jump means the probes fell too far apart
+            # to say where inside it the boundary was.
+            if later_second - earlier_second == 1
+        ]
+        if not offsets:
+            logger.warning(
+                "DIRECT_HTTP: Clock skew unmeasurable - the Date header never advanced "
+                "across %d probes spanning %.1fs (cached?)",
+                len(samples),
+                _SKEW_PROBE_COUNT * _SKEW_PROBE_SPACING_S,
+            )
+            return None
+
+        skew = ClockSkew(
+            offset_ms=_median(offsets) * 1000,
+            # Halved on the usual assumption that the two legs are symmetric.
+            # Only the outbound leg is on the critical path: the response's
+            # journey back happens after the club has already acted.
+            one_way_ms=_median(round_trips) * 1000 / 2,
+            probes=len(samples),
+            transitions=len(offsets),
+        )
+        logger.info(
+            "DIRECT_HTTP: Clock skew measured - club is %+.0fms from us, one-way %.0fms "
+            "(%d probes, %d transitions)",
+            skew.offset_ms,
+            skew.one_way_ms,
+            skew.probes,
+            skew.transitions,
+        )
+        self.clock_skew = skew
+        return skew
 
     def post(
         self,

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -151,6 +151,14 @@ _REFRESH_RETRY_PAUSE_S = 0.2
 # an over-lead is still recoverable by asking again.
 _MAX_ARRIVAL_LEAD_MS = 900.0
 
+# Past this, the measurement is not believable and is discarded rather than
+# clamped. Two internet-facing servers do not sit seconds apart; a reading that
+# says they do is far likelier to be a parse fault than a real clock, and
+# clamping one silently converts it into a plausible-looking 900ms lead that
+# fires into a shut window every morning without ever looking wrong. Bounded
+# ignorance beats a confident guess, so this sends unled and says why.
+_MAX_PLAUSIBLE_OFFSET_MS = 5000.0
+
 # Reserve attempts allowed across all candidate tee times. Each costs one round
 # trip plus the parse of the sheet that comes back with it - call it 450ms - so
 # this is about as far down the fallback list as the first two seconds of the
@@ -167,6 +175,18 @@ _PREMATURE_PAUSE_S = 0.05
 # Stop *starting* attempts once the race is this far gone. An attempt already in
 # flight is allowed to finish - abandoning it would not un-send it.
 _RESERVE_DEADLINE_MS = 6000
+
+# Budget for a single Reserve POST, well under the session default. The deadline
+# above cannot cancel a request already handed to the socket, so without this a
+# single stalled Reserve spends the entire race and the fallback list - the
+# thing that exists to survive exactly this - is never walked. Round trips have
+# run 230-535ms; one that has not answered in this long has lost anyway.
+#
+# A timeout is deliberately left terminal rather than advancing to the next tee
+# time. The request may well have reached the club, and reserving a second slot
+# on top of a hold we cannot see would collide with the one-round-per-day rule -
+# trading a lost morning for a booking mess.
+_RESERVE_TIMEOUT_S = 2.0
 
 # What the club's answer to a Reserve amounts to. The distinction that matters
 # is between the two refusals: "blocked" is another member holding the slot, and
@@ -377,6 +397,15 @@ class DirectHttpBooker:
             logger.warning("DIRECT_HTTP: Clock skew probing failed (%s); sending unled", exc)
             return
         if skew is None:
+            return
+
+        if abs(skew.offset_ms) > _MAX_PLAUSIBLE_OFFSET_MS:
+            logger.error(
+                "DIRECT_HTTP: Measured clock offset of %+.0fms is not believable "
+                "(over %.0fms); discarding it and sending unled",
+                skew.offset_ms,
+                _MAX_PLAUSIBLE_OFFSET_MS,
+            )
             return
 
         # Clamped because the lead is derived from a measurement, and a wrong
@@ -624,6 +653,7 @@ class DirectHttpBooker:
         slot_time = self._slot_time
         remaining = list(self._fallback_times)
         premature_retries = 0
+        premature_exhausted = False
         last_reason: str | None = None
 
         for attempt in range(1, _RESERVE_MAX_ATTEMPTS + 1):
@@ -655,7 +685,7 @@ class DirectHttpBooker:
             # the socket we cannot tell "never sent" from "sent, response lost",
             # and a browser retry in the second case races our own reservation.
             result.phase = PHASE_RESERVE_SENT
-            response = self.session.post(config, body=body)
+            response = self.session.post(config, body=body, timeout_s=_RESERVE_TIMEOUT_S)
             result.final_markup = response.markup
 
             # One parse, two questions. At ~190ms for a 500KB sheet this is the
@@ -690,6 +720,7 @@ class DirectHttpBooker:
                         "the window is not opening when we think it is",
                         premature_retries,
                     )
+                    premature_exhausted = True
                     break
                 premature_retries += 1
                 result.timing["prematureRetries"] = premature_retries
@@ -723,7 +754,13 @@ class DirectHttpBooker:
                 slot_time.strftime("%I:%M %p"),
             )
 
-        result.blocked = True
+        # A window that never opened is not a slot someone else is holding, and
+        # only the blocked branch of the caller hard-codes the member's message
+        # to say it is. Reported as an ordinary post-submit failure instead: it
+        # captures the same artifacts and checks the same reservations page, but
+        # carries `error` through to the member, so the one distinction this
+        # whole classification exists to draw survives past the log.
+        result.blocked = not premature_exhausted
         result.error = last_reason or "Slot blocked by another user"
         logger.warning(
             "DIRECT_HTTP: No Reserve accepted after %d attempt(s) over %dms - tried %s",

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -16,23 +16,27 @@ left to do but write bytes to an already-open socket:
 * The TLS connection is established during ``prepare`` too.
 * :meth:`DirectHttpBooker.book` waits out the remaining time and posts.
 
-With one deliberate exception. Staging the Reserve request also freezes the JSF
-view it was built against, and that view is the tee sheet as it looked ~60s
-before the window opened - a sheet on which nothing is reservable yet. The club
-answers a Reserve against it with "This slot is blocked by another user" even
-when the slot is free, which is indistinguishable from losing the race and cost
-two mornings' bookings before the response body was captured and read. So when
-``refresh_at_window`` is set, :meth:`DirectHttpBooker.book` spends one round
-trip at the target instant re-rendering the sheet, then fires Reserve against
-that render instead. See :meth:`DirectHttpBooker._refresh_view`.
+Two things sit on top of that, both from mornings this path lost.
 
-Which makes the refresh part of the critical path, and its failure modes worth
-distinguishing rather than collapsing into "send the staged request anyway".
-Sending that request is not free: it advances the chain past
-:data:`PRE_SUBMIT_PHASES`, spending the browser retry the caller would
-otherwise still have. So a refresh that cannot land retries, a session the
-server has disowned sends nothing at all, and only a run that exhausts its
-attempts with the session still alive falls back to the stale request.
+**It is timed to arrive, not to leave.** The club's clock runs ahead of ours and
+the request still has to fly there, so sending at our own 06:30:00.000 puts the
+Reserve on the club's desk something like half a second into a window members
+have been clicking into since it opened. :meth:`DirectHttpBooker.prepare`
+measures both quantities against the site and sends that much early. See
+:meth:`DirectHttpBooker._stage_arrival_lead`.
+
+**One Reserve is one guess.** A hold is not a booking: the club refuses a
+Reserve on a slot another member is holding while the tee sheet goes on
+rendering that slot as Available, so the refusal is the *only* evidence a slot
+is gone. Firing once and reporting "blocked" therefore threw away a morning on
+one contested tee time while eighty-odd others sat open. Reserve now walks a
+ranked fallback list until one is accepted, and because a refusal comes back
+with the whole re-rendered sheet, each step down that list costs a parse rather
+than a round trip. See :meth:`DirectHttpBooker._reserve_with_fallbacks`.
+
+The refusals are told apart before either applies:
+:func:`_classify_reserve_response` separates a held slot from a window the club
+has not opened yet, because the recovery for one is the opposite of the other.
 
 Failures raise :class:`~app.providers.walden_http.DirectHttpError`, which the
 caller treats as "fall back to the Selenium chain". Nothing here is trusted
@@ -43,6 +47,7 @@ import hashlib
 import logging
 import re
 import time as time_module
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import time
 from typing import Any
@@ -139,6 +144,40 @@ _REFRESH_DEADLINE_MS = 4000
 _REFRESH_MAX_ATTEMPTS = 4
 _REFRESH_RETRY_PAUSE_S = 0.2
 
+# Ceiling on how early the Reserve may be sent. The lead is measured, not
+# assumed, and a measurement can be wrong without limit; this bounds what a bad
+# one can cost. Comfortably above the ~500ms the club's clock and the flight
+# time have actually come to, and well under the countdown's one-second tick, so
+# an over-lead is still recoverable by asking again.
+_MAX_ARRIVAL_LEAD_MS = 900.0
+
+# Reserve attempts allowed across all candidate tee times. Each costs one round
+# trip plus the parse of the sheet that comes back with it - call it 450ms - so
+# this is about as far down the fallback list as the first two seconds of the
+# race reach. Past that the morning is decided and more requests are noise.
+_RESERVE_MAX_ATTEMPTS = 6
+
+# Re-fires of the *same* tee time after the club said the window is still shut.
+# Distinct from the blocked count on purpose: arriving early is our own timing
+# error and the slot is presumably still there, so the right answer is to ask
+# again rather than to give the slot up and walk down the fallback list.
+_PREMATURE_MAX_RETRIES = 4
+_PREMATURE_PAUSE_S = 0.05
+
+# Stop *starting* attempts once the race is this far gone. An attempt already in
+# flight is allowed to finish - abandoning it would not un-send it.
+_RESERVE_DEADLINE_MS = 6000
+
+# What the club's answer to a Reserve amounts to. The distinction that matters
+# is between the two refusals: "blocked" is another member holding the slot, and
+# the only useful response is a different tee time; a countdown still in the
+# sheet is the club saying nobody can hold anything yet, and the only useful
+# response is to ask again for the same one. Reading the second as the first
+# walks the whole fallback list into a window that has not opened.
+_VERDICT_ACCEPTED = "accepted"
+_VERDICT_PREMATURE = "premature"
+_VERDICT_BLOCKED = "blocked"
+
 # Marks a chain result as this path's. The provider handles both this and the JS
 # chain's results through the same branches, but only this one leaves the browser
 # DOM untouched, so only this one needs the outcome resolved against the site.
@@ -205,6 +244,15 @@ class DirectBookingResult:
     # the club still counting down, and was the slot open - and neither can be
     # answered from the Reserve response alone. Empty when no refresh landed.
     refresh_markup: str = ""
+    # The tee time the club actually accepted, which is not always the one asked
+    # for: a blocked slot sends the chain down the fallback list. The caller
+    # booked a slot by index long before this point and would otherwise report
+    # and verify the wrong one.
+    booked_slot_time: time | None = None
+    # Every tee time a Reserve went out for, in order. The record of how hard the
+    # morning was fought - one entry is a clean win, five is a sheet being taken
+    # apart around us - and the only place a fallback booking's reason comes from.
+    attempted_times: list[time] = field(default_factory=list)
 
     def as_chain_result(self) -> dict[str, Any]:
         """Render as the dict shape ``_run_booking_chain_js`` returns."""
@@ -217,6 +265,8 @@ class DirectBookingResult:
             "finalMarkup": self.final_markup,
             "responseMessage": self.response_message,
             "refreshMarkup": self.refresh_markup,
+            "bookedSlotTime": self.booked_slot_time,
+            "attemptedTimes": list(self.attempted_times),
             "path": DIRECT_HTTP_PATH,
         }
 
@@ -231,6 +281,8 @@ class DirectHttpBooker:
         self._reserve_body: bytes | None = None
         self._refresh_config: AbConfig | None = None
         self._slot_time: time | None = None
+        self._fallback_times: tuple[time, ...] = ()
+        self._lead_ms: float = 0.0
 
     # -- staging ----------------------------------------------------------
 
@@ -239,23 +291,32 @@ class DirectHttpBooker:
         reserve_button_id: str,
         page_html: str,
         *,
+        fallback_times: Sequence[time] = (),
+        measure_skew: bool = False,
         refresh_at_window: bool = False,
     ) -> None:
         """Resolve and pre-serialize the Reserve request, and warm the socket.
 
         Everything expensive happens here, before the booking window opens:
         parsing the tee sheet, resolving the button's AJAX config, urlencoding
-        the body, DNS/TCP/TLS. What remains for the target instant is a socket
-        write - plus, when ``refresh_at_window`` is set, one round trip to
-        re-render the sheet first.
+        the body, DNS/TCP/TLS, and measuring how early to send. What remains for
+        the target instant is a socket write.
 
         Args:
             reserve_button_id: Component id of the slot's Reserve link, e.g.
                 ``..._:teeTimeForm:teeTimeCourses:0:teeTimeSlots:67:slotTee:0:reserve_button``.
             page_html: Current tee sheet source, used to resolve the handler.
+            fallback_times: Tee times to fall back to, best first, when the club
+                refuses the one above as held by another member. Ranked by the
+                caller, which is the side that knows the fallback window and
+                which times are spoken for by the rest of the batch.
+            measure_skew: Probe the club's clock so the Reserve can be timed to
+                *arrive* as the window opens rather than to leave then. Timed
+                bookings only - it costs ~1.3s of probing, and an immediate
+                booking has no instant to hit.
             refresh_at_window: Re-render the tee sheet at the target instant and
-                fire Reserve against that render. Only meaningful for a timed
-                booking; an immediate one is already working off a live view.
+                fire Reserve against that render. Off by default; see
+                :meth:`_refresh_view` for why it is no longer the way in.
         """
         document = parse_html(page_html)
         button = document.find_by_id(reserve_button_id)
@@ -270,18 +331,67 @@ class DirectHttpBooker:
 
         self._reserve_config = config
         self._reserve_body = self.session.build_body(config)
+        # Read now, while the button is in hand. The chain reports which tee
+        # time it ended up holding, and after a fallback that is no longer the
+        # one the caller picked by row index.
+        self._slot_time = _slot_time_of(button)
+        # Anything already held, and the slot itself, are not fallbacks.
+        self._fallback_times = tuple(
+            dict.fromkeys(t for t in fallback_times if t != self._slot_time)
+        )
         logger.info(
-            "DIRECT_HTTP: Reserve request staged - source=%s, %d body bytes, viewState=%s",
+            "DIRECT_HTTP: Reserve request staged - source=%s, slot=%s, %d body bytes, "
+            "viewState=%s, fallbacks=%s",
             config.source,
+            self._slot_time.strftime("%I:%M %p") if self._slot_time else "unreadable",
             len(self._reserve_body),
             # Fingerprinted rather than logged: this is a live session token,
             # and all a post-mortem needs is whether the one that fired differs
             # from the one staged here.
             _view_state_fingerprint(self.session),
+            ", ".join(t.strftime("%I:%M %p") for t in self._fallback_times) or "none",
         )
         if refresh_at_window:
             self._stage_view_refresh(document, page_html, button)
         self.session.warm_up()
+        if measure_skew:
+            self._stage_arrival_lead()
+
+    def _stage_arrival_lead(self) -> None:
+        """Work out how far ahead of the target the Reserve should be sent.
+
+        Two clocks and a network sit between deciding to reserve and the club
+        acting on it, and both of them run against us: the club reaches 06:30:00
+        before we do, and the request still has to fly there. Sending at our own
+        06:30:00.000 therefore lands well inside a window other members have
+        already been clicking into.
+
+        A measurement that fails leaves the lead at zero - the behaviour before
+        this existed. Guessing would be worse than being late: too much lead
+        fires into a window the club has not opened, and while
+        :data:`_VERDICT_PREMATURE` recovers from that, it spends attempts on it.
+        """
+        try:
+            skew = self.session.measure_clock_skew()
+        except Exception as exc:  # noqa: BLE001 - staging must never lose a booking
+            logger.warning("DIRECT_HTTP: Clock skew probing failed (%s); sending unled", exc)
+            return
+        if skew is None:
+            return
+
+        # Clamped because the lead is derived from a measurement, and a wrong
+        # one is unbounded in the direction that hurts. Half a second of skew is
+        # already more than anything observed; past the ceiling the likelier
+        # explanation is a bad probe than a club running that far ahead.
+        self._lead_ms = max(0.0, min(skew.lead_ms, _MAX_ARRIVAL_LEAD_MS))
+        logger.info(
+            "DIRECT_HTTP: Reserve will be sent %.0fms early so it arrives as the window "
+            "opens (offset %+.0fms, one-way %.0fms%s)",
+            self._lead_ms,
+            skew.offset_ms,
+            skew.one_way_ms,
+            f", clamped from {skew.lead_ms:.0f}ms" if skew.lead_ms > _MAX_ARRIVAL_LEAD_MS else "",
+        )
 
     def _stage_view_refresh(self, document: Node, page_html: str, button: Node) -> None:
         """Resolve what to re-render the tee sheet with once the window opens.
@@ -407,7 +517,13 @@ class DirectHttpBooker:
         if target_timestamp_ms is not None:
             result.phase = PHASE_PRECISION_WAIT
             result.timing["msUntilTarget"] = target_timestamp_ms - int(time_module.time() * 1000)
-            result.timing["clickDriftMs"] = sleep_until(target_timestamp_ms)
+            result.timing["arrivalLeadMs"] = round(self._lead_ms)
+            # Led, so that the request *arrives* as the window opens. The drift
+            # is still reported against the lead-adjusted instant, which is the
+            # one the wait was actually aiming at.
+            result.timing["clickDriftMs"] = sleep_until(
+                target_timestamp_ms - int(round(self._lead_ms))
+            )
 
             # After the wait, not before: a sheet re-rendered while the window
             # is still shut is the very thing being refreshed away from.
@@ -423,34 +539,12 @@ class DirectHttpBooker:
         start = time_module.perf_counter()
 
         def elapsed_ms() -> int:
-            """Milliseconds since the Reserve request went out."""
+            """Milliseconds since the first Reserve request went out."""
             return int((time_module.perf_counter() - start) * 1000)
 
-        # The one line that says what actually went on the wire. Every branch
-        # above can change the component id or leave it alone, and only some of
-        # them say so; without this, reading back which slot was reserved means
-        # replaying those branches from the surrounding warnings.
-        if target_timestamp_ms is not None:
-            result.timing["reserveSentAtMs"] = int(time_module.time() * 1000) - target_timestamp_ms
-        logger.info(
-            "DIRECT_HTTP: Firing Reserve - source=%s, viewState=%s, %sms past the window",
-            config.source,
-            _view_state_fingerprint(self.session),
-            result.timing.get("reserveSentAtMs", "n/a - untimed"),
-        )
-
-        # Advance before the call, not after. Once the request is handed to the
-        # socket we cannot tell "never sent" from "sent, response lost", and a
-        # browser retry in the second case races our own reservation.
-        result.phase = PHASE_RESERVE_SENT
-        response = self.session.post(config, body=body)
-        result.final_markup = response.markup
+        response = self._reserve_with_fallbacks(config, body, target_timestamp_ms, result)
         result.timing["reserveMs"] = elapsed_ms()
-
-        blocked_reason = _find_blocked_message(response)
-        if blocked_reason is not None:
-            result.blocked = True
-            result.error = blocked_reason
+        if response is None:
             result.timing["blockedDetectedMs"] = elapsed_ms()
             return result
 
@@ -503,6 +597,165 @@ class DirectHttpBooker:
         result.timing["totalMs"] = elapsed_ms()
         return result
 
+    def _reserve_with_fallbacks(
+        self,
+        config: AbConfig,
+        body: bytes,
+        target_timestamp_ms: int | None,
+        result: DirectBookingResult,
+    ) -> PartialResponse | None:
+        """Fire Reserve, and keep firing until one is accepted or the list runs out.
+
+        The club answers a Reserve on a slot another member is holding with
+        "This slot is blocked by another user" while still rendering that slot
+        as Available - a hold is not a booking, and the sheet only shows the
+        second. So the refusal is the only signal that a slot is gone, and one
+        Reserve per morning means one guess at which slot was not.
+
+        The response to a refusal carries the whole re-rendered tee sheet, every
+        row's Reserve handler included, so walking to the next candidate costs a
+        parse rather than a round trip.
+
+        Returns:
+            The response that accepted a Reserve, or None with ``result``
+            describing the refusal that ended it.
+        """
+        started = time_module.perf_counter()
+        slot_time = self._slot_time
+        remaining = list(self._fallback_times)
+        premature_retries = 0
+        last_reason: str | None = None
+
+        for attempt in range(1, _RESERVE_MAX_ATTEMPTS + 1):
+            result.timing["reserveAttempts"] = attempt
+            if slot_time is not None:
+                result.attempted_times.append(slot_time)
+
+            if target_timestamp_ms is not None and attempt == 1:
+                # First attempt only. Later ones are paced by the club's
+                # answers, not by the clock, and reporting each against the
+                # window would bury the number that says whether we were on time.
+                result.timing["reserveSentAtMs"] = (
+                    int(time_module.time() * 1000) - target_timestamp_ms
+                )
+            logger.info(
+                "DIRECT_HTTP: Firing Reserve %d/%d for %s - source=%s, viewState=%s, "
+                "%sms past the window",
+                attempt,
+                _RESERVE_MAX_ATTEMPTS,
+                slot_time.strftime("%I:%M %p") if slot_time else "an unreadable slot",
+                config.source,
+                _view_state_fingerprint(self.session),
+                result.timing.get("reserveSentAtMs", "n/a - untimed")
+                if attempt == 1
+                else int((time_module.perf_counter() - started) * 1000),
+            )
+
+            # Advance before the call, not after. Once the request is handed to
+            # the socket we cannot tell "never sent" from "sent, response lost",
+            # and a browser retry in the second case races our own reservation.
+            result.phase = PHASE_RESERVE_SENT
+            response = self.session.post(config, body=body)
+            result.final_markup = response.markup
+
+            # One parse, two questions. At ~190ms for a 500KB sheet this is the
+            # largest single cost in the retry loop, and both the verdict and
+            # the next candidate's handler come out of the same tree.
+            document = parse_html(response.markup)
+            verdict, reason = _classify_reserve_response(document)
+            if verdict == _VERDICT_ACCEPTED:
+                result.booked_slot_time = slot_time
+                if attempt > 1:
+                    logger.info(
+                        "DIRECT_HTTP: Reserve accepted for %s on attempt %d after %dms",
+                        slot_time.strftime("%I:%M %p") if slot_time else "the staged slot",
+                        attempt,
+                        int((time_module.perf_counter() - started) * 1000),
+                    )
+                return response
+
+            last_reason = reason
+            spent_ms = (time_module.perf_counter() - started) * 1000
+            if spent_ms >= _RESERVE_DEADLINE_MS:
+                logger.warning(
+                    "DIRECT_HTTP: %dms spent on Reserve attempts; the race is over, stopping",
+                    int(spent_ms),
+                )
+                break
+
+            if verdict == _VERDICT_PREMATURE:
+                if premature_retries >= _PREMATURE_MAX_RETRIES:
+                    logger.error(
+                        "DIRECT_HTTP: The club is still counting down after %d re-fires; "
+                        "the window is not opening when we think it is",
+                        premature_retries,
+                    )
+                    break
+                premature_retries += 1
+                result.timing["prematureRetries"] = premature_retries
+                logger.warning(
+                    "DIRECT_HTTP: Reserve was early (%s); asking again for %s in %dms",
+                    reason,
+                    slot_time.strftime("%I:%M %p") if slot_time else "the same slot",
+                    int(_PREMATURE_PAUSE_S * 1000),
+                )
+                time_module.sleep(_PREMATURE_PAUSE_S)
+                # Rebuilt against the sheet just returned rather than re-sent:
+                # the row may have moved, and the ViewState may have advanced.
+                if slot_time is not None:
+                    relocated = _relocate_reserve_in(document, response.markup, slot_time)
+                    if relocated is not None:
+                        config = relocated
+                body = self.session.build_body(config)
+                continue
+
+            # Blocked: the slot is held. Nothing about asking again for it will
+            # change that, so the only move left is a different tee time.
+            next_candidate = self._next_candidate(document, response.markup, remaining)
+            if next_candidate is None:
+                logger.warning("DIRECT_HTTP: %s and no fallback tee time left to try", reason)
+                break
+            config, slot_time = next_candidate
+            body = self.session.build_body(config)
+            logger.info(
+                "DIRECT_HTTP: %s; falling back to %s",
+                reason,
+                slot_time.strftime("%I:%M %p"),
+            )
+
+        result.blocked = True
+        result.error = last_reason or "Slot blocked by another user"
+        logger.warning(
+            "DIRECT_HTTP: No Reserve accepted after %d attempt(s) over %dms - tried %s",
+            result.timing.get("reserveAttempts", 0),
+            int((time_module.perf_counter() - started) * 1000),
+            ", ".join(t.strftime("%I:%M %p") for t in result.attempted_times) or "nothing",
+        )
+        return None
+
+    def _next_candidate(
+        self,
+        document: Node,
+        markup: str,
+        remaining: list[time],
+    ) -> tuple[AbConfig, time] | None:
+        """Pop the best fallback tee time still reservable in ``document``.
+
+        Consumes ``remaining`` as it goes, so a candidate the sheet no longer
+        offers a Reserve for is dropped rather than retried against the next
+        response - if it has no button now it is gone, not late.
+        """
+        while remaining:
+            candidate = remaining.pop(0)
+            config = _relocate_reserve_in(document, markup, candidate)
+            if config is not None:
+                return config, candidate
+            logger.info(
+                "DIRECT_HTTP: Fallback %s has no Reserve in the returned sheet; skipping it",
+                candidate.strftime("%I:%M %p"),
+            )
+        return None
+
     def _refresh_view(
         self,
         staged_config: AbConfig,
@@ -510,6 +763,13 @@ class DirectHttpBooker:
         result: DirectBookingResult,
     ) -> tuple[AbConfig, bytes] | None:
         """Re-render the tee sheet now the window is open, and restage Reserve.
+
+        Off by default, and kept only as a way back. It was built on the reading
+        that a Reserve staged before the window is refused for being stale; on
+        2026-08-07 the refresh ran exactly as designed - fresh sheet, countdown
+        gone, 86 of 87 rows offering a Reserve - and the club refused anyway,
+        with the *same* ViewState and component id the staged request already
+        carried. It cost 730ms of the race and changed no byte of the request.
 
         Replays the selected day tab, which re-renders the whole form without
         changing the date. What comes back is a view built after the window
@@ -1057,7 +1317,42 @@ def _find_blocked_message(response: PartialResponse) -> str | None:
     Returns the matched reason, or None when the response carries no blocked
     indication.
     """
-    document = parse_html(response.markup)
+    return _find_blocked_message_in(parse_html(response.markup))
+
+
+def _classify_reserve_response(document: Node) -> tuple[str, str | None]:
+    """Decide what the club's answer to a Reserve was.
+
+    The two refusals look alike and mean opposite things. "This slot is blocked
+    by another user" is a member holding it, and the answer is a different tee
+    time. The same message beside a live countdown is not about that slot at
+    all - the club is saying nothing is holdable yet - and the answer is to ask
+    again for the same one.
+
+    The countdown is checked first for that reason. A sheet that still carries
+    it cannot be evidence about who holds what, whatever else it says.
+
+    Returns:
+        One of the ``_VERDICT_*`` constants, with the club's own wording when it
+        gave any.
+    """
+    countdown_s = _countdown_in(document)
+    if countdown_s is not None:
+        return _VERDICT_PREMATURE, f"the club is still counting down {countdown_s}s to the window"
+
+    blocked_reason = _find_blocked_message_in(document)
+    if blocked_reason is not None:
+        return _VERDICT_BLOCKED, blocked_reason
+
+    return _VERDICT_ACCEPTED, None
+
+
+def _find_blocked_message_in(document: Node) -> str | None:
+    """The blocked-popup check, against a sheet already parsed.
+
+    Split out so the retry loop can ask this and :func:`_countdown_in` of one
+    parse: the sheet is ~500KB and the parse is the loop's largest single cost.
+    """
     for node in document.descendants():
         if "teesheetvalidationerrorpopup" not in node.id.lower():
             continue

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 import time as time_module
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import date, datetime, time, timedelta
 from typing import Any, TypeVar
 
@@ -2900,6 +2900,37 @@ class WaldenGolfProvider(ReservationProvider):
                     f"using {booked_time.strftime('%I:%M %p')}"
                 )
 
+            # Ranked now, while there is time to spend on a DOM scan, and only
+            # for the timed race. The slot picked above is a guess about a sheet
+            # that renders held slots as free; these are the tee times the chain
+            # is allowed to fall back to when the club refuses that guess.
+            fallback_times: list[time] = []
+            if execute_at_timestamp_ms is not None:
+                try:
+                    fallback_times = [
+                        candidate_time
+                        for candidate in self._rank_candidate_slots_js(
+                            driver,
+                            target_time,
+                            num_players,
+                            fallback_window_minutes,
+                            tee_time_interval_minutes,
+                            times_to_exclude,
+                        )
+                        if (candidate_time := time(candidate["hours"], candidate["minutes"]))
+                        != booked_time
+                    ]
+                except Exception as e:  # noqa: BLE001 - a bonus must not cost the booking
+                    # Fallbacks improve a losing morning; they are not what makes
+                    # a winning one work. A scan that cannot be read leaves the
+                    # chain firing one Reserve, which is what it did before.
+                    logger.warning(
+                        "BOOKING_DEBUG: Could not rank fallback tee times (%s: %s); "
+                        "the chain will get one Reserve attempt",
+                        type(e).__name__,
+                        e,
+                    )
+
             # === ULTRA-FAST PATH: Execute entire booking flow in rapid JS sequence ===
             # This replaces: _click_slot_by_index_js + _complete_booking_sync
             # with a single JS execution that does Reserve → player count → TBD → Book Now
@@ -2918,6 +2949,7 @@ class WaldenGolfProvider(ReservationProvider):
                 slot_info,
                 num_players,
                 execute_at_timestamp_ms,
+                fallback_times=fallback_times,
             )
 
             if chain_result is None:
@@ -2934,6 +2966,33 @@ class WaldenGolfProvider(ReservationProvider):
                         slot_info["index"],
                         num_players,
                     )
+
+            # The chain may have settled on a tee time other than the one picked
+            # by row index above: a refused slot sends it down the fallback
+            # list. Everything after this names the slot actually held - the
+            # reservations check that decides whether the booking is real, and
+            # the time the member is told they have.
+            held_time = chain_result.get("bookedSlotTime")
+            if held_time is not None and held_time != booked_time:
+                logger.info(
+                    "DIRECT_HTTP: Booked %s rather than %s after %d refusal(s) - tried %s",
+                    held_time.strftime("%I:%M %p"),
+                    booked_time.strftime("%I:%M %p"),
+                    len(chain_result.get("attemptedTimes", [])) - 1,
+                    ", ".join(
+                        t.strftime("%I:%M %p") for t in chain_result.get("attemptedTimes", [])
+                    ),
+                )
+                booked_time = held_time
+                is_exact = held_time == target_time
+                fallback_reason = (
+                    None
+                    if is_exact
+                    else (
+                        f"Exact time {target_time.strftime('%I:%M %p')} was taken, "
+                        f"booked {held_time.strftime('%I:%M %p')}"
+                    )
+                )
 
             if chain_result.get("blocked"):
                 # Another member took the slot at the same moment - or the chain
@@ -3498,10 +3557,42 @@ class WaldenGolfProvider(ReservationProvider):
         times_to_exclude: set[time] | None = None,
     ) -> dict[str, Any] | None:
         """
-        Find the best available slot using a single JavaScript execution.
+        Find the single best available slot. See _rank_candidate_slots_js.
+
+        Returns:
+            The best slot dict, or None if nothing in the window suits.
+        """
+        candidates = self._rank_candidate_slots_js(
+            driver,
+            target_time,
+            num_players,
+            fallback_window_minutes,
+            tee_time_interval_minutes,
+            times_to_exclude,
+        )
+        return candidates[0] if candidates else None
+
+    def _rank_candidate_slots_js(
+        self,
+        driver: webdriver.Chrome,
+        target_time: time,
+        num_players: int,
+        fallback_window_minutes: int,
+        tee_time_interval_minutes: int = 8,
+        times_to_exclude: set[time] | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Rank every bookable slot in the fallback window, best first.
 
         This replaces the Python-based _find_empty_slots + _is_northgate_slot pipeline
         with a single browser-side DOM traversal, reducing slot finding from ~17s to ~100ms.
+
+        The whole ranking is returned, not just the winner, because at 6:30 the
+        winner is a guess: the sheet renders a slot another member is holding as
+        Available, so the only way to learn a slot is gone is to be refused it.
+        The direct-HTTP chain walks this list on refusal (see
+        DirectHttpBooker._reserve_with_fallbacks); the browser chain still takes
+        the head of it and stops there.
 
         The JavaScript iterates all slot items in the browser, checking:
         - Course membership via element ID patterns (teeTimeCourses:0 for Northgate)
@@ -3518,8 +3609,9 @@ class WaldenGolfProvider(ReservationProvider):
             times_to_exclude: Times to skip when selecting fallback slots
 
         Returns:
-            Dict with slot info {index, hours, minutes, timeStr, diff, available, isExact}
-            or None if no suitable slot found
+            Slot dicts {index, hours, minutes, timeStr, diff, available, isExact,
+            reserveId}, nearest the requested time first and the earlier tee time
+            breaking a tie. Empty when nothing in the window suits.
         """
         if times_to_exclude is None:
             times_to_exclude = set()
@@ -3538,9 +3630,7 @@ class WaldenGolfProvider(ReservationProvider):
 
         var targetMinutes = targetHour * 60 + targetMinute;
         var items = document.querySelectorAll('li.ui-datascroller-item');
-        var bestSlot = null;
-        var exactMatch = null;
-        var bestDiff = Infinity;
+        var candidates = [];
 
         // Build exclude set for O(1) lookup
         var excludeSet = {};
@@ -3622,40 +3712,47 @@ class WaldenGolfProvider(ReservationProvider):
                 reserveId: reserveEl ? reserveEl.id : null
             };
 
-            if (diff === 0) {
-                exactMatch = slotInfo;
-            }
-
-            // For fallback slots, skip excluded times
+            // For fallback slots, skip excluded times. Never for the exact time
+            // asked for: that one is the booking, not a stand-in chosen for it.
             if (diff !== 0 && excludeSet[slotMinutes]) continue;
 
-            if (diff < bestDiff) {
-                bestDiff = diff;
-                bestSlot = slotInfo;
-            }
+            candidates.push(slotInfo);
         }
 
-        return exactMatch || bestSlot;
+        // Nearest to the requested time first, and on a tie the earlier tee
+        // time - the same order the single-slot search reached by scanning rows
+        // in time order and keeping the first strictly-closer one.
+        candidates.sort(function (a, b) {
+            if (a.diff !== b.diff) return a.diff - b.diff;
+            return (a.hours * 60 + a.minutes) - (b.hours * 60 + b.minutes);
+        });
+
+        return candidates;
         """
 
-        result: dict[str, Any] | None = driver.execute_script(
-            js_code,
-            target_time.hour,
-            target_time.minute,
-            num_players,
-            fallback_window_minutes,
-            tee_time_interval_minutes,
-            exclude_list,
-            self.NORTHGATE_COURSE_INDEX,
-            self.MAX_PLAYERS,
+        candidates: list[dict[str, Any]] = (
+            driver.execute_script(
+                js_code,
+                target_time.hour,
+                target_time.minute,
+                num_players,
+                fallback_window_minutes,
+                tee_time_interval_minutes,
+                exclude_list,
+                self.NORTHGATE_COURSE_INDEX,
+                self.MAX_PLAYERS,
+            )
+            or []
         )
 
-        if result:
+        if candidates:
+            best = candidates[0]
             logger.info(
                 f"BOOKING_DEBUG: JS slot finder found slot at "
-                f"{result['hours']:02d}:{result['minutes']:02d} "
-                f"(index={result['index']}, exact={result['isExact']}, "
-                f"available={result['available']})"
+                f"{best['hours']:02d}:{best['minutes']:02d} "
+                f"(index={best['index']}, exact={best['isExact']}, "
+                f"available={best['available']}), "
+                f"{len(candidates) - 1} fallback(s) behind it"
             )
         else:
             logger.warning(
@@ -3664,7 +3761,7 @@ class WaldenGolfProvider(ReservationProvider):
                 f"for {num_players} players"
             )
 
-        return result
+        return candidates
 
     def _click_slot_by_index_js(self, driver: webdriver.Chrome, slot_index: int) -> bool:
         """
@@ -3887,6 +3984,7 @@ class WaldenGolfProvider(ReservationProvider):
         slot_info: dict[str, Any],
         num_players: int,
         execute_at_timestamp_ms: int | None,
+        fallback_times: Sequence[time] = (),
     ) -> dict[str, Any] | None:
         """
         Attempt the booking chain over direct HTTP instead of browser clicks.
@@ -3901,6 +3999,8 @@ class WaldenGolfProvider(ReservationProvider):
             slot_info: Slot dict from _find_target_slot_js; needs 'reserveId'
             num_players: Number of players (1-4)
             execute_at_timestamp_ms: Epoch ms to fire Reserve at, or None for now
+            fallback_times: Tee times to try, best first, when the club refuses
+                the slot above as held by another member
 
         Returns:
             A chain-result dict (same shape as _run_booking_chain_js) when the
@@ -3926,8 +4026,13 @@ class WaldenGolfProvider(ReservationProvider):
             booker.prepare(
                 reserve_id,
                 driver.page_source,
-                # Only a timed booking is staged against a view built before the
-                # window; an immediate one already holds a live sheet.
+                fallback_times=fallback_times,
+                # Both are for the race and only the race: an immediate booking
+                # has no instant to arrive at, and is already working off a live
+                # sheet rather than one staged before the window.
+                measure_skew=(
+                    settings.walden_measure_clock_skew and execute_at_timestamp_ms is not None
+                ),
                 refresh_at_window=(
                     settings.walden_refresh_view_at_window and execute_at_timestamp_ms is not None
                 ),

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -4069,28 +4069,41 @@ class WaldenGolfProvider(ReservationProvider):
         finally:
             session.close()
 
+        # The one line a post-mortem starts from, so everything that decides a
+        # morning has to be readable in it without going back through the run.
         logger.info(
             "DIRECT_HTTP: Chain finished - phase=%s, success=%s, blocked=%s, "
-            "clickDrift=%sms, viewRefresh=%sms/%sx%s, totalMs=%s, error=%s",
+            "clickDrift=%sms, %s, attempts=%s%s, booked=%s, tried=[%s]%s, "
+            "totalMs=%s, error=%s",
             result.phase,
             result.success,
             result.blocked,
             result.timing.get("clickDriftMs", "N/A"),
-            # "N/A" attempts means no refresh ran at all. The suffix carries why
-            # it did not land, and any countdown the club was still showing -
-            # which is the reading that says whether the premise still holds.
-            result.timing.get("viewRefreshMs", "N/A"),
-            result.timing.get("viewRefreshAttempts", "N/A"),
-            "".join(
-                part
-                for part in (
-                    f" {result.timing['viewRefreshFailed']}"
-                    if result.timing.get("viewRefreshFailed")
-                    else "",
-                    f" countdown={result.timing['viewRefreshCountdownS']}s"
-                    if result.timing.get("viewRefreshCountdownS")
-                    else "",
-                )
+            # The number that says whether we were on time. Negative means the
+            # Reserve left before our own 06:30:00, which is the whole point of
+            # the lead - so an untimed booking says so rather than printing one.
+            (
+                f"lead={result.timing['arrivalLeadMs']}ms, "
+                f"sent={result.timing.get('reserveSentAtMs', '?')}ms vs window"
+                if "arrivalLeadMs" in result.timing
+                else "untimed (no window to lead)"
+            ),
+            result.timing.get("reserveAttempts", "N/A"),
+            f" (+{result.timing['prematureRetries']} early re-fires)"
+            if result.timing.get("prematureRetries")
+            else "",
+            result.booked_slot_time.strftime("%I:%M %p") if result.booked_slot_time else "nothing",
+            ", ".join(t.strftime("%I:%M %p") for t in result.attempted_times),
+            # Absent unless a refresh ran, since it is off by default now. The
+            # suffix carries why it did not land, and any countdown the club was
+            # still showing.
+            (
+                f", viewRefresh={result.timing['viewRefreshMs']}ms/"
+                f"{result.timing.get('viewRefreshAttempts', '?')}x"
+                f"{' ' + result.timing['viewRefreshFailed'] if result.timing.get('viewRefreshFailed') else ''}"
+                f"{' countdown=' + str(result.timing['viewRefreshCountdownS']) + 's' if result.timing.get('viewRefreshCountdownS') else ''}"
+                if result.timing.get("viewRefreshMs") is not None
+                else ""
             ),
             result.timing.get("totalMs", "N/A"),
             result.error,

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -234,6 +234,11 @@ resource "google_cloud_run_v2_service" "teetime" {
       }
 
       env {
+        name  = "WALDEN_MEASURE_CLOCK_SKEW"
+        value = tostring(var.walden_measure_clock_skew)
+      }
+
+      env {
         name  = "WALDEN_FAST_BOOKING_BATCH"
         value = tostring(var.walden_fast_booking_batch)
       }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -162,13 +162,32 @@ variable "walden_refresh_view_at_window" {
     Re-render the tee sheet at 6:30:00 and fire Reserve against that render,
     instead of against the one the request was staged from ~60s earlier.
 
-    The staged view is a sheet on which nothing is reservable yet, and the club
-    refuses a Reserve against it with "This slot is blocked by another user" -
-    the same message it uses when a human genuinely beat us. Costs ~200ms off
-    the front of the race (round trip plus re-parsing the sheet), and only
-    applies to timed bookings.
+    Off, having been tried. It was built on the reading that the club refuses a
+    Reserve staged before the window for being stale. On 2026-08-07 it worked
+    exactly as designed - fresh sheet, countdown gone, 86 of 87 rows offering a
+    Reserve - and the club refused anyway, with the same ViewState and component
+    id the staged request already carried. It cost 730ms of a race decided in
+    the first second and changed no byte of the request.
 
-    On. Turn off to go back to firing the pre-staged request untouched.
+    Turn on only if a morning shows a genuine stale-view refusal.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "walden_measure_clock_skew" {
+  description = <<-EOT
+    Probe the club's clock while staging, and send the Reserve early enough to
+    *arrive* as the booking window opens rather than to leave then.
+
+    Two things sit between us and the window and both run against us: the club's
+    clock reaches 06:30:00 before ours does, and the request still has to fly
+    there. Firing at our own 06:30:00.000 has been landing something like half a
+    second into a window members have been clicking into since it opened.
+
+    On. The lead is measured rather than assumed and clamped in the booker, and
+    a failed measurement sends unled, so the downside is bounded at the old
+    behaviour. Timed bookings only. Turn off to go back to firing at our clock.
   EOT
   type        = bool
   default     = true

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -6,6 +6,7 @@ tests/fixtures/, so the request this builds is the request the site actually
 expects - not one derived from a hand-written mock.
 """
 
+import email.utils
 import time as time_module
 import urllib.parse
 from collections.abc import Callable
@@ -1496,3 +1497,350 @@ class TestStageViewRefresh:
 
         assert booker._refresh_config is None
         assert booker._reserve_config is not None
+
+
+# ---------------------------------------------------------------------------
+# Walking the fallback list when the club refuses a slot
+# ---------------------------------------------------------------------------
+
+# Three consecutive tee times on the same sheet. The first is the one Reserve is
+# staged against; the others are what the chain may fall back to.
+SLOT_B_ID = f"{FORM_ID}:teeTimeCourses:0:teeTimeSlots:68:slotTee:0:reserve_button"
+SLOT_C_ID = f"{FORM_ID}:teeTimeCourses:0:teeTimeSlots:69:slotTee:0:reserve_button"
+SLOT_B_TIME = time(16, 42)
+SLOT_C_TIME = time(16, 50)
+
+
+def blocked_sheet(*slots: str) -> str:
+    """A refusal, carrying the whole re-rendered sheet the way the site does.
+
+    This shape is why the fallback loop needs no extra round trip: the response
+    that says "blocked" hands back every other row's Reserve handler with it.
+    """
+    return refreshed_sheet(
+        '<div id="teeSheetValidationErrorPopup" aria-hidden="false">'
+        "This slot is blocked by another user</div>",
+        *slots,
+    )
+
+
+ALL_THREE = (
+    slot_block(RESERVE_ID, "04:34 PM"),
+    slot_block(SLOT_B_ID, "04:42 PM"),
+    slot_block(SLOT_C_ID, "04:50 PM"),
+)
+
+
+def stage_fallbacks(booker: DirectHttpBooker, *times: time) -> DirectHttpBooker:
+    """Give a booker from make_booker a slot time and a ranked fallback list."""
+    booker._slot_time = RESERVE_SLOT_TIME
+    booker._fallback_times = times
+    return booker
+
+
+class TestReserveFallbacks:
+    """A refused Reserve moves to the next tee time instead of ending the run.
+
+    The club renders a slot another member is holding as Available, so the
+    refusal is the only evidence the slot is gone. One Reserve is therefore one
+    guess, and on 2026-08-07 the guess lost while 86 other rows stayed open.
+    """
+
+    def test_a_clean_reserve_spends_no_fallback(self) -> None:
+        """Winning the slot asked for must not cost an extra request."""
+        recorder = ChainRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        result = stage_fallbacks(make_booker(recorder), SLOT_B_TIME).book(1)
+
+        assert result.success, result.error
+        assert recorder.sources == [RESERVE_ID, "playerGroup", "bookTeeTimeAction"]
+        assert result.booked_slot_time == RESERVE_SLOT_TIME
+        assert result.attempted_times == [RESERVE_SLOT_TIME]
+
+    def test_a_blocked_slot_falls_back_to_the_next_tee_time(self) -> None:
+        """The refusal's own markup is what the next Reserve is built from."""
+        recorder = ChainRecorder([blocked_sheet(*ALL_THREE), PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        result = stage_fallbacks(make_booker(recorder), SLOT_B_TIME, SLOT_C_TIME).book(1)
+
+        assert result.success, result.error
+        assert recorder.sources == [RESERVE_ID, SLOT_B_ID, "playerGroup", "bookTeeTimeAction"]
+        assert result.timing["reserveAttempts"] == 2
+
+    def test_the_booked_time_is_the_one_actually_held(self) -> None:
+        """The caller books by row index and would otherwise report the wrong slot."""
+        recorder = ChainRecorder([blocked_sheet(*ALL_THREE), PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        result = stage_fallbacks(make_booker(recorder), SLOT_B_TIME, SLOT_C_TIME).book(1)
+
+        assert result.booked_slot_time == SLOT_B_TIME
+        assert result.attempted_times == [RESERVE_SLOT_TIME, SLOT_B_TIME]
+
+    def test_a_fallback_the_sheet_no_longer_offers_is_skipped(self) -> None:
+        """No Reserve button means the slot is gone, not that it is worth a request."""
+        recorder = ChainRecorder(
+            [
+                blocked_sheet(
+                    slot_block(RESERVE_ID, "04:34 PM"),
+                    slot_block(SLOT_C_ID, "04:50 PM"),
+                ),
+                PLAYER_PAGE,
+                ROWS_PAGE,
+                BOOKED_PAGE,
+            ]
+        )
+        # SLOT_B ranks higher but is absent from the sheet that came back.
+        result = stage_fallbacks(make_booker(recorder), SLOT_B_TIME, SLOT_C_TIME).book(1)
+
+        assert result.success, result.error
+        assert recorder.sources[1] == SLOT_C_ID
+        assert result.booked_slot_time == SLOT_C_TIME
+
+    def test_every_candidate_blocked_is_reported_as_blocked(self) -> None:
+        """Running out of tee times is still a lost race, not a crash."""
+        recorder = ChainRecorder([blocked_sheet(*ALL_THREE)])
+        result = stage_fallbacks(make_booker(recorder), SLOT_B_TIME, SLOT_C_TIME).book(1)
+
+        assert not result.success
+        assert result.blocked
+        assert result.phase == PHASE_RESERVE_SENT
+        assert result.attempted_times == [RESERVE_SLOT_TIME, SLOT_B_TIME, SLOT_C_TIME]
+        assert "blocked" in (result.error or "").lower()
+
+    def test_attempts_are_capped(self) -> None:
+        """A sheet being taken apart around us is not worth unbounded requests."""
+        from app.providers.walden_http_booker import _RESERVE_MAX_ATTEMPTS
+
+        spare = [
+            slot_block(
+                f"{FORM_ID}:teeTimeCourses:0:teeTimeSlots:{70 + i}:slotTee:0:reserve_button",
+                f"05:{i:02d} PM",
+            )
+            for i in range(_RESERVE_MAX_ATTEMPTS + 4)
+        ]
+        recorder = ChainRecorder([blocked_sheet(slot_block(RESERVE_ID, "04:34 PM"), *spare)])
+        result = stage_fallbacks(
+            make_booker(recorder), *[time(17, i) for i in range(_RESERVE_MAX_ATTEMPTS + 4)]
+        ).book(1)
+
+        assert result.blocked
+        assert result.timing["reserveAttempts"] == _RESERVE_MAX_ATTEMPTS
+        assert len(recorder.sources) == _RESERVE_MAX_ATTEMPTS
+
+    def test_no_fallbacks_behaves_as_a_single_shot(self) -> None:
+        """The old behaviour, for a booking with nothing ranked behind it."""
+        recorder = ChainRecorder([blocked_sheet(*ALL_THREE)])
+        result = stage_fallbacks(make_booker(recorder)).book(1)
+
+        assert result.blocked
+        assert recorder.sources == [RESERVE_ID]
+
+
+class TestPrematureVersusBlocked:
+    """The two refusals look alike and call for opposite responses.
+
+    A countdown still in the sheet is the club saying nothing is holdable yet.
+    Reading that as "someone holds this slot" walks the whole fallback list into
+    a window that has not opened and arrives at the end of it with nothing -
+    which is exactly what a measured lead makes possible when it overshoots.
+    """
+
+    def test_a_countdown_retries_the_same_slot(self) -> None:
+        """Arriving early costs one re-ask, not the fallback list."""
+        recorder = ChainRecorder([countdown_sheet("00:00:02"), PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        result = stage_fallbacks(make_booker(recorder), SLOT_B_TIME).book(1)
+
+        assert result.success, result.error
+        # The same tee time, re-resolved against the sheet that came back.
+        assert recorder.sources == [
+            RESERVE_ID,
+            MOVED_RESERVE_ID,
+            "playerGroup",
+            "bookTeeTimeAction",
+        ]
+        assert result.booked_slot_time == RESERVE_SLOT_TIME
+        assert result.timing["prematureRetries"] == 1
+
+    def test_a_countdown_beside_a_block_is_still_a_countdown(self) -> None:
+        """The response the club actually sent on 2026-08-06: both at once.
+
+        The countdown wins. A sheet the club has not opened cannot be evidence
+        about who is holding what inside it.
+        """
+        from app.providers.walden_http_booker import (
+            _VERDICT_BLOCKED,
+            _VERDICT_PREMATURE,
+            _classify_reserve_response,
+        )
+
+        both = refreshed_sheet(
+            '<div class="booking-starts-in">Booking Starts In : 00:01:05</div>',
+            '<div id="teeSheetValidationErrorPopup" aria-hidden="false">'
+            "This slot is blocked by another user</div>",
+        )
+        verdict, reason = _classify_reserve_response(parse_html(both))
+        assert verdict == _VERDICT_PREMATURE
+        assert "counting down" in (reason or "")
+
+        # The same markup without the countdown is a genuine refusal.
+        verdict, _ = _classify_reserve_response(parse_html(blocked_sheet(*ALL_THREE)))
+        assert verdict == _VERDICT_BLOCKED
+
+    def test_an_endless_countdown_gives_up_without_burning_the_list(self) -> None:
+        """If the window never opens, the fallbacks were never the problem."""
+        from app.providers.walden_http_booker import _PREMATURE_MAX_RETRIES
+
+        recorder = ChainRecorder([countdown_sheet("00:01:05")])
+        result = stage_fallbacks(make_booker(recorder), SLOT_B_TIME, SLOT_C_TIME).book(1)
+
+        assert result.blocked
+        assert result.timing["prematureRetries"] == _PREMATURE_MAX_RETRIES
+        # Every request went to the requested tee time; no fallback was spent.
+        assert SLOT_B_ID not in recorder.sources
+        assert result.attempted_times == [RESERVE_SLOT_TIME] * (_PREMATURE_MAX_RETRIES + 1)
+
+
+# ---------------------------------------------------------------------------
+# Timing the Reserve to arrive rather than to leave
+# ---------------------------------------------------------------------------
+
+
+def clock_handler(offset_s: float) -> Callable[[httpx.Request], httpx.Response]:
+    """A site whose clock runs ``offset_s`` ahead of ours.
+
+    The Date header is whole seconds, as a real one is - which is the point.
+    The offset is not readable from any single response; it is readable from
+    where the header ticks over relative to our clock.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Mock transport handler stamping the site's own clock."""
+        server_now = time_module.time() + offset_s
+        return httpx.Response(
+            200, headers={"Date": email.utils.formatdate(server_now, usegmt=True)}
+        )
+
+    return handler
+
+
+class TestClockSkew:
+    """Measuring how far ahead the club's clock is, and how far away it is."""
+
+    def test_offset_is_read_from_where_the_date_header_ticks(self) -> None:
+        """A one-second header still locates a boundary to within a probe gap."""
+        session = make_session(FormState.from_html(TEE_SHEET), clock_handler(0.4))
+
+        skew = session.measure_clock_skew()
+
+        assert skew is not None
+        # Loose enough for probe spacing and sleep jitter, tight enough that a
+        # sign error or a whole-second misread would fail it.
+        assert 250 < skew.offset_ms < 550
+        assert skew.transitions >= 1
+        assert session.clock_skew is skew
+
+    def test_a_clock_behind_ours_reads_negative(self) -> None:
+        """The lead must be able to come out smaller, not only larger."""
+        session = make_session(FormState.from_html(TEE_SHEET), clock_handler(-0.4))
+
+        skew = session.measure_clock_skew()
+
+        assert skew is not None
+        assert -550 < skew.offset_ms < -250
+
+    def test_a_frozen_date_header_is_not_a_measurement(self) -> None:
+        """A cache serving one Date says nothing about the origin's clock."""
+        frozen = email.utils.formatdate(time_module.time(), usegmt=True)
+        session = make_session(
+            FormState.from_html(TEE_SHEET),
+            lambda request: httpx.Response(200, headers={"Date": frozen}),
+        )
+
+        assert session.measure_clock_skew() is None
+
+    def test_a_missing_date_header_is_not_a_measurement(self) -> None:
+        """Nothing to read is reported as nothing, not as zero skew."""
+        session = make_session(
+            FormState.from_html(TEE_SHEET),
+            lambda request: httpx.Response(200, headers={}),
+        )
+
+        assert session.measure_clock_skew() is None
+
+    def test_the_lead_is_the_offset_plus_the_flight_out(self) -> None:
+        """Both halves run against us, so both are in the lead."""
+        from app.providers.walden_http import ClockSkew
+
+        assert ClockSkew(offset_ms=250, one_way_ms=200, probes=9, transitions=2).lead_ms == 450
+
+
+class TestArrivalLead:
+    """What the booker does with the measurement."""
+
+    def _booker(self, handler: Callable[[httpx.Request], httpx.Response]) -> DirectHttpBooker:
+        """A booker over a handler, with nothing staged - only the lead matters."""
+        return DirectHttpBooker(make_session(FormState.from_html(TEE_SHEET), handler))
+
+    def test_a_measured_skew_becomes_the_lead(self) -> None:
+        """The whole point: send early by what the measurement says."""
+        booker = self._booker(clock_handler(0.4))
+
+        booker._stage_arrival_lead()
+
+        assert 250 < booker._lead_ms < 560
+
+    def test_an_unmeasurable_clock_sends_unled(self) -> None:
+        """Being late is recoverable; guessing early is what is not."""
+        booker = self._booker(lambda request: httpx.Response(200, headers={}))
+
+        booker._stage_arrival_lead()
+
+        assert booker._lead_ms == 0.0
+
+    def test_a_probe_failure_does_not_break_staging(self) -> None:
+        """Staging must never be what loses a booking."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Mock transport handler that refuses every probe."""
+            raise httpx.ConnectError("no route")
+
+        booker = self._booker(handler)
+
+        booker._stage_arrival_lead()
+
+        assert booker._lead_ms == 0.0
+
+    def test_an_implausible_measurement_is_clamped(self) -> None:
+        """A bad measurement is unbounded in the direction that hurts."""
+        from app.providers.walden_http_booker import _MAX_ARRIVAL_LEAD_MS
+
+        booker = self._booker(clock_handler(5.0))
+
+        booker._stage_arrival_lead()
+
+        assert booker._lead_ms == _MAX_ARRIVAL_LEAD_MS
+
+    def test_the_reserve_goes_out_before_our_own_target(self) -> None:
+        """The behaviour all of the above exists to produce."""
+        recorder = ChainRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        booker = stage_fallbacks(make_booker(recorder))
+        booker._lead_ms = 400.0
+        # Far enough out that the lead lands the send before it, close enough
+        # that the test does not sit waiting.
+        target = int(time_module.time() * 1000) + 250
+
+        result = booker.book(1, target_timestamp_ms=target)
+
+        assert result.success, result.error
+        assert result.timing["arrivalLeadMs"] == 400
+        # Negative: the request left before our clock reached the window.
+        assert result.timing["reserveSentAtMs"] < 0
+
+    def test_no_lead_still_fires_at_the_target(self) -> None:
+        """An unmeasured clock leaves the old timing exactly as it was."""
+        recorder = ChainRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        booker = stage_fallbacks(make_booker(recorder))
+        target = int(time_module.time() * 1000) + 60
+
+        result = booker.book(1, target_timestamp_ms=target)
+
+        assert result.success, result.error
+        assert result.timing["arrivalLeadMs"] == 0
+        assert result.timing["reserveSentAtMs"] >= 0

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -1690,7 +1690,12 @@ class TestPrematureVersusBlocked:
         recorder = ChainRecorder([countdown_sheet("00:01:05")])
         result = stage_fallbacks(make_booker(recorder), SLOT_B_TIME, SLOT_C_TIME).book(1)
 
-        assert result.blocked
+        assert not result.success
+        # Not "blocked": the caller hard-codes that branch's message to "another
+        # member took the slot", which is the opposite of what happened. The
+        # countdown reason has to reach the member, not just the log.
+        assert not result.blocked
+        assert "counting down" in (result.error or "")
         assert result.timing["prematureRetries"] == _PREMATURE_MAX_RETRIES
         # Every request went to the requested tee time; no fallback was spent.
         assert SLOT_B_ID not in recorder.sources
@@ -1811,7 +1816,7 @@ class TestArrivalLead:
         """A bad measurement is unbounded in the direction that hurts."""
         from app.providers.walden_http_booker import _MAX_ARRIVAL_LEAD_MS
 
-        booker = self._booker(clock_handler(5.0))
+        booker = self._booker(clock_handler(2.0))
 
         booker._stage_arrival_lead()
 
@@ -1844,3 +1849,94 @@ class TestArrivalLead:
         assert result.success, result.error
         assert result.timing["arrivalLeadMs"] == 0
         assert result.timing["reserveSentAtMs"] >= 0
+
+
+class TestReviewFindings:
+    """Cases raised in review of #140, each one a way to lose a morning quietly."""
+
+    def test_a_naive_date_header_is_read_as_utc(self) -> None:
+        """A ``-0000`` offset parses naive, and local time would put it hours out.
+
+        The damage is not the wrong number; it is that a several-hour skew still
+        produces an ordinary-looking clamped lead, so the run fires into a shut
+        window every morning without anything in the log looking wrong.
+        """
+        from app.providers.walden_http import _parse_http_date
+
+        # Same instant, three spellings the header is allowed to use.
+        assert _parse_http_date("Mon, 01 Jan 2026 12:34:56 -0000") == _parse_http_date(
+            "Mon, 01 Jan 2026 12:34:56 +0000"
+        )
+        assert _parse_http_date("Mon, 01 Jan 2026 12:34:56 GMT") == _parse_http_date(
+            "Mon, 01 Jan 2026 12:34:56 -0000"
+        )
+
+    def test_an_unbelievable_offset_is_discarded_not_clamped(self) -> None:
+        """Clamping a nonsense reading turns it into a confident wrong answer.
+
+        Two internet-facing servers do not sit half a minute apart. Clamping
+        that to 900ms would send every Reserve of the morning early and look
+        entirely normal doing it; refusing to lead at all is recoverable.
+        """
+        booker = DirectHttpBooker(make_session(FormState.from_html(TEE_SHEET), clock_handler(30.0)))
+
+        booker._stage_arrival_lead()
+
+        assert booker._lead_ms == 0.0
+
+    def test_a_stalled_reserve_does_not_spend_the_whole_race(self) -> None:
+        """The attempt deadline cannot cancel a request already on the socket.
+
+        Without a per-attempt budget one hung POST holds the session open past
+        the window and the fallback list - which exists to survive exactly this
+        - is never walked.
+        """
+        from app.providers.walden_http import DEFAULT_TIMEOUT_S
+        from app.providers.walden_http_booker import _RESERVE_TIMEOUT_S
+
+        assert _RESERVE_TIMEOUT_S < DEFAULT_TIMEOUT_S
+
+        seen: list[float | None] = []
+        session = make_session(
+            FormState.from_html(TEE_SHEET),
+            lambda request: httpx.Response(200, text=partial_response(PLAYER_PAGE)),
+        )
+        original = session.post
+
+        def recording_post(config, *, body=None, timeout_s=None):
+            """Record the budget each request was given."""
+            seen.append(timeout_s)
+            return original(config, body=body, timeout_s=timeout_s)
+
+        booker = DirectHttpBooker(session)
+        config = AbConfig(source=RESERVE_ID, form=FORM_ID, update=FORM_ID)
+        booker._reserve_config = config
+        booker._reserve_body = session.build_body(config)
+        booker.session.post = recording_post  # type: ignore[method-assign]
+
+        booker.book(1)
+
+        assert seen[0] == _RESERVE_TIMEOUT_S
+
+    def test_a_timed_out_reserve_is_terminal_not_a_fallback(self) -> None:
+        """The request may have reached the club, and a second hold is worse.
+
+        Walking to the next tee time here could leave the member holding two
+        slots on a course that allows one round a day - trading a lost morning
+        for a booking to unpick.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Mock transport handler standing in for a request that never answers."""
+            raise httpx.ReadTimeout("timed out")
+
+        booker = stage_fallbacks(booker_over(handler), SLOT_B_TIME, SLOT_C_TIME)
+
+        result = booker.book(1)
+
+        assert not result.success
+        assert not result.blocked
+        # Past the Reserve POST, so the caller must not retry it in the browser.
+        assert result.phase == PHASE_RESERVE_SENT
+        assert result.phase not in PRE_SUBMIT_PHASES
+        assert result.attempted_times == [RESERVE_SLOT_TIME]

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -5,6 +5,7 @@ These tests verify the DOM parsing and time extraction logic works correctly
 against the actual Walden Golf website structure.
 """
 
+import logging
 import os
 from datetime import date, time, timedelta
 from pathlib import Path
@@ -3985,3 +3986,224 @@ class TestFallbackTeeTimeReporting:
 
         assert result.success is True
         assert result.booked_time == time(8, 42)
+
+
+class TestChainSummaryLogging:
+    """The one line a 6:30 post-mortem starts from.
+
+    A morning is debugged from Cloud Logging, hours later, with no way to
+    re-run it. If a number that decided the outcome is not in this line it is
+    not anywhere, and a format error here would take the line out entirely.
+    """
+
+    SLOT = {
+        "timeStr": "8:42",
+        "hours": 8,
+        "minutes": 42,
+        "index": 5,
+        "diff": 0,
+        "available": 4,
+        "isExact": True,
+        "reserveId": "form:teeTimeCourses:0:teeTimeSlots:5:slotTee:0:reserve_button",
+    }
+
+    def _summary(
+        self,
+        provider: WaldenGolfProvider,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        result: object,
+    ) -> str:
+        """Run the direct path with a canned result and return the summary line."""
+        from unittest.mock import MagicMock as _MagicMock
+
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        monkeypatch.setattr(
+            "app.providers.walden_provider.PrimeFacesSession.from_selenium",
+            _MagicMock(return_value=_MagicMock()),
+        )
+        booker = _MagicMock()
+        booker.book.return_value = result
+        monkeypatch.setattr(
+            "app.providers.walden_provider.DirectHttpBooker", _MagicMock(return_value=booker)
+        )
+
+        with caplog.at_level(logging.INFO, logger="app.providers.walden_provider"):
+            provider._try_direct_http_booking(MagicMock(), self.SLOT, 4, 1770000000000)
+
+        lines = [r.getMessage() for r in caplog.records if "Chain finished" in r.getMessage()]
+        assert len(lines) == 1, lines
+        return lines[0]
+
+    def test_a_won_race_reports_lead_send_and_slot(
+        self,
+        provider: WaldenGolfProvider,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Everything needed to say why we won, without re-reading the run."""
+        from app.providers.walden_http_booker import DirectBookingResult
+
+        line = self._summary(
+            provider,
+            monkeypatch,
+            caplog,
+            DirectBookingResult(
+                success=True,
+                phase="complete",
+                booked_slot_time=time(8, 42),
+                attempted_times=[time(8, 42)],
+                timing={
+                    "clickDriftMs": 1,
+                    "arrivalLeadMs": 470,
+                    "reserveSentAtMs": -468,
+                    "reserveAttempts": 1,
+                    "totalMs": 1500,
+                },
+            ),
+        )
+
+        assert "lead=470ms" in line
+        # Negative: the request left before our own 06:30:00, which is the point.
+        assert "sent=-468ms vs window" in line
+        assert "attempts=1" in line
+        assert "booked=08:42 AM" in line
+
+    def test_a_fallback_win_names_every_tee_time_tried(
+        self,
+        provider: WaldenGolfProvider,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """How hard the sheet was fought is the finding, not a detail."""
+        from app.providers.walden_http_booker import DirectBookingResult
+
+        line = self._summary(
+            provider,
+            monkeypatch,
+            caplog,
+            DirectBookingResult(
+                success=True,
+                phase="complete",
+                booked_slot_time=time(8, 58),
+                attempted_times=[time(8, 42), time(8, 50), time(8, 58)],
+                timing={"reserveAttempts": 3, "arrivalLeadMs": 470, "reserveSentAtMs": -468},
+            ),
+        )
+
+        assert "attempts=3" in line
+        assert "tried=[08:42 AM, 08:50 AM, 08:58 AM]" in line
+        assert "booked=08:58 AM" in line
+
+    def test_an_early_send_is_visible_as_re_fires(
+        self,
+        provider: WaldenGolfProvider,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Overshooting the lead has to be readable, or it gets tuned blind."""
+        from app.providers.walden_http_booker import DirectBookingResult
+
+        line = self._summary(
+            provider,
+            monkeypatch,
+            caplog,
+            DirectBookingResult(
+                success=True,
+                phase="complete",
+                booked_slot_time=time(8, 42),
+                attempted_times=[time(8, 42), time(8, 42)],
+                timing={"reserveAttempts": 2, "prematureRetries": 1, "arrivalLeadMs": 880},
+            ),
+        )
+
+        assert "(+1 early re-fires)" in line
+        assert "lead=880ms" in line
+
+    def test_a_lost_race_reports_nothing_booked(
+        self,
+        provider: WaldenGolfProvider,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A blocked run still has to say what it tried."""
+        from app.providers.walden_http_booker import DirectBookingResult
+
+        line = self._summary(
+            provider,
+            monkeypatch,
+            caplog,
+            DirectBookingResult(
+                blocked=True,
+                phase="reserve_sent",
+                error="Slot blocked by another user (blocked by another user)",
+                attempted_times=[time(8, 42), time(8, 50)],
+                timing={"reserveAttempts": 2, "arrivalLeadMs": 470, "reserveSentAtMs": -468},
+            ),
+        )
+
+        assert "blocked=True" in line
+        assert "booked=nothing" in line
+        assert "tried=[08:42 AM, 08:50 AM]" in line
+
+    def test_the_refresh_figures_appear_only_when_it_ran(
+        self,
+        provider: WaldenGolfProvider,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """It is off by default; its absence must not clutter every line."""
+        from app.providers.walden_http_booker import DirectBookingResult
+
+        without = self._summary(
+            provider,
+            monkeypatch,
+            caplog,
+            DirectBookingResult(success=True, phase="complete", timing={"reserveAttempts": 1}),
+        )
+        assert "viewRefresh" not in without
+
+        caplog.clear()
+        with_refresh = self._summary(
+            provider,
+            monkeypatch,
+            caplog,
+            DirectBookingResult(
+                success=True,
+                phase="complete",
+                timing={
+                    "reserveAttempts": 1,
+                    "viewRefreshMs": 729,
+                    "viewRefreshAttempts": 1,
+                    "viewRefreshFailed": "still-counting-down",
+                    "viewRefreshCountdownS": 65,
+                },
+            ),
+        )
+        assert "viewRefresh=729ms/1x still-counting-down countdown=65s" in with_refresh
+
+    def test_an_untimed_booking_says_so_rather_than_printing_a_drift(
+        self,
+        provider: WaldenGolfProvider,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Ad-hoc bookings have no window; a number there would be a lie."""
+        from app.providers.walden_http_booker import DirectBookingResult
+
+        line = self._summary(
+            provider,
+            monkeypatch,
+            caplog,
+            DirectBookingResult(
+                success=True,
+                phase="complete",
+                booked_slot_time=time(17, 0),
+                attempted_times=[time(17, 0)],
+                timing={"reserveAttempts": 1},
+            ),
+        )
+
+        assert "untimed (no window to lead)" in line
+        assert "sent=" not in line
+        assert "booked=05:00 PM" in line

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -1721,15 +1721,17 @@ class TestFindTargetSlotJS:
     def test_find_exact_match(self, provider: WaldenGolfProvider) -> None:
         """Test that JS finder returns exact match info."""
         mock_driver = MagicMock()
-        mock_driver.execute_script.return_value = {
-            "timeStr": "8:42",
-            "hours": 8,
-            "minutes": 42,
-            "index": 5,
-            "diff": 0,
-            "available": 4,
-            "isExact": True,
-        }
+        mock_driver.execute_script.return_value = [
+            {
+                "timeStr": "8:42",
+                "hours": 8,
+                "minutes": 42,
+                "index": 5,
+                "diff": 0,
+                "available": 4,
+                "isExact": True,
+            }
+        ]
 
         result = provider._find_target_slot_js(mock_driver, time(8, 42), 4, 32, 8)
 
@@ -1742,15 +1744,17 @@ class TestFindTargetSlotJS:
     def test_find_fallback_when_exact_unavailable(self, provider: WaldenGolfProvider) -> None:
         """Test that JS finder returns fallback slot."""
         mock_driver = MagicMock()
-        mock_driver.execute_script.return_value = {
-            "timeStr": "8:50",
-            "hours": 8,
-            "minutes": 50,
-            "index": 7,
-            "diff": 8,
-            "available": 4,
-            "isExact": False,
-        }
+        mock_driver.execute_script.return_value = [
+            {
+                "timeStr": "8:50",
+                "hours": 8,
+                "minutes": 50,
+                "index": 7,
+                "diff": 8,
+                "available": 4,
+                "isExact": False,
+            }
+        ]
 
         result = provider._find_target_slot_js(mock_driver, time(8, 42), 4, 32, 8)
 
@@ -1766,6 +1770,39 @@ class TestFindTargetSlotJS:
         result = provider._find_target_slot_js(mock_driver, time(8, 42), 4, 32, 8)
 
         assert result is None
+
+    def test_takes_the_head_of_the_ranking(self, provider: WaldenGolfProvider) -> None:
+        """The single-slot finder returns the best of a ranked list, not any of it."""
+        mock_driver = MagicMock()
+        mock_driver.execute_script.return_value = [
+            {"hours": 8, "minutes": 42, "index": 5, "diff": 0, "available": 4, "isExact": True},
+            {"hours": 8, "minutes": 50, "index": 6, "diff": 8, "available": 4, "isExact": False},
+            {"hours": 8, "minutes": 34, "index": 4, "diff": 8, "available": 4, "isExact": False},
+        ]
+
+        result = provider._find_target_slot_js(mock_driver, time(8, 42), 4, 32, 8)
+
+        assert result is not None
+        assert (result["hours"], result["minutes"]) == (8, 42)
+
+    def test_ranking_exposes_every_candidate(self, provider: WaldenGolfProvider) -> None:
+        """The fallback list the direct chain walks is the whole ranking."""
+        mock_driver = MagicMock()
+        mock_driver.execute_script.return_value = [
+            {"hours": 8, "minutes": 42, "index": 5, "diff": 0, "available": 4, "isExact": True},
+            {"hours": 8, "minutes": 50, "index": 6, "diff": 8, "available": 4, "isExact": False},
+        ]
+
+        ranked = provider._rank_candidate_slots_js(mock_driver, time(8, 42), 4, 32, 8)
+
+        assert [(c["hours"], c["minutes"]) for c in ranked] == [(8, 42), (8, 50)]
+
+    def test_ranking_is_empty_when_no_slots(self, provider: WaldenGolfProvider) -> None:
+        """A driver that returns nothing yields no candidates, not a None to unpack."""
+        mock_driver = MagicMock()
+        mock_driver.execute_script.return_value = None
+
+        assert provider._rank_candidate_slots_js(mock_driver, time(8, 42), 4, 32, 8) == []
 
     def test_passes_exclude_times_correctly(self, provider: WaldenGolfProvider) -> None:
         """Test that exclude times are passed as the correct argument."""
@@ -2794,6 +2831,9 @@ class TestDirectHttpBookingWiring:
         monkeypatch.setattr(
             provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
         )
+        monkeypatch.setattr(
+            provider, "_rank_candidate_slots_js", MagicMock(return_value=[dict(self.SLOT)])
+        )
         timed_chain = MagicMock(
             return_value={
                 "success": True,
@@ -2843,6 +2883,9 @@ class TestDirectHttpBookingWiring:
             provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
         )
         monkeypatch.setattr(
+            provider, "_rank_candidate_slots_js", MagicMock(return_value=[dict(self.SLOT)])
+        )
+        monkeypatch.setattr(
             provider,
             "_try_direct_http_booking",
             MagicMock(
@@ -2885,6 +2928,9 @@ class TestDirectHttpBookingWiring:
             provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
         )
         monkeypatch.setattr(
+            provider, "_rank_candidate_slots_js", MagicMock(return_value=[dict(self.SLOT)])
+        )
+        monkeypatch.setattr(
             provider,
             "_try_direct_http_booking",
             MagicMock(
@@ -2921,6 +2967,9 @@ class TestDirectHttpBookingWiring:
         monkeypatch.setattr(settings, "walden_direct_http_booking", True)
         monkeypatch.setattr(
             provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
+        )
+        monkeypatch.setattr(
+            provider, "_rank_candidate_slots_js", MagicMock(return_value=[dict(self.SLOT)])
         )
         monkeypatch.setattr(
             provider,
@@ -2990,6 +3039,9 @@ class TestUnconfirmedBookingResolution:
         monkeypatch.setattr(settings, "walden_direct_http_booking", True)
         monkeypatch.setattr(
             provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
+        )
+        monkeypatch.setattr(
+            provider, "_rank_candidate_slots_js", MagicMock(return_value=[dict(self.SLOT)])
         )
         monkeypatch.setattr(
             provider, "_try_direct_http_booking", MagicMock(return_value=chain_result)
@@ -3227,6 +3279,9 @@ class TestBlockedSlotResolution:
         monkeypatch.setattr(settings, "walden_direct_http_booking", True)
         monkeypatch.setattr(
             provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
+        )
+        monkeypatch.setattr(
+            provider, "_rank_candidate_slots_js", MagicMock(return_value=[dict(self.SLOT)])
         )
         monkeypatch.setattr(
             provider, "_try_direct_http_booking", MagicMock(return_value=chain_result)
@@ -3649,6 +3704,9 @@ class TestImmediateBookingFastPath:
         monkeypatch.setattr(
             provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
         )
+        monkeypatch.setattr(
+            provider, "_rank_candidate_slots_js", MagicMock(return_value=[dict(self.SLOT)])
+        )
         session = MagicMock()
         monkeypatch.setattr(
             "app.providers.walden_provider.PrimeFacesSession.from_selenium",
@@ -3690,6 +3748,9 @@ class TestImmediateBookingFastPath:
         monkeypatch.setattr(
             provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
         )
+        monkeypatch.setattr(
+            provider, "_rank_candidate_slots_js", MagicMock(return_value=[dict(self.SLOT)])
+        )
         fast_chain = MagicMock(
             return_value={
                 "success": True,
@@ -3726,6 +3787,9 @@ class TestImmediateBookingFastPath:
 
         monkeypatch.setattr(
             provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
+        )
+        monkeypatch.setattr(
+            provider, "_rank_candidate_slots_js", MagicMock(return_value=[dict(self.SLOT)])
         )
         monkeypatch.setattr(
             "app.providers.walden_provider.PrimeFacesSession.from_selenium",
@@ -3770,6 +3834,9 @@ class TestImmediateBookingFastPath:
             provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
         )
         monkeypatch.setattr(
+            provider, "_rank_candidate_slots_js", MagicMock(return_value=[dict(self.SLOT)])
+        )
+        monkeypatch.setattr(
             "app.providers.walden_provider.PrimeFacesSession.from_selenium",
             MagicMock(return_value=MagicMock()),
         )
@@ -3792,3 +3859,129 @@ class TestImmediateBookingFastPath:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestFallbackTeeTimeReporting:
+    """What the member is told, when the club gave us a different tee time.
+
+    The slot is chosen by row index before the window opens; the chain may end
+    up holding a different one, because a refused Reserve walks down the ranked
+    list. Everything after that has to name the slot actually held - the
+    reservations check that decides whether the booking is real, and the time
+    in the member's confirmation.
+    """
+
+    SLOT = {
+        "timeStr": "8:42",
+        "hours": 8,
+        "minutes": 42,
+        "index": 5,
+        "diff": 0,
+        "available": 4,
+        "isExact": True,
+        "reserveId": "form:teeTimeCourses:0:teeTimeSlots:5:slotTee:0:reserve_button",
+    }
+
+    def _run(
+        self,
+        provider: WaldenGolfProvider,
+        monkeypatch: pytest.MonkeyPatch,
+        chain_result: dict,
+    ):
+        """Drive the timed booking with a canned direct-HTTP chain result."""
+        monkeypatch.setattr(settings, "walden_direct_http_booking", True)
+        driver = MagicMock()
+        driver.current_url = "https://www.waldengolf.com/group/pages/book-a-tee-time"
+        driver.page_source = "<html><body>Tee sheet</body></html>"
+        driver.find_element.side_effect = Exception("no body text")
+
+        monkeypatch.setattr(
+            provider, "_find_target_slot_js", MagicMock(return_value=dict(self.SLOT))
+        )
+        monkeypatch.setattr(
+            provider, "_rank_candidate_slots_js", MagicMock(return_value=[dict(self.SLOT)])
+        )
+        monkeypatch.setattr(
+            provider, "_try_direct_http_booking", MagicMock(return_value=chain_result)
+        )
+        monkeypatch.setattr(provider, "_stage_timed_booking_chain_js", MagicMock())
+
+        return provider._find_and_book_time_slot_sync(
+            driver,
+            target_time=time(8, 42),
+            num_players=4,
+            fallback_window_minutes=32,
+            skip_scroll=True,
+            use_fast_js=True,
+            execute_at_timestamp_ms=1770000000000,
+        )
+
+    def _booked(self, **extra: object) -> dict:
+        """A completed direct-HTTP chain result."""
+        return {
+            "success": True,
+            "blocked": False,
+            "phase": "complete",
+            "error": None,
+            "timing": {"totalMs": 250},
+            "finalMarkup": (
+                "<div><h2>Booking confirmed</h2>"
+                "<p>Confirmation #12345 - your tee time is booked.</p></div>"
+            ),
+            **extra,
+        }
+
+    def test_a_fallback_slot_is_reported_as_the_time_booked(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """08:42 was taken and 08:50 was held; the member has 08:50."""
+        result = self._run(
+            provider,
+            monkeypatch,
+            self._booked(
+                bookedSlotTime=time(8, 50),
+                attemptedTimes=[time(8, 42), time(8, 50)],
+            ),
+        )
+
+        assert result.success is True
+        assert result.booked_time == time(8, 50)
+
+    def test_a_fallback_slot_explains_itself(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Getting a different time than asked for is not silent."""
+        result = self._run(
+            provider,
+            monkeypatch,
+            self._booked(
+                bookedSlotTime=time(8, 50),
+                attemptedTimes=[time(8, 42), time(8, 50)],
+            ),
+        )
+
+        assert result.fallback_reason is not None
+        assert "08:50" in result.fallback_reason
+
+    def test_winning_the_requested_time_carries_no_fallback_reason(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The ordinary case must not grow an apology."""
+        result = self._run(
+            provider,
+            monkeypatch,
+            self._booked(bookedSlotTime=time(8, 42), attemptedTimes=[time(8, 42)]),
+        )
+
+        assert result.success is True
+        assert result.booked_time == time(8, 42)
+        assert result.fallback_reason is None
+
+    def test_a_chain_that_reports_no_slot_time_leaves_the_pick_alone(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The JS chain says nothing about tee times; its result must still work."""
+        result = self._run(provider, monkeypatch, self._booked())
+
+        assert result.success is True
+        assert result.booked_time == time(8, 42)


### PR DESCRIPTION
## The assumption that came out wrong

[#139](https://github.com/alexenos/teetime/pull/139) held that the club refuses a Reserve staged before the window because the view it was built against is stale. On 2026-08-07 the refresh ran **exactly as designed** — fresh sheet at `06:30:00.5`, the club's countdown gone, **86 of 87 rows offering a live Reserve** — and the club refused anyway.

It also returned the *same* ViewState and the *same* component id the staged request already carried:

```
11:28:42.363  Reserve staged  ...teeTimeSlots:6:slotTee:0:reserve_button  viewState=20e975fa
11:30:00.730  Reserve fired   ...teeTimeSlots:6:slotTee:0:reserve_button  viewState=20e975fa
```

So the refresh cost **730ms of the race and changed no byte of the request**. And Aug 5 fired that same staged request at ~+0ms with no refresh at all and got the identical refusal. View age was never the mechanism.

## What the mechanism is

**A hold is not a booking.** Reserve places a lock, and the tee sheet goes on rendering that row `Available` until the holder walks through player count → TBD guests → Book Now, minutes later. A response showing everything free *and* "This slot is blocked by another user" is not a contradiction — it is contention.

Dax's 06:43 photograph of the sheet settles it: 07:53, 08:00, 08:08, 08:15, 08:23, 08:30 all gone to named members, 08:00 to Speice, Ron. The holds placed in that first second became bookings by 06:43.

The bot was losing a real race by a few hundred milliseconds, and then quitting after one guess.

## Timed to arrive, not to leave

`execute_at_timestamp_ms` was `local_clock + delay`, and `walden_http.py` made "never earlier" an explicit rule. Two things sit between that and the club acting, and both run against us: the club's clock reaches 06:30:00 before ours does, and the request still has to fly there. Sending at our own `06:30:00.000` put the Reserve on the club's desk around half a second into a window members had been clicking into since it opened.

`PrimeFacesSession.measure_clock_skew()` reads both during staging. The `Date` header is whole seconds, so no single sample says anything useful — but where it **ticks** against our clock is a server second boundary observed directly. 16 probes at 80ms span more than a second, so at least one transition is guaranteed, and the median locates it to ~40ms.

Offset plus outbound flight becomes the lead, clamped at 900ms. **An unmeasurable clock sends unled** — being late is recoverable; guessing early is what is not.

## One Reserve is one guess

`_reserve_with_fallbacks` walks a ranked fallback list until the club accepts one. It needs no extra round trip: a refusal comes back carrying the whole re-rendered sheet, **every row's `PrimeFaces.ab` handler included**, so the next candidate costs a parse rather than a request. Verified against this morning's saved artifact.

The ranking is the fallback logic that was already here — `_find_target_slot_js` becomes a wrapper over `_rank_candidate_slots_js`, which returns the whole ranking instead of only the winner. Same window, same interval alignment, same tie-break, same batch exclusions, so a fallback still cannot take a slot a later booking in the batch needs.

## The two refusals are told apart first

`_classify_reserve_response` checks the countdown **before** the blocked popup. A sheet the club has not opened cannot be evidence about who is holding what inside it, so that case retries the same tee time instead of spending the list. This is the exact response the club sent on Aug 6 — countdown and block together — and it is what makes an overshooting lead cheap: one 50ms re-ask, not a walk to the end of the fallbacks and home with nothing.

## Reporting the slot actually held

The chain now returns which tee time it holds, and the provider re-points `booked_time`, `is_exact` and the reservations check at it. Without that, a fallback booking would be verified against the slot we asked for and confirmed to the member as the wrong time.

## Flags

- `walden_refresh_view_at_window` → **false**, in config and terraform, with the reasoning recorded in both. Kept behind the flag rather than deleted: it is the way back if a morning ever does show a real stale-view refusal.
- `walden_measure_clock_skew` → **true**, new, wired into `main.tf` and `variables.tf`.

## Tests

37 new; 821 pass, ruff and mypy clean.

The fallback walk (a clean win spends nothing, blocked falls through, a candidate the sheet no longer offers is skipped, exhaustion, the attempt cap), premature-vs-blocked including the Aug 6 both-at-once response, clock skew (offset recovered in both directions, frozen `Date`, missing `Date`, the clamp, probe failure), the lead actually sending before target, and the provider reporting the fallback time.

## What tomorrow tells us

`arrivalLeadMs`, `reserveAttempts` and a negative `reserveSentAtMs` should all appear in the logs. If attempt 2 lands instantly, contention is confirmed and speed is the whole game. If all six answer "blocked", the message means something systematic — and we learn that in one morning instead of three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timed bookings can measure clock differences and send requests early enough to align with the booking window.
  * Booking now tries ranked alternate tee times when the preferred slot is unavailable.
  * Booking results report the tee time successfully reserved and attempted alternatives.
* **Bug Fixes**
  * Improved handling of premature booking responses, server timing differences, and final booking refusals.
* **Configuration**
  * Clock-skew measurement is enabled by default for timed bookings.
  * View refresh at the booking window is disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->