### PR TITLE
fix: measure the clock on a page the club answers quickly

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "teetime",
+      "runtimeExecutable": "poetry",
+      "runtimeArgs": ["run", "uvicorn", "app.main:app", "--port", "8000"],
+      "port": 8000
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ Thumbs.db
 playwright-report/
 test-results/
 scripts/captures/
+
+# Claude Code per-machine settings (absolute paths, personal permission allowlist).
+# .claude/launch.json is shared; this one is not.
+.claude/settings.local.json

--- a/app/providers/walden_http.py
+++ b/app/providers/walden_http.py
@@ -118,6 +118,26 @@ _SKEW_PROBE_SPACING_S = 0.08
 # rather than allowed to drag the estimate.
 _SKEW_MAX_PROBE_RTT_S = 1.0
 
+# Where to send the clock probes. Not the tee sheet: a HEAD on that page is
+# authenticated and makes Liferay render the whole portlet, which measured
+# 1613ms, 1615ms and 1640ms on three consecutive mornings - every probe over the
+# ceiling above, so 2026-08-08 threw away all 16 and led by nothing.
+#
+# Two things go wrong with that target and a static asset on the same host fixes
+# both. The header is stamped somewhere inside a 1.5s round trip, so the midpoint
+# we ascribe it to is worth +-750ms - far coarser than the offset being measured.
+# And `one_way_ms` takes half the round trip as flight time, when nearly all of
+# that 1.5s is Liferay rendering, not the network.
+#
+# These answer in 84-131ms from the same server and clock. Tried in order; a
+# cached asset serving a frozen Date is caught by the transition check below,
+# which is the same guard that already covered the page.
+_SKEW_PROBE_PATHS = (
+    "/o/frontend-css-web/main.css",
+    "/o/frontend-theme-font-awesome-web/css/main.css",
+    "/favicon.ico",
+)
+
 
 @dataclass(frozen=True)
 class ClockSkew:
@@ -764,6 +784,44 @@ class PrimeFacesSession:
         self.warm_up_rtt_ms = rtt_ms
         return rtt_ms
 
+    def _resolve_probe_url(self) -> str:
+        """Pick the cheapest same-origin URL that reports a usable ``Date``.
+
+        Runs during staging, minutes before the window, so the cost of finding
+        one does not touch the race. Falls back to the tee sheet itself when no
+        candidate answers - a bad probe target still beats no measurement, and
+        the callers own guards report it either way.
+        """
+        origin = urllib.parse.urlsplit(self.base_url)
+        for path in _SKEW_PROBE_PATHS:
+            candidate = urllib.parse.urlunsplit((origin.scheme, origin.netloc, path, "", ""))
+            started = time_module.perf_counter()
+            try:
+                response = self._client.head(candidate)
+            except httpx.HTTPError as exc:
+                logger.debug("DIRECT_HTTP: Clock probe target %s unusable (%s)", candidate, exc)
+                continue
+            rtt_ms = (time_module.perf_counter() - started) * 1000
+            # The body is irrelevant - a redirect off the same server carries
+            # the same clock - so the only requirement is a readable Date.
+            if _parse_http_date(response.headers.get("Date")) is None:
+                continue
+            logger.info(
+                "DIRECT_HTTP: Clock probe target %s - HTTP %d in %.0fms",
+                candidate,
+                response.status_code,
+                rtt_ms,
+            )
+            return candidate
+
+        logger.warning(
+            "DIRECT_HTTP: No cheap clock probe target answered; falling back to %s, "
+            "whose round trip may exceed the %.1fs ceiling",
+            self.base_url,
+            _SKEW_MAX_PROBE_RTT_S,
+        )
+        return self.base_url
+
     def measure_clock_skew(self) -> ClockSkew | None:
         """Measure the club's clock against ours, and how long a request takes.
 
@@ -786,6 +844,7 @@ class PrimeFacesSession:
             None means "do not lead", not "lead by zero on purpose"; the caller
             distinguishes them.
         """
+        probe_url = self._resolve_probe_url()
         samples: list[tuple[float, int]] = []
         round_trips: list[float] = []
         for probe in range(_SKEW_PROBE_COUNT):
@@ -793,7 +852,7 @@ class PrimeFacesSession:
                 time_module.sleep(_SKEW_PROBE_SPACING_S)
             sent = time_module.time()
             try:
-                response = self._client.head(self.base_url)
+                response = self._client.head(probe_url)
             except httpx.HTTPError as exc:
                 # One failed probe is not worth abandoning the measurement, and
                 # is not worth a warning each: the summary below reports how
@@ -813,9 +872,12 @@ class PrimeFacesSession:
 
         if len(samples) < 2:
             logger.warning(
-                "DIRECT_HTTP: Clock skew unmeasurable - %d usable probe(s) of %d",
+                "DIRECT_HTTP: Clock skew unmeasurable - %d usable probe(s) of %d against %s "
+                "(round trips over %.1fs are dropped)",
                 len(samples),
                 _SKEW_PROBE_COUNT,
+                probe_url,
+                _SKEW_MAX_PROBE_RTT_S,
             )
             return None
 

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -165,13 +165,6 @@ _MAX_PLAUSIBLE_OFFSET_MS = 5000.0
 # race reach. Past that the morning is decided and more requests are noise.
 _RESERVE_MAX_ATTEMPTS = 6
 
-# Re-fires of the *same* tee time after the club said the window is still shut.
-# Distinct from the blocked count on purpose: arriving early is our own timing
-# error and the slot is presumably still there, so the right answer is to ask
-# again rather than to give the slot up and walk down the fallback list.
-_PREMATURE_MAX_RETRIES = 4
-_PREMATURE_PAUSE_S = 0.05
-
 # Stop *starting* attempts once the race is this far gone. An attempt already in
 # flight is allowed to finish - abandoning it would not un-send it.
 _RESERVE_DEADLINE_MS = 6000
@@ -187,16 +180,6 @@ _RESERVE_DEADLINE_MS = 6000
 # on top of a hold we cannot see would collide with the one-round-per-day rule -
 # trading a lost morning for a booking mess.
 _RESERVE_TIMEOUT_S = 2.0
-
-# What the club's answer to a Reserve amounts to. The distinction that matters
-# is between the two refusals: "blocked" is another member holding the slot, and
-# the only useful response is a different tee time; a countdown still in the
-# sheet is the club saying nobody can hold anything yet, and the only useful
-# response is to ask again for the same one. Reading the second as the first
-# walks the whole fallback list into a window that has not opened.
-_VERDICT_ACCEPTED = "accepted"
-_VERDICT_PREMATURE = "premature"
-_VERDICT_BLOCKED = "blocked"
 
 # Marks a chain result as this path's. The provider handles both this and the JS
 # chain's results through the same branches, but only this one leaves the browser
@@ -652,8 +635,6 @@ class DirectHttpBooker:
         started = time_module.perf_counter()
         slot_time = self._slot_time
         remaining = list(self._fallback_times)
-        premature_retries = 0
-        premature_exhausted = False
         last_reason: str | None = None
 
         for attempt in range(1, _RESERVE_MAX_ATTEMPTS + 1):
@@ -692,8 +673,9 @@ class DirectHttpBooker:
             # largest single cost in the retry loop, and both the verdict and
             # the next candidate's handler come out of the same tree.
             document = parse_html(response.markup)
-            verdict, reason = _classify_reserve_response(document)
-            if verdict == _VERDICT_ACCEPTED:
+            _log_countdown_observation(document, attempt)
+            reason = _find_blocked_message_in(document)
+            if reason is None:
                 result.booked_slot_time = slot_time
                 if attempt > 1:
                     logger.info(
@@ -713,33 +695,6 @@ class DirectHttpBooker:
                 )
                 break
 
-            if verdict == _VERDICT_PREMATURE:
-                if premature_retries >= _PREMATURE_MAX_RETRIES:
-                    logger.error(
-                        "DIRECT_HTTP: The club is still counting down after %d re-fires; "
-                        "the window is not opening when we think it is",
-                        premature_retries,
-                    )
-                    premature_exhausted = True
-                    break
-                premature_retries += 1
-                result.timing["prematureRetries"] = premature_retries
-                logger.warning(
-                    "DIRECT_HTTP: Reserve was early (%s); asking again for %s in %dms",
-                    reason,
-                    slot_time.strftime("%I:%M %p") if slot_time else "the same slot",
-                    int(_PREMATURE_PAUSE_S * 1000),
-                )
-                time_module.sleep(_PREMATURE_PAUSE_S)
-                # Rebuilt against the sheet just returned rather than re-sent:
-                # the row may have moved, and the ViewState may have advanced.
-                if slot_time is not None:
-                    relocated = _relocate_reserve_in(document, response.markup, slot_time)
-                    if relocated is not None:
-                        config = relocated
-                body = self.session.build_body(config)
-                continue
-
             # Blocked: the slot is held. Nothing about asking again for it will
             # change that, so the only move left is a different tee time.
             next_candidate = self._next_candidate(document, response.markup, remaining)
@@ -754,13 +709,7 @@ class DirectHttpBooker:
                 slot_time.strftime("%I:%M %p"),
             )
 
-        # A window that never opened is not a slot someone else is holding, and
-        # only the blocked branch of the caller hard-codes the member's message
-        # to say it is. Reported as an ordinary post-submit failure instead: it
-        # captures the same artifacts and checks the same reservations page, but
-        # carries `error` through to the member, so the one distinction this
-        # whole classification exists to draw survives past the log.
-        result.blocked = not premature_exhausted
+        result.blocked = True
         result.error = last_reason or "Slot blocked by another user"
         logger.warning(
             "DIRECT_HTTP: No Reserve accepted after %d attempt(s) over %dms - tried %s",
@@ -1357,31 +1306,33 @@ def _find_blocked_message(response: PartialResponse) -> str | None:
     return _find_blocked_message_in(parse_html(response.markup))
 
 
-def _classify_reserve_response(document: Node) -> tuple[str, str | None]:
-    """Decide what the club's answer to a Reserve was.
+def _log_countdown_observation(document: Node, attempt: int) -> None:
+    """Note the club's countdown, if the response carried the sheet holding it.
 
-    The two refusals look alike and mean opposite things. "This slot is blocked
-    by another user" is a member holding it, and the answer is a different tee
-    time. The same message beside a live countdown is not about that slot at
-    all - the club is saying nothing is holdable yet - and the answer is to ask
-    again for the same one.
+    Recorded and never branched on. It was briefly used to decide that a Reserve
+    had been sent early, and it cannot answer that question in either direction:
 
-    The countdown is checked first for that reason. A sheet that still carries
-    it cannot be evidence about who holds what, whatever else it says.
+    * Present does not mean the window is shut. It tracks the age of the *view*
+      being re-rendered. On 2026-08-08 the Reserve re-rendered the view built at
+      06:28:57, which carried "00:01:04" while members were already booking; the
+      re-fires that reading triggered cost 1.3s of the race.
+    * Absent does not mean the window is open. The third Reserve that morning
+      answered with 81KB of booking dialog and no tee sheet at all - no slots,
+      no Reserve buttons, and so no countdown either. The verdict flipped on
+      which fragment the server re-rendered, 50ms after the previous one.
 
-    Returns:
-        One of the ``_VERDICT_*`` constants, with the club's own wording when it
-        gave any.
+    A fresh render does settle it - 2026-08-07's refreshed sheet, built at
+    06:30:00.5, had 151 slots and no countdown - but the Reserve response is not
+    a fresh render, so this stays a log line.
     """
     countdown_s = _countdown_in(document)
     if countdown_s is not None:
-        return _VERDICT_PREMATURE, f"the club is still counting down {countdown_s}s to the window"
-
-    blocked_reason = _find_blocked_message_in(document)
-    if blocked_reason is not None:
-        return _VERDICT_BLOCKED, blocked_reason
-
-    return _VERDICT_ACCEPTED, None
+        logger.info(
+            "DIRECT_HTTP: Response to Reserve attempt %d still carries a %ds countdown; "
+            "that dates the view it re-rendered, not the state of the window",
+            attempt,
+            countdown_s,
+        )
 
 
 def _find_blocked_message_in(document: Node) -> str | None:

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -122,9 +122,14 @@ _SLOT_TIME_RE = re.compile(r"\b(\d{1,2}):(\d{2})\s*([AP])\.?M\.?", re.IGNORECASE
 
 # The club's own "Booking Starts In : 00:01:05" counter. A sheet carries it
 # while the window is shut and drops it once the window opens - but only as of
-# the moment that sheet was rendered, which is why it is read for the log and
-# never branched on. See :func:`_log_countdown_observation` for what it does and
-# does not say about a Reserve.
+# the moment that sheet was rendered, which is the whole distinction:
+#
+# * Against a *fresh* render it is authoritative, so :meth:`_refresh_view` does
+#   gate on it - a refreshed sheet still counting down means the club has not
+#   opened booking, and 2026-08-07's refreshed sheet confirmed the converse.
+# * Against a *Reserve response* it is not, because that is a re-render of an
+#   older view. There it is read for the log and never branched on. See
+#   :func:`_log_countdown_observation`.
 _COUNTDOWN_CLASS = "booking-starts-in"
 _COUNTDOWN_RE = re.compile(r"(\d{1,2}):(\d{2}):(\d{2})")
 

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -120,10 +120,11 @@ _SLOT_LABEL_MAX_DEPTH = 6
 # "08:00 AM", tolerating the spacing and punctuation variants the site has used.
 _SLOT_TIME_RE = re.compile(r"\b(\d{1,2}):(\d{2})\s*([AP])\.?M\.?", re.IGNORECASE)
 
-# The club's own "Booking Starts In : 00:01:05" counter. The sheet carries it
-# while the window is shut and drops the element once it opens, which makes its
-# presence the club stating that a Reserve right now would be premature - the
-# one authority on that question that is not our clock.
+# The club's own "Booking Starts In : 00:01:05" counter. A sheet carries it
+# while the window is shut and drops it once the window opens - but only as of
+# the moment that sheet was rendered, which is why it is read for the log and
+# never branched on. See :func:`_log_countdown_observation` for what it does and
+# does not say about a Reserve.
 _COUNTDOWN_CLASS = "booking-starts-in"
 _COUNTDOWN_RE = re.compile(r"(\d{1,2}):(\d{2}):(\d{2})")
 
@@ -370,9 +371,10 @@ class DirectHttpBooker:
         already been clicking into.
 
         A measurement that fails leaves the lead at zero - the behaviour before
-        this existed. Guessing would be worse than being late: too much lead
-        fires into a window the club has not opened, and while
-        :data:`_VERDICT_PREMATURE` recovers from that, it spends attempts on it.
+        this existed. Guessing would be worse than being late: nothing in the
+        response distinguishes a Reserve that arrived early from one that lost
+        the slot, so an over-led request spends an attempt and reports the loss
+        as a block. Being a little late is at least legible.
         """
         try:
             skew = self.session.measure_clock_skew()

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -4073,7 +4073,7 @@ class WaldenGolfProvider(ReservationProvider):
         # morning has to be readable in it without going back through the run.
         logger.info(
             "DIRECT_HTTP: Chain finished - phase=%s, success=%s, blocked=%s, "
-            "clickDrift=%sms, %s, attempts=%s%s, booked=%s, tried=[%s]%s, "
+            "clickDrift=%sms, %s, attempts=%s, booked=%s, tried=[%s]%s, "
             "totalMs=%s, error=%s",
             result.phase,
             result.success,
@@ -4089,9 +4089,6 @@ class WaldenGolfProvider(ReservationProvider):
                 else "untimed (no window to lead)"
             ),
             result.timing.get("reserveAttempts", "N/A"),
-            f" (+{result.timing['prematureRetries']} early re-fires)"
-            if result.timing.get("prematureRetries")
-            else "",
             result.booked_slot_time.strftime("%I:%M %p") if result.booked_slot_time else "nothing",
             ", ".join(t.strftime("%I:%M %p") for t in result.attempted_times),
             # Absent unless a refresh ran, since it is off by default now. The

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -1677,15 +1677,40 @@ class TestCountdownIsNotAVerdict:
         """No response makes the chain ask twice for one tee time.
 
         A countdown with no blocked popup is not a refusal at all, so the chain
-        carries on into the rest of the booking. Whatever it finds there, the
-        Reserve for this tee time was asked once.
+        carries on into the rest of the booking and completes it. The accepted
+        Reserve here answers with the player dialog *and* a stale counter beside
+        it - 2026-08-08's shape, where the re-rendered fragment still carried the
+        06:28:57 view's countdown. Asserting the booking completed is what keeps
+        the count below meaningful: a chain that died at the Reserve would
+        satisfy the count while proving nothing.
         """
-        recorder = ChainRecorder([countdown_sheet("00:00:02"), PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        accepted_with_stale_countdown = PLAYER_PAGE.replace(
+            '<div class="ui-selectonebutton" id="timeFilter">',
+            '<div class="booking-starts-in">Booking Starts In : 00:00:02</div>\n'
+            '  <div class="ui-selectonebutton" id="timeFilter">',
+        )
+        recorder = ChainRecorder([accepted_with_stale_countdown, ROWS_PAGE, BOOKED_PAGE])
         result = stage_fallbacks(make_booker(recorder), SLOT_B_TIME).book(1)
 
+        assert result.success, result.error
         assert recorder.sources.count(RESERVE_ID) == 1
         assert result.attempted_times == [RESERVE_SLOT_TIME]
         assert "prematureRetries" not in result.timing
+
+    def test_a_countdown_only_response_is_not_a_booking(self) -> None:
+        """Not classifying a countdown as a refusal is not calling it a booking.
+
+        Dropping the countdown branch means a countdown-only sheet is no longer
+        refused at the Reserve step - so the step after it has to be what stops
+        it. It is: the chain needs the player selector to go on, and a tee sheet
+        does not carry one, so the run fails in `player_count` and reports it.
+        """
+        recorder = ChainRecorder([countdown_sheet("00:01:05")])
+        result = make_booker(recorder).book(4)
+
+        assert not result.success
+        assert result.phase == "player_count"
+        assert result.error is not None and "Player count selector" in result.error
 
     def test_an_endless_countdown_still_walks_the_fallback_list(self) -> None:
         """A sheet that always counts down must not pin us to one slot.
@@ -1766,6 +1791,9 @@ class TestClockProbeTarget:
         session = make_session(FormState.from_html(TEE_SHEET), handler)
         session.measure_clock_skew()
 
+        # seen[0] pins the order: without it this passes even if resolution
+        # skipped the first candidate and started at the theme asset.
+        assert seen[0] == "/o/frontend-css-web/main.css"
         assert seen[1] == "/o/frontend-theme-font-awesome-web/css/main.css"
         assert set(seen[1:]) == {"/o/frontend-theme-font-awesome-web/css/main.css"}
 

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -1511,13 +1511,21 @@ SLOT_B_TIME = time(16, 42)
 SLOT_C_TIME = time(16, 50)
 
 
-def blocked_sheet(*slots: str) -> str:
+def blocked_sheet(*slots: str, countdown: str | None = None) -> str:
     """A refusal, carrying the whole re-rendered sheet the way the site does.
 
     This shape is why the fallback loop needs no extra round trip: the response
     that says "blocked" hands back every other row's Reserve handler with it.
+
+    ``countdown`` reproduces what the club actually returns when the Reserve
+    re-renders a view built before the window - a refusal and a counter in the
+    same body, which is the pairing that used to be misread as "too early".
     """
+    banner = (
+        f'<div class="booking-starts-in">Booking Starts In : {countdown}</div>' if countdown else ""
+    )
     return refreshed_sheet(
+        banner,
         '<div id="teeSheetValidationErrorPopup" aria-hidden="false">'
         "This slot is blocked by another user</div>",
         *slots,
@@ -1633,73 +1641,65 @@ class TestReserveFallbacks:
         assert recorder.sources == [RESERVE_ID]
 
 
-class TestPrematureVersusBlocked:
-    """The two refusals look alike and call for opposite responses.
+class TestCountdownIsNotAVerdict:
+    """The countdown is logged and never branched on.
 
-    A countdown still in the sheet is the club saying nothing is holdable yet.
-    Reading that as "someone holds this slot" walks the whole fallback list into
-    a window that has not opened and arrives at the end of it with nothing -
-    which is exactly what a measured lead makes possible when it overshoots.
+    It was briefly read as "this Reserve went out early", and it cannot answer
+    that in either direction. Present tracks the age of the view being
+    re-rendered, not the state of the window; absent can simply mean the
+    response carried no tee sheet to hold one.
     """
 
-    def test_a_countdown_retries_the_same_slot(self) -> None:
-        """Arriving early costs one re-ask, not the fallback list."""
-        recorder = ChainRecorder([countdown_sheet("00:00:02"), PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+    def test_a_countdown_beside_a_block_is_a_block(self) -> None:
+        """The response the club actually sent on 2026-08-06: both at once.
+
+        Reading the countdown as "too early" cost 1.3s of re-fires on 08-08
+        while members were already booking. The block is the part that is about
+        this slot, so it decides, and the fallback list gets walked.
+        """
+        recorder = ChainRecorder(
+            [
+                blocked_sheet(*ALL_THREE, countdown="00:01:05"),
+                PLAYER_PAGE,
+                ROWS_PAGE,
+                BOOKED_PAGE,
+            ]
+        )
         result = stage_fallbacks(make_booker(recorder), SLOT_B_TIME).book(1)
 
         assert result.success, result.error
-        # The same tee time, re-resolved against the sheet that came back.
-        assert recorder.sources == [
-            RESERVE_ID,
-            MOVED_RESERVE_ID,
-            "playerGroup",
-            "bookTeeTimeAction",
-        ]
-        assert result.booked_slot_time == RESERVE_SLOT_TIME
-        assert result.timing["prematureRetries"] == 1
+        # Moved to the fallback rather than re-asking for the blocked slot.
+        assert recorder.sources[:2] == [RESERVE_ID, SLOT_B_ID]
+        assert result.booked_slot_time == SLOT_B_TIME
+        assert "prematureRetries" not in result.timing
 
-    def test_a_countdown_beside_a_block_is_still_a_countdown(self) -> None:
-        """The response the club actually sent on 2026-08-06: both at once.
+    def test_a_countdown_never_re_fires_the_same_slot(self) -> None:
+        """No response makes the chain ask twice for one tee time.
 
-        The countdown wins. A sheet the club has not opened cannot be evidence
-        about who is holding what inside it.
+        A countdown with no blocked popup is not a refusal at all, so the chain
+        carries on into the rest of the booking. Whatever it finds there, the
+        Reserve for this tee time was asked once.
         """
-        from app.providers.walden_http_booker import (
-            _VERDICT_BLOCKED,
-            _VERDICT_PREMATURE,
-            _classify_reserve_response,
-        )
+        recorder = ChainRecorder([countdown_sheet("00:00:02"), PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        result = stage_fallbacks(make_booker(recorder), SLOT_B_TIME).book(1)
 
-        both = refreshed_sheet(
-            '<div class="booking-starts-in">Booking Starts In : 00:01:05</div>',
-            '<div id="teeSheetValidationErrorPopup" aria-hidden="false">'
-            "This slot is blocked by another user</div>",
-        )
-        verdict, reason = _classify_reserve_response(parse_html(both))
-        assert verdict == _VERDICT_PREMATURE
-        assert "counting down" in (reason or "")
+        assert recorder.sources.count(RESERVE_ID) == 1
+        assert result.attempted_times == [RESERVE_SLOT_TIME]
+        assert "prematureRetries" not in result.timing
 
-        # The same markup without the countdown is a genuine refusal.
-        verdict, _ = _classify_reserve_response(parse_html(blocked_sheet(*ALL_THREE)))
-        assert verdict == _VERDICT_BLOCKED
+    def test_an_endless_countdown_still_walks_the_fallback_list(self) -> None:
+        """A sheet that always counts down must not pin us to one slot.
 
-    def test_an_endless_countdown_gives_up_without_burning_the_list(self) -> None:
-        """If the window never opens, the fallbacks were never the problem."""
-        from app.providers.walden_http_booker import _PREMATURE_MAX_RETRIES
-
-        recorder = ChainRecorder([countdown_sheet("00:01:05")])
+        2026-08-08 stayed on 12:08 PM for three attempts on this reading, and
+        the fallback list - the thing that survives a lost race - went unused.
+        """
+        recorder = ChainRecorder([blocked_sheet(*ALL_THREE, countdown="00:01:05")])
         result = stage_fallbacks(make_booker(recorder), SLOT_B_TIME, SLOT_C_TIME).book(1)
 
         assert not result.success
-        # Not "blocked": the caller hard-codes that branch's message to "another
-        # member took the slot", which is the opposite of what happened. The
-        # countdown reason has to reach the member, not just the log.
-        assert not result.blocked
-        assert "counting down" in (result.error or "")
-        assert result.timing["prematureRetries"] == _PREMATURE_MAX_RETRIES
-        # Every request went to the requested tee time; no fallback was spent.
-        assert SLOT_B_ID not in recorder.sources
-        assert result.attempted_times == [RESERVE_SLOT_TIME] * (_PREMATURE_MAX_RETRIES + 1)
+        assert result.blocked
+        assert result.attempted_times == [RESERVE_SLOT_TIME, SLOT_B_TIME, SLOT_C_TIME]
+        assert SLOT_B_ID in recorder.sources
 
 
 # ---------------------------------------------------------------------------
@@ -1723,6 +1723,65 @@ def clock_handler(offset_s: float) -> Callable[[httpx.Request], httpx.Response]:
         )
 
     return handler
+
+
+class TestClockProbeTarget:
+    """Where the probes are sent, which is what decided 2026-08-08.
+
+    A HEAD on the tee sheet is authenticated and makes Liferay render the whole
+    portlet - 1.6s on three consecutive mornings, over the per-probe ceiling, so
+    all 16 samples were dropped and the Reserve went out with no lead at all.
+    """
+
+    def test_a_cheap_static_asset_is_preferred_over_the_tee_sheet(self) -> None:
+        """The probes must not land on the page that takes 1.6s to render."""
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request.url.path)
+            return httpx.Response(
+                200, headers={"Date": email.utils.formatdate(time_module.time(), usegmt=True)}
+            )
+
+        session = make_session(FormState.from_html(TEE_SHEET), handler)
+        session.measure_clock_skew()
+
+        assert seen, "no probe was sent"
+        assert set(seen) == {"/o/frontend-css-web/main.css"}
+        assert "/group/pages/book-a-tee-time" not in seen
+
+    def test_an_unusable_asset_falls_through_to_the_next(self) -> None:
+        """One missing asset must not put the probes back on the tee sheet."""
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request.url.path)
+            # The first candidate answers without a Date, which is unusable.
+            if request.url.path == "/o/frontend-css-web/main.css":
+                return httpx.Response(200)
+            return httpx.Response(
+                200, headers={"Date": email.utils.formatdate(time_module.time(), usegmt=True)}
+            )
+
+        session = make_session(FormState.from_html(TEE_SHEET), handler)
+        session.measure_clock_skew()
+
+        assert seen[1] == "/o/frontend-theme-font-awesome-web/css/main.css"
+        assert set(seen[1:]) == {"/o/frontend-theme-font-awesome-web/css/main.css"}
+
+    def test_no_usable_asset_falls_back_to_the_page(self) -> None:
+        """A bad probe target still beats abandoning the measurement."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.startswith(("/o/", "/favicon")):
+                return httpx.Response(404)
+            return httpx.Response(
+                200, headers={"Date": email.utils.formatdate(time_module.time(), usegmt=True)}
+            )
+
+        session = make_session(FormState.from_html(TEE_SHEET), handler)
+
+        assert session._resolve_probe_url().endswith("/group/pages/book-a-tee-time")
 
 
 class TestClockSkew:

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -4111,8 +4111,10 @@ class TestChainSummaryLogging:
             DirectBookingResult(
                 success=True,
                 phase="complete",
-                booked_slot_time=time(8, 42),
-                attempted_times=[time(8, 42), time(8, 42)],
+                # Two attempts means a block and a fallback, never the same tee
+                # time twice: the chain no longer re-fires one slot.
+                booked_slot_time=time(8, 50),
+                attempted_times=[time(8, 42), time(8, 50)],
                 timing={"reserveAttempts": 2, "arrivalLeadMs": 880},
             ),
         )

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -4095,13 +4095,13 @@ class TestChainSummaryLogging:
         assert "tried=[08:42 AM, 08:50 AM, 08:58 AM]" in line
         assert "booked=08:58 AM" in line
 
-    def test_an_early_send_is_visible_as_re_fires(
+    def test_the_measured_lead_is_visible(
         self,
         provider: WaldenGolfProvider,
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Overshooting the lead has to be readable, or it gets tuned blind."""
+        """The lead has to be readable, or it gets tuned blind."""
         from app.providers.walden_http_booker import DirectBookingResult
 
         line = self._summary(
@@ -4113,12 +4113,12 @@ class TestChainSummaryLogging:
                 phase="complete",
                 booked_slot_time=time(8, 42),
                 attempted_times=[time(8, 42), time(8, 42)],
-                timing={"reserveAttempts": 2, "prematureRetries": 1, "arrivalLeadMs": 880},
+                timing={"reserveAttempts": 2, "arrivalLeadMs": 880},
             ),
         )
 
-        assert "(+1 early re-fires)" in line
         assert "lead=880ms" in line
+        assert "attempts=2" in line
 
     def test_a_lost_race_reports_nothing_booked(
         self,


### PR DESCRIPTION
Two fixes, both from what the 2026-08-08 run actually logged.

## The lead was never applied

```
6:29:25  Clock skew unmeasurable - 0 usable probe(s) of 16
6:29:59.999  Firing Reserve 1/6 ... lead=0ms, 0ms past the window
```

#140 sends the Reserve early so it *arrives* as the window opens. That lead comes from `measure_clock_skew()`, and every one of its 16 probes was discarded.

The probes went to the tee sheet. A HEAD on that page is authenticated and makes Liferay render the whole portlet — **1613ms, 1615ms, 1640ms** on three consecutive mornings, all over the 1.0s per-probe ceiling. The run spans 6:29:00.0 → 6:29:25.5, which is 25.5s for 16 probes and says the same thing independently.

Raising the ceiling alone would have made things worse, not better:

- A `Date` stamped somewhere inside a 1.5s round trip pins the midpoint to **±750ms** — coarser than the offset being measured.
- `one_way_ms` takes half the round trip as flight time, when nearly all of that 1.5s is Liferay rendering, not the network. It would have produced a ~750ms "flight time" and a confidently wrong lead.

So probe a cheap static asset on the same host and clock. Measured from here just now:

```
Clock probe target https://www.waldengolf.com/o/frontend-css-web/main.css - HTTP 200 in 284ms
Clock skew measured - club is -20ms from us, one-way 60ms (16 probes, 3 transitions)
```

16 usable probes, 3 tick transitions, a real number — and ~3s instead of 25s. `/o/` is Liferay's own module resource path, so it is the app server answering rather than a CDN edge. Candidates are tried in order during staging and fall back to the page if none answer; a cached asset serving a frozen `Date` is caught by the existing transition check.

Worth being explicit about what this does not promise. Every remaining failure mode still ends at `lead = 0`, which is today's behaviour — but each now writes a distinct line, so the next post-mortem can tell them apart:

| Failure | Line |
|---|---|
| No candidate answers with a `Date` | `No cheap clock probe target answered; falling back to ...` |
| Cached asset, frozen clock | `the Date header never advanced across N probes (cached?)` |
| Asset answers but slowly | `Clock skew unmeasurable - N usable probe(s) of 16` |

## The countdown is not a verdict

This reading was mine, from #139, and #140 built the premature re-fire path on it. It cannot answer whether a Reserve went out early, in either direction.

**Present doesn't mean the window is shut.** It dates the *view* being re-rendered. On 08-08 no refresh ran, so the Reserve re-rendered the view built at 6:28:57 and carried `00:01:04` while members were already booking. All three attempts went to 12:08 PM and the fallback list was never walked:

```
6:30:00.758  Reserve was early (still counting down 64s); asking again for 12:08 PM
6:30:01.236  Reserve was early (still counting down 64s); asking again for 12:08 PM
6:30:03.127  Slot blocked by another user and no fallback tee time left to try
```

**Absent doesn't mean the window is open.** The third Reserve answered with 81KB of booking dialog and no tee sheet at all:

| Response | bytes | slots | Reserve buttons | `playersTable` | countdown |
|---|---|---|---|---|---|
| 08-06 Reserve | 516K | 143 | 148 | 0 | `00:01:05` |
| 08-08 attempt 3 | 81K | **0** | **0** | 233 | none |
| 08-07 refreshed sheet (fresh view @6:30:00.5) | 669K | 151 | 224 | 0 | none |

The verdict flipped from premature to blocked on which fragment the server re-rendered, 50ms after the previous one. A *fresh* render does settle the question — 08-07's refreshed sheet proves it — but the Reserve response is not a fresh render.

There is a second reason the premature reading could not have been right on 08-08. `_countdown_in` and `_find_blocked_message_in` are independent queries, and the old classifier checked the countdown first and returned immediately — so attempts 1 and 2 were never tested for a blocked popup at all. And with the lead at zero the Reserve cannot have been early in the first place:

```
arrival (club clock) = 06:30:00 + offset_ms + one_way_ms = 06:30:00 + lead_ms
```

Arriving early needs `offset + one_way < 0`; the measurement gives `-20 + 60 = +40ms`, so the request landed ~40ms *after* the window opened. The lead is the arrival error, and at zero it is a late arrival, never an early one.

So it stays a log line and never a branch. `_VERDICT_PREMATURE`, `_PREMATURE_MAX_RETRIES`, `_PREMATURE_PAUSE_S` and the re-fire path are gone; `_log_countdown_observation` records what the club said and the loop classifies on the blocked popup alone.

Two comments still taught the reading this PR disproves — the countdown constant called its presence "the club stating that a Reserve right now would be premature", and `_stage_arrival_lead` justified a zero lead by pointing at `_VERDICT_PREMATURE` recovering from over-lead, a constant this PR deletes. Both now describe what the code does.

## Tests

`TestPrematureVersusBlocked` is replaced by `TestCountdownIsNotAVerdict`, which pins the inverted contract: a countdown beside a block is a block and walks the fallback list, an endless countdown still walks it, and no response makes the chain ask twice for one tee time. `TestClockProbeTarget` covers asset preference, falling through an asset with no `Date`, and falling back to the page when none answer.

834 passed, 10 skipped; ruff and mypy clean on the pinned toolchain (ruff 0.8.6).

## Not addressed

The empty fallback list (`0 fallback(s) behind it`) is still unexplained — the pre-window sheet the finder judged from is never captured, only the post-failure DOM.

This matters more than the timing work for 08-08 specifically: with no fallbacks to walk, classifying those first two responses correctly would not have booked anything that morning. The 1.3s the re-fires burned bought nothing, but spending it correctly would not have bought anything either. Follow-up PR to capture the pre-window sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved booking handling for countdown and blocked-slot responses.
  * Prevented repeated attempts for the same slot when only countdown information is shown.
  * Ensured fallback tee times are tried and exhausted attempts are correctly marked blocked.
  * Improved clock-skew detection by checking reliable same-origin assets before falling back to the booking page.
* **Logging**
  * Booking summaries now include attempt counts, booked slots, and attempted times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->