### PR TITLE
fix: stop the slot finder from discarding the fallback list

### DIFF
--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -602,6 +602,12 @@ class WaldenGolfProvider(ReservationProvider):
         credentials are missing - operations will fail at login time.
         """
         self.wait_strategy = WaitStrategy()
+        # The tee sheet the slot finder judged from, kept from staging so a
+        # morning that ends with no fallbacks can be read against the sheet that
+        # produced them. Only the post-failure DOM was ever captured, and by then
+        # the window has opened and other members have taken slots - which is
+        # exactly the difference in question. Uploaded only if the booking fails.
+        self._pre_window_sheet: str | None = None
         if not settings.walden_member_number or not settings.walden_password:
             logger.warning(
                 "Walden Golf credentials not configured. "
@@ -1094,6 +1100,7 @@ class WaldenGolfProvider(ReservationProvider):
                     "BATCH_BOOKING: Step 6 - Pre-locating target slots via JavaScript "
                     f"for {len(sorted_requests)} request(s)"
                 )
+                self._capture_pre_window_sheet(driver)
                 for req in sorted_requests:
                     # Build a preliminary times_to_exclude using only the known
                     # target times of other requests (booked_times is empty here).
@@ -3016,6 +3023,10 @@ class WaldenGolfProvider(ReservationProvider):
                     # beat us" from "we reserved against a view the club had
                     # not opened yet" - the two this path exists to tell apart.
                     self._capture_refresh_artifact(chain_result, blocked_phase)
+                # The sheet the fallback list was built from. A blocked morning
+                # that walked no fallbacks is the case this exists for: it says
+                # whether the finder had anything to walk.
+                self._flush_pre_window_sheet(f"blocked_{blocked_phase}")
                 # Before the reservations check, not after: that check navigates
                 # to the dashboard, and a screenshot taken on the way out would
                 # show that page instead of the state that failed.
@@ -3064,6 +3075,7 @@ class WaldenGolfProvider(ReservationProvider):
                             f"direct_http_failed_{phase}", partial_markup
                         )
                     self._capture_refresh_artifact(chain_result, phase)
+                    self._flush_pre_window_sheet(f"failed_{phase}")
                     # Before the reservations check, not after: that check
                     # navigates to the dashboard, and a screenshot taken on the
                     # way out would show that page instead of the state that
@@ -3632,6 +3644,13 @@ class WaldenGolfProvider(ReservationProvider):
         var items = document.querySelectorAll('li.ui-datascroller-item');
         var candidates = [];
 
+        // Why slots were dropped, not just how many survived. "0 fallback(s)"
+        // on 2026-08-08 could not be read as "the sheet was full" or "we
+        // rejected bookable slots", and those call for opposite fixes.
+        var rejected = {
+            course: 0, unparsed: 0, window: 0, offGrid: 0, capacity: 0, excluded: 0
+        };
+
         // Build exclude set for O(1) lookup
         var excludeSet = {};
         for (var e = 0; e < excludeTimes.length; e++) {
@@ -3646,6 +3665,7 @@ class WaldenGolfProvider(ReservationProvider):
             // Northgate uses index "0", Walden uses index "1"
             var courseMatch = itemHtml.match(/teeTimeCourses:(\\d+)/);
             if (!courseMatch || courseMatch[1] !== northgateIndex) {
+                rejected.course++;
                 continue; // Skip slots without a course index or non-Northgate slots
             }
 
@@ -3659,11 +3679,11 @@ class WaldenGolfProvider(ReservationProvider):
                     timeText = timeMatch[0];
                 }
             }
-            if (!timeText) continue;
+            if (!timeText) { rejected.unparsed++; continue; }
 
             // Parse time
             var tmatch = timeText.match(/(\\d{1,2}):(\\d{2})\\s*([AaPp][Mm])/i);
-            if (!tmatch) continue;
+            if (!tmatch) { rejected.unparsed++; continue; }
             var h = parseInt(tmatch[1]);
             var m = parseInt(tmatch[2]);
             var ampm = tmatch[3].toUpperCase();
@@ -3674,10 +3694,17 @@ class WaldenGolfProvider(ReservationProvider):
             var diff = Math.abs(slotMinutes - targetMinutes);
 
             // Check fallback window
-            if (diff > fallbackMinutes) continue;
+            if (diff > fallbackMinutes) { rejected.window++; continue; }
 
-            // Check interval alignment
-            if (diff % intervalMinutes !== 0) continue;
+            // Grid alignment. This used to drop the slot, which assumes the
+            // requested time sits on the sheet's own grid - ask for 8:00 when
+            // the day runs 7:56/8:04 and every slot is a non-multiple of 8 away,
+            // so the whole list empties and the morning has no fallback at all.
+            // Kept as a ranking key instead: aligned slots sort first, so the
+            // slot actually reserved is the same one as before, and misaligned
+            // ones line up behind it rather than vanishing.
+            var aligned = (diff % intervalMinutes === 0);
+            if (!aligned) rejected.offGrid++;
 
             // Check availability
             var emptyDivs = item.querySelectorAll('div.Empty');
@@ -3693,7 +3720,7 @@ class WaldenGolfProvider(ReservationProvider):
                 isAvailable = true;
             }
 
-            if (!isAvailable) continue;
+            if (!isAvailable) { rejected.capacity++; continue; }
 
             // Component id of the slot's Reserve link. The direct-HTTP path
             // replays that component's PrimeFaces request, so it needs the id
@@ -3709,50 +3736,77 @@ class WaldenGolfProvider(ReservationProvider):
                 diff: diff,
                 available: availableCount,
                 isExact: (diff === 0),
+                aligned: aligned,
                 reserveId: reserveEl ? reserveEl.id : null
             };
 
             // For fallback slots, skip excluded times. Never for the exact time
             // asked for: that one is the booking, not a stand-in chosen for it.
-            if (diff !== 0 && excludeSet[slotMinutes]) continue;
+            if (diff !== 0 && excludeSet[slotMinutes]) { rejected.excluded++; continue; }
 
             candidates.push(slotInfo);
         }
 
-        // Nearest to the requested time first, and on a tie the earlier tee
-        // time - the same order the single-slot search reached by scanning rows
-        // in time order and keeping the first strictly-closer one.
+        // Grid-aligned first, so the slot reserved is the one this finder would
+        // have picked when alignment was a hard filter. Then nearest to the
+        // requested time, and on a tie the earlier tee time - the order the
+        // single-slot search reached by scanning rows in time order and keeping
+        // the first strictly-closer one.
         candidates.sort(function (a, b) {
+            if (a.aligned !== b.aligned) return a.aligned ? -1 : 1;
             if (a.diff !== b.diff) return a.diff - b.diff;
             return (a.hours * 60 + a.minutes) - (b.hours * 60 + b.minutes);
         });
 
-        return candidates;
+        return {candidates: candidates, rejected: rejected, scanned: items.length};
         """
 
-        candidates: list[dict[str, Any]] = (
-            driver.execute_script(
-                js_code,
-                target_time.hour,
-                target_time.minute,
-                num_players,
-                fallback_window_minutes,
-                tee_time_interval_minutes,
-                exclude_list,
-                self.NORTHGATE_COURSE_INDEX,
-                self.MAX_PLAYERS,
-            )
-            or []
+        found = driver.execute_script(
+            js_code,
+            target_time.hour,
+            target_time.minute,
+            num_players,
+            fallback_window_minutes,
+            tee_time_interval_minutes,
+            exclude_list,
+            self.NORTHGATE_COURSE_INDEX,
+            self.MAX_PLAYERS,
+        )
+        # A dict since the tally was added. Tolerating the old bare list keeps a
+        # stubbed driver in a test - or a browser that somehow ran an older
+        # script - from failing here instead of where it would say why.
+        if isinstance(found, dict):
+            candidates: list[dict[str, Any]] = found.get("candidates") or []
+            rejected: dict[str, Any] = found.get("rejected") or {}
+            scanned: Any = found.get("scanned", "?")
+        else:
+            candidates = found or []
+            rejected, scanned = {}, "?"
+
+        # Logged whether or not anything was found, and before the verdict: when
+        # a morning comes back with no fallbacks, this line is what separates a
+        # full sheet from a finder that threw bookable slots away.
+        logger.info(
+            "BOOKING_DEBUG: Slot scan of %s row(s) for %s, %d player(s), +/-%d min - "
+            "%d candidate(s); dropped %s",
+            scanned,
+            target_time.strftime("%I:%M %p"),
+            num_players,
+            fallback_window_minutes,
+            len(candidates),
+            ", ".join(f"{name}={count}" for name, count in rejected.items() if count) or "nothing",
         )
 
         if candidates:
             best = candidates[0]
+            off_grid = sum(1 for c in candidates if not c.get("aligned", True))
             logger.info(
                 f"BOOKING_DEBUG: JS slot finder found slot at "
                 f"{best['hours']:02d}:{best['minutes']:02d} "
                 f"(index={best['index']}, exact={best['isExact']}, "
                 f"available={best['available']}), "
                 f"{len(candidates) - 1} fallback(s) behind it"
+                f"{f' ({off_grid} off-grid)' if off_grid else ''}"
             )
         else:
             logger.warning(
@@ -5261,6 +5315,41 @@ class WaldenGolfProvider(ReservationProvider):
             )
             return
         self._capture_response_artifact(f"direct_http_refreshed_sheet_{phase}", refresh_markup)
+
+    def _capture_pre_window_sheet(self, driver: webdriver.Chrome) -> None:
+        """Keep the tee sheet the slot finder is about to judge.
+
+        Read once per staging run, minutes before the window, so the cost sits
+        nowhere near the race - and deliberately not on the 06:30 re-scan path,
+        where reading a ~600KB DOM would be spent against the clock.
+
+        Held rather than uploaded: most mornings end in a booking and the sheet
+        is worth nothing. :meth:`_flush_pre_window_sheet` sends it if one does
+        not.
+        """
+        try:
+            self._pre_window_sheet = driver.page_source
+            logger.info(
+                "BOOKING_DEBUG: Held the pre-window tee sheet (%d bytes) in case "
+                "this morning needs explaining",
+                len(self._pre_window_sheet or ""),
+            )
+        except Exception as exc:  # noqa: BLE001 - diagnostics must not lose a booking
+            self._pre_window_sheet = None
+            logger.warning("BOOKING_DEBUG: Could not read the pre-window tee sheet (%s)", exc)
+
+    def _flush_pre_window_sheet(self, context: str) -> None:
+        """Upload the held sheet, if a failed morning made it worth having."""
+        sheet = self._pre_window_sheet
+        if not sheet:
+            logger.info(
+                "BOOKING_DEBUG: No pre-window tee sheet held for %s - staging never "
+                "reached slot pre-location",
+                context,
+            )
+            return
+        self._pre_window_sheet = None
+        self._capture_response_artifact(f"pre_window_sheet_{context}", sheet)
 
     def _capture_response_artifact(self, context: str, markup: str) -> None:
         """Record a direct-HTTP response body for diagnosis.

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -559,6 +559,144 @@ _SLOT_RESCAN_FINAL_INTERVAL_S = 0.1
 _SLOT_RESCAN_GRACE_MS = _CHAIN_ENABLED_MAX_WAIT_MS
 
 
+# The slot scan, as a module constant so a test can run the exact string the
+# browser is handed. Its ranking is load-bearing - grid-aligned first, then
+# nearest the requested time - and a test that re-sorts its own fixture proves
+# nothing about the comparator below.
+_SLOT_FINDER_JS = """
+var targetHour = arguments[0];
+var targetMinute = arguments[1];
+var minPlayers = arguments[2];
+var fallbackMinutes = arguments[3];
+var intervalMinutes = arguments[4];
+var excludeTimes = arguments[5];
+var northgateIndex = arguments[6];
+var maxPlayers = arguments[7];
+
+var targetMinutes = targetHour * 60 + targetMinute;
+var items = document.querySelectorAll('li.ui-datascroller-item');
+var candidates = [];
+
+// Why slots were dropped, not just how many survived. "0 fallback(s)"
+// on 2026-08-08 could not be read as "the sheet was full" or "we
+// rejected bookable slots", and those call for opposite fixes.
+var rejected = {course: 0, unparsed: 0, window: 0, capacity: 0, excluded: 0};
+
+// Build exclude set for O(1) lookup
+var excludeSet = {};
+for (var e = 0; e < excludeTimes.length; e++) {
+    excludeSet[excludeTimes[e].h * 60 + excludeTimes[e].m] = true;
+}
+
+for (var i = 0; i < items.length; i++) {
+    var item = items[i];
+    var itemHtml = item.innerHTML;
+
+    // Check course via element ID pattern: teeTimeCourses:X
+    // Northgate uses index "0", Walden uses index "1"
+    var courseMatch = itemHtml.match(/teeTimeCourses:(\\d+)/);
+    if (!courseMatch || courseMatch[1] !== northgateIndex) {
+        rejected.course++;
+        continue; // Skip slots without a course index or non-Northgate slots
+    }
+
+    // Extract time from label or text content
+    var label = item.querySelector('label');
+    var timeText = label ? label.textContent.trim() : '';
+    if (!timeText) {
+        var allText = item.textContent;
+        var timeMatch = allText.match(/(\\d{1,2}):(\\d{2})\\s*([AaPp][Mm])/);
+        if (timeMatch) {
+            timeText = timeMatch[0];
+        }
+    }
+    if (!timeText) { rejected.unparsed++; continue; }
+
+    // Parse time
+    var tmatch = timeText.match(/(\\d{1,2}):(\\d{2})\\s*([AaPp][Mm])/i);
+    if (!tmatch) { rejected.unparsed++; continue; }
+    var h = parseInt(tmatch[1]);
+    var m = parseInt(tmatch[2]);
+    var ampm = tmatch[3].toUpperCase();
+    if (ampm === 'PM' && h !== 12) h += 12;
+    if (ampm === 'AM' && h === 12) h = 0;
+
+    var slotMinutes = h * 60 + m;
+    var diff = Math.abs(slotMinutes - targetMinutes);
+
+    // Check fallback window
+    if (diff > fallbackMinutes) { rejected.window++; continue; }
+
+    // Grid alignment. This used to drop the slot, which assumes the
+    // requested time sits on the sheet's own grid - ask for 8:00 when
+    // the day runs 7:56/8:04 and every slot is a non-multiple of 8 away,
+    // so the whole list empties and the morning has no fallback at all.
+    // Kept as a ranking key instead: aligned slots sort first, so the
+    // slot actually reserved is the same one as before, and misaligned
+    // ones line up behind it rather than vanishing.
+    // Not counted as a rejection: the slot is still a candidate, and a
+    // tally that called a fallback we went on to reserve "dropped" would
+    // be the same kind of misleading line this whole scan exists to fix.
+    // Retained off-grid slots are counted off the candidate list; ones
+    // that do get dropped are counted by whichever check drops them.
+    var aligned = (diff % intervalMinutes === 0);
+
+    // Check availability
+    var emptyDivs = item.querySelectorAll('div.Empty');
+    var availableSpans = item.querySelectorAll('span.custom-free-slot-span');
+    var isAvailable = false;
+    var availableCount = 0;
+
+    if (emptyDivs.length > 0) {
+        availableCount = maxPlayers;
+        isAvailable = (minPlayers <= maxPlayers);
+    } else if (availableSpans.length >= minPlayers) {
+        availableCount = availableSpans.length;
+        isAvailable = true;
+    }
+
+    if (!isAvailable) { rejected.capacity++; continue; }
+
+    // Component id of the slot's Reserve link. The direct-HTTP path
+    // replays that component's PrimeFaces request, so it needs the id
+    // rather than the NodeList index the JS chain clicks by.
+    var reserveEl = item.querySelector("a[id*='reserve_button']") ||
+        item.querySelector('a.slot-link');
+
+    var slotInfo = {
+        timeStr: h + ':' + (m < 10 ? '0' : '') + m,
+        hours: h,
+        minutes: m,
+        index: i,
+        diff: diff,
+        available: availableCount,
+        isExact: (diff === 0),
+        aligned: aligned,
+        reserveId: reserveEl ? reserveEl.id : null
+    };
+
+    // For fallback slots, skip excluded times. Never for the exact time
+    // asked for: that one is the booking, not a stand-in chosen for it.
+    if (diff !== 0 && excludeSet[slotMinutes]) { rejected.excluded++; continue; }
+
+    candidates.push(slotInfo);
+}
+
+// Grid-aligned first, so the slot reserved is the one this finder would
+// have picked when alignment was a hard filter. Then nearest to the
+// requested time, and on a tie the earlier tee time - the order the
+// single-slot search reached by scanning rows in time order and keeping
+// the first strictly-closer one.
+candidates.sort(function (a, b) {
+    if (a.aligned !== b.aligned) return a.aligned ? -1 : 1;
+    if (a.diff !== b.diff) return a.diff - b.diff;
+    return (a.hours * 60 + a.minutes) - (b.hours * 60 + b.minutes);
+});
+
+return {candidates: candidates, rejected: rejected, scanned: items.length};
+"""
+
+
 class WaldenGolfProvider(ReservationProvider):
     """
     Selenium-based provider for booking tee times at Walden Golf / Northgate Country Club.
@@ -945,6 +1083,14 @@ class WaldenGolfProvider(ReservationProvider):
         avoid conflicts where a fallback slot for an earlier booking takes a slot needed
         by a later booking.
         """
+        # Dropped at the door, before the early return below, so a run can never
+        # flush the *previous* run's sheet. A batch that fails before it reaches
+        # slot pre-location would otherwise upload whatever the last one staged
+        # and label it with this morning's failure - a diagnostic describing the
+        # wrong day is worse than none. Also releases the last run's member data
+        # when the provider is reused.
+        self._pre_window_sheet = None
+
         if not requests:
             return BatchBookingResult()
 
@@ -2891,6 +3037,10 @@ class WaldenGolfProvider(ReservationProvider):
                 )
                 if detail:
                     error_message += f". {detail}"
+                # The case the sheet was staged for. "Nothing was bookable" is
+                # the finder's account of a sheet nobody else can see, and this
+                # is the one path where the sheet is the whole answer.
+                self._flush_pre_window_sheet("no_candidate")
                 return BookingResult(
                     success=False,
                     course_name=self.NORTHGATE_COURSE_NAME,
@@ -3068,6 +3218,11 @@ class WaldenGolfProvider(ReservationProvider):
                 phase = chain_result.get("phase", "unknown")
                 error = chain_result.get("error", "Unknown error in fast booking chain")
                 held: bool | None = None
+                # Outside the path check below on purpose. A chain that raised
+                # builds its result by hand and carries no `path`, so anything
+                # gated on the direct-HTTP branch would skip the very failure
+                # nobody has an account of.
+                self._flush_pre_window_sheet(f"failed_{phase}")
                 if chain_result.get("path") == DIRECT_HTTP_PATH:
                     partial_markup = chain_result.get("finalMarkup")
                     if partial_markup:
@@ -3075,7 +3230,6 @@ class WaldenGolfProvider(ReservationProvider):
                             f"direct_http_failed_{phase}", partial_markup
                         )
                     self._capture_refresh_artifact(chain_result, phase)
-                    self._flush_pre_window_sheet(f"failed_{phase}")
                     # Before the reservations check, not after: that check
                     # navigates to the dashboard, and a screenshot taken on the
                     # way out would show that page instead of the state that
@@ -3177,6 +3331,7 @@ class WaldenGolfProvider(ReservationProvider):
                 # The response's own message containers are the only place a
                 # refusal we have no phrase for can still be read from.
                 site_message = chain_result.get("responseMessage")
+                self._flush_pre_window_sheet("unverified")
                 return BookingResult(
                     success=False,
                     error_message=self._member_facing_failure(
@@ -3630,136 +3785,7 @@ class WaldenGolfProvider(ReservationProvider):
 
         exclude_list = [{"h": t.hour, "m": t.minute} for t in times_to_exclude]
 
-        js_code = """
-        var targetHour = arguments[0];
-        var targetMinute = arguments[1];
-        var minPlayers = arguments[2];
-        var fallbackMinutes = arguments[3];
-        var intervalMinutes = arguments[4];
-        var excludeTimes = arguments[5];
-        var northgateIndex = arguments[6];
-        var maxPlayers = arguments[7];
-
-        var targetMinutes = targetHour * 60 + targetMinute;
-        var items = document.querySelectorAll('li.ui-datascroller-item');
-        var candidates = [];
-
-        // Why slots were dropped, not just how many survived. "0 fallback(s)"
-        // on 2026-08-08 could not be read as "the sheet was full" or "we
-        // rejected bookable slots", and those call for opposite fixes.
-        var rejected = {
-            course: 0, unparsed: 0, window: 0, offGrid: 0, capacity: 0, excluded: 0
-        };
-
-        // Build exclude set for O(1) lookup
-        var excludeSet = {};
-        for (var e = 0; e < excludeTimes.length; e++) {
-            excludeSet[excludeTimes[e].h * 60 + excludeTimes[e].m] = true;
-        }
-
-        for (var i = 0; i < items.length; i++) {
-            var item = items[i];
-            var itemHtml = item.innerHTML;
-
-            // Check course via element ID pattern: teeTimeCourses:X
-            // Northgate uses index "0", Walden uses index "1"
-            var courseMatch = itemHtml.match(/teeTimeCourses:(\\d+)/);
-            if (!courseMatch || courseMatch[1] !== northgateIndex) {
-                rejected.course++;
-                continue; // Skip slots without a course index or non-Northgate slots
-            }
-
-            // Extract time from label or text content
-            var label = item.querySelector('label');
-            var timeText = label ? label.textContent.trim() : '';
-            if (!timeText) {
-                var allText = item.textContent;
-                var timeMatch = allText.match(/(\\d{1,2}):(\\d{2})\\s*([AaPp][Mm])/);
-                if (timeMatch) {
-                    timeText = timeMatch[0];
-                }
-            }
-            if (!timeText) { rejected.unparsed++; continue; }
-
-            // Parse time
-            var tmatch = timeText.match(/(\\d{1,2}):(\\d{2})\\s*([AaPp][Mm])/i);
-            if (!tmatch) { rejected.unparsed++; continue; }
-            var h = parseInt(tmatch[1]);
-            var m = parseInt(tmatch[2]);
-            var ampm = tmatch[3].toUpperCase();
-            if (ampm === 'PM' && h !== 12) h += 12;
-            if (ampm === 'AM' && h === 12) h = 0;
-
-            var slotMinutes = h * 60 + m;
-            var diff = Math.abs(slotMinutes - targetMinutes);
-
-            // Check fallback window
-            if (diff > fallbackMinutes) { rejected.window++; continue; }
-
-            // Grid alignment. This used to drop the slot, which assumes the
-            // requested time sits on the sheet's own grid - ask for 8:00 when
-            // the day runs 7:56/8:04 and every slot is a non-multiple of 8 away,
-            // so the whole list empties and the morning has no fallback at all.
-            // Kept as a ranking key instead: aligned slots sort first, so the
-            // slot actually reserved is the same one as before, and misaligned
-            // ones line up behind it rather than vanishing.
-            var aligned = (diff % intervalMinutes === 0);
-            if (!aligned) rejected.offGrid++;
-
-            // Check availability
-            var emptyDivs = item.querySelectorAll('div.Empty');
-            var availableSpans = item.querySelectorAll('span.custom-free-slot-span');
-            var isAvailable = false;
-            var availableCount = 0;
-
-            if (emptyDivs.length > 0) {
-                availableCount = maxPlayers;
-                isAvailable = (minPlayers <= maxPlayers);
-            } else if (availableSpans.length >= minPlayers) {
-                availableCount = availableSpans.length;
-                isAvailable = true;
-            }
-
-            if (!isAvailable) { rejected.capacity++; continue; }
-
-            // Component id of the slot's Reserve link. The direct-HTTP path
-            // replays that component's PrimeFaces request, so it needs the id
-            // rather than the NodeList index the JS chain clicks by.
-            var reserveEl = item.querySelector("a[id*='reserve_button']") ||
-                item.querySelector('a.slot-link');
-
-            var slotInfo = {
-                timeStr: h + ':' + (m < 10 ? '0' : '') + m,
-                hours: h,
-                minutes: m,
-                index: i,
-                diff: diff,
-                available: availableCount,
-                isExact: (diff === 0),
-                aligned: aligned,
-                reserveId: reserveEl ? reserveEl.id : null
-            };
-
-            // For fallback slots, skip excluded times. Never for the exact time
-            // asked for: that one is the booking, not a stand-in chosen for it.
-            if (diff !== 0 && excludeSet[slotMinutes]) { rejected.excluded++; continue; }
-
-            candidates.push(slotInfo);
-        }
-
-        // Grid-aligned first, so the slot reserved is the one this finder would
-        // have picked when alignment was a hard filter. Then nearest to the
-        // requested time, and on a tie the earlier tee time - the order the
-        // single-slot search reached by scanning rows in time order and keeping
-        // the first strictly-closer one.
-        candidates.sort(function (a, b) {
-            if (a.aligned !== b.aligned) return a.aligned ? -1 : 1;
-            if (a.diff !== b.diff) return a.diff - b.diff;
-            return (a.hours * 60 + a.minutes) - (b.hours * 60 + b.minutes);
-        });
-
-        return {candidates: candidates, rejected: rejected, scanned: items.length};
-        """
+        js_code = _SLOT_FINDER_JS
 
         found = driver.execute_script(
             js_code,
@@ -5339,7 +5365,15 @@ class WaldenGolfProvider(ReservationProvider):
             logger.warning("BOOKING_DEBUG: Could not read the pre-window tee sheet (%s)", exc)
 
     def _flush_pre_window_sheet(self, context: str) -> None:
-        """Upload the held sheet, if a failed morning made it worth having."""
+        """Upload the held sheet, if a failed morning made it worth having.
+
+        Stored but never echoed. :meth:`_capture_response_artifact` logs the
+        first 1000 characters of its markup's visible text, which on a tee sheet
+        is other members' names - the same ones
+        :meth:`_extract_bookers_from_slot` reads deliberately. Application logs
+        are a far wider audience than the artifact bucket, so this path logs the
+        size and the URI and puts the sheet itself only in storage.
+        """
         sheet = self._pre_window_sheet
         if not sheet:
             logger.info(
@@ -5349,7 +5383,33 @@ class WaldenGolfProvider(ReservationProvider):
             )
             return
         self._pre_window_sheet = None
-        self._capture_response_artifact(f"pre_window_sheet_{context}", sheet)
+
+        bucket_name = os.getenv("DEBUG_ARTIFACTS_BUCKET")
+        if not bucket_name:
+            logger.info(
+                "BOOKING_DEBUG: Pre-window tee sheet for %s is %d bytes, but "
+                "DEBUG_ARTIFACTS_BUCKET is unset so there is nowhere to put it",
+                context,
+                len(sheet),
+            )
+            return
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        try:
+            uri = self._upload_bytes_to_gcs(
+                bucket_name=bucket_name,
+                object_name=f"walden/pre_window_sheet_{context}/{timestamp}/tee_sheet.html",
+                content_type="text/html; charset=utf-8",
+                data=sheet.encode("utf-8", errors="replace"),
+            )
+            logger.info(
+                "BOOKING_DEBUG: Saved the pre-window tee sheet for %s (%d bytes) to %s",
+                context,
+                len(sheet),
+                uri,
+            )
+        except Exception as exc:  # noqa: BLE001 - diagnostics must not fail a booking
+            logger.warning("BOOKING_DEBUG: Failed to upload the pre-window tee sheet: %s", exc)
 
     def _capture_response_artifact(self, context: str, markup: str) -> None:
         """Record a direct-HTTP response body for diagnosis.

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -10,7 +10,7 @@ import os
 from datetime import date, time, timedelta
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import ANY, MagicMock, PropertyMock, patch
 
 import pytest
 from selenium.common.exceptions import WebDriverException
@@ -1772,6 +1772,83 @@ class TestFindTargetSlotJS:
 
         assert result is None
 
+    def test_the_rejection_tally_is_logged(
+        self, provider: WaldenGolfProvider, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A morning with no fallbacks has to say whether the sheet was full.
+
+        2026-08-08 logged "0 fallback(s) behind it" and nothing else, which is
+        the same line whether every slot was taken or the finder threw bookable
+        ones away. The tally is what tells those apart without the sheet.
+        """
+        mock_driver = MagicMock()
+        mock_driver.execute_script.return_value = {
+            "candidates": [],
+            "rejected": {"course": 40, "window": 12, "capacity": 9, "offGrid": 0, "excluded": 0},
+            "scanned": 61,
+        }
+
+        with caplog.at_level(logging.INFO):
+            provider._find_target_slot_js(mock_driver, time(8, 0), 4, 32, 8)
+
+        line = next(m for m in caplog.messages if "Slot scan of" in m)
+        assert "61 row(s)" in line
+        assert "0 candidate(s)" in line
+        # The counts that separate "full sheet" from "finder dropped them".
+        assert "capacity=9" in line
+        assert "course=40" in line
+        # Zeroed reasons stay out of the line rather than padding it.
+        assert "offGrid" not in line
+
+    def test_off_grid_fallbacks_are_flagged(
+        self, provider: WaldenGolfProvider, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Slots the old interval filter would have dropped are called out."""
+        mock_driver = MagicMock()
+        mock_driver.execute_script.return_value = {
+            "candidates": [
+                {
+                    "hours": 8,
+                    "minutes": 8,
+                    "index": 2,
+                    "diff": 8,
+                    "available": 4,
+                    "isExact": False,
+                    "aligned": True,
+                },
+                {
+                    "hours": 8,
+                    "minutes": 2,
+                    "index": 1,
+                    "diff": 2,
+                    "available": 4,
+                    "isExact": False,
+                    "aligned": False,
+                },
+            ],
+            "rejected": {"offGrid": 1},
+            "scanned": 12,
+        }
+
+        with caplog.at_level(logging.INFO):
+            result = provider._find_target_slot_js(mock_driver, time(8, 0), 4, 32, 8)
+
+        # The aligned slot still wins, so the slot reserved is unchanged.
+        assert result is not None and (result["hours"], result["minutes"]) == (8, 8)
+        assert any("1 fallback(s) behind it (1 off-grid)" in m for m in caplog.messages)
+
+    def test_a_bare_list_is_still_understood(self, provider: WaldenGolfProvider) -> None:
+        """The finder predates the tally, and a plain list must still work."""
+        mock_driver = MagicMock()
+        mock_driver.execute_script.return_value = [
+            {"hours": 8, "minutes": 42, "index": 5, "diff": 0, "available": 4, "isExact": True}
+        ]
+
+        result = provider._find_target_slot_js(mock_driver, time(8, 42), 4, 32, 8)
+
+        assert result is not None
+        assert (result["hours"], result["minutes"]) == (8, 42)
+
     def test_takes_the_head_of_the_ranking(self, provider: WaldenGolfProvider) -> None:
         """The single-slot finder returns the best of a ranked list, not any of it."""
         mock_driver = MagicMock()
@@ -1838,6 +1915,68 @@ class TestFindTargetSlotJS:
         # The northgate index is the 7th positional argument (index 6 after js_code)
         northgate_index = call_args[0][7]
         assert northgate_index == "0"
+
+
+class TestPreWindowSheetCapture:
+    """The sheet the fallback list was built from, kept until it is needed.
+
+    Only the post-failure DOM was ever captured, and by then the window has
+    opened and other members have taken slots - so it cannot answer whether the
+    finder had fallbacks to walk when it made the list.
+    """
+
+    def test_the_sheet_is_held_not_uploaded(self, provider: WaldenGolfProvider) -> None:
+        """Staging keeps it; a booked morning never pays to store it."""
+        mock_driver = MagicMock()
+        mock_driver.page_source = "<html>tee sheet</html>"
+
+        with patch.object(provider, "_capture_response_artifact") as upload:
+            provider._capture_pre_window_sheet(mock_driver)
+
+        assert provider._pre_window_sheet == "<html>tee sheet</html>"
+        upload.assert_not_called()
+
+    def test_a_failed_morning_flushes_it(self, provider: WaldenGolfProvider) -> None:
+        """The upload happens once the morning turns out to need explaining."""
+        provider._pre_window_sheet = "<html>tee sheet</html>"
+
+        with patch.object(provider, "_capture_response_artifact") as upload:
+            provider._flush_pre_window_sheet("blocked_reserve_sent")
+
+        upload.assert_called_once_with(
+            "pre_window_sheet_blocked_reserve_sent", "<html>tee sheet</html>"
+        )
+        # Cleared, so a second failure in the same run cannot re-upload a sheet
+        # that no longer describes it.
+        assert provider._pre_window_sheet is None
+
+    def test_no_sheet_says_so_rather_than_going_quiet(
+        self, provider: WaldenGolfProvider, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """ "Never staged" and "staged and lost" call for different fixes."""
+        provider._pre_window_sheet = None
+
+        with (
+            caplog.at_level(logging.INFO),
+            patch.object(provider, "_capture_response_artifact") as upload,
+        ):
+            provider._flush_pre_window_sheet("failed_player_count")
+
+        upload.assert_not_called()
+        assert any("No pre-window tee sheet held" in m for m in caplog.messages)
+
+    def test_an_unreadable_dom_does_not_break_staging(
+        self, provider: WaldenGolfProvider, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Diagnostics must never be what loses a booking."""
+        mock_driver = MagicMock()
+        type(mock_driver).page_source = PropertyMock(side_effect=WebDriverException("gone"))
+
+        with caplog.at_level(logging.WARNING):
+            provider._capture_pre_window_sheet(mock_driver)
+
+        assert provider._pre_window_sheet is None
+        assert any("Could not read the pre-window tee sheet" in m for m in caplog.messages)
 
 
 class TestClickSlotByIndexJS:

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -5,11 +5,16 @@ These tests verify the DOM parsing and time extraction logic works correctly
 against the actual Walden Golf website structure.
 """
 
+import json
 import logging
 import os
+import shutil
+import subprocess
+import tempfile
 from datetime import date, time, timedelta
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import ANY, MagicMock, PropertyMock, patch
 
 import pytest
@@ -1803,7 +1808,13 @@ class TestFindTargetSlotJS:
     def test_off_grid_fallbacks_are_flagged(
         self, provider: WaldenGolfProvider, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Slots the old interval filter would have dropped are called out."""
+        """Slots the old interval filter would have dropped are called out.
+
+        The Python side only counts and reports what the scan returns, so this
+        covers the log line and nothing about the ranking - the fixture is
+        pre-sorted and would satisfy this test with the comparator deleted.
+        `TestSlotFinderScript` runs the real script for that.
+        """
         mock_driver = MagicMock()
         mock_driver.execute_script.return_value = {
             "candidates": [
@@ -1826,14 +1837,16 @@ class TestFindTargetSlotJS:
                     "aligned": False,
                 },
             ],
-            "rejected": {"offGrid": 1},
+            # No offGrid key: a retained off-grid slot is not a rejection, and
+            # the "(N off-grid)" count below comes off the candidate list.
+            "rejected": {"capacity": 2},
             "scanned": 12,
         }
 
         with caplog.at_level(logging.INFO):
             result = provider._find_target_slot_js(mock_driver, time(8, 0), 4, 32, 8)
 
-        # The aligned slot still wins, so the slot reserved is unchanged.
+        # Head of whatever the scan ranked, which the fixture fixes as 8:08.
         assert result is not None and (result["hours"], result["minutes"]) == (8, 8)
         assert any("1 fallback(s) behind it (1 off-grid)" in m for m in caplog.messages)
 
@@ -1917,6 +1930,125 @@ class TestFindTargetSlotJS:
         assert northgate_index == "0"
 
 
+_DOM_SHIM = """
+function slot(timeText, available, course) {
+  return {
+    innerHTML: '<a id="f:teeTimeCourses:' + course + ':teeTimeSlots:1:slotTee:0:reserve_button">',
+    textContent: timeText,
+    querySelector: function (sel) {
+      if (sel === 'label') return {textContent: timeText};
+      if (sel.indexOf('reserve_button') !== -1) return {id: 'reserve_' + timeText};
+      return null;
+    },
+    querySelectorAll: function (sel) {
+      if (sel === 'div.Empty') return [];
+      if (sel === 'span.custom-free-slot-span') return new Array(available).fill({});
+      return [];
+    }
+  };
+}
+var rows = ROWS.map(function (r) { return slot(r[0], r[1], r[2] || '0'); });
+global.document = {querySelectorAll: function () { return rows; }};
+var run = new Function(SCRIPT);
+var out = run.apply(null, ARGS);
+console.log(JSON.stringify(out));
+"""
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not on PATH")
+class TestSlotFinderScript:
+    """The scan itself, run as the browser gets it.
+
+    The ranking is the load-bearing part of the off-grid change and it lives in
+    JavaScript, so a Python test that hands `_find_target_slot_js` a pre-sorted
+    list cannot exercise it - that test would pass with the comparator deleted.
+    This runs the real script over a stand-in DOM instead.
+    """
+
+    def _scan(
+        self,
+        rows: list[tuple[str, int]],
+        target: time,
+        *,
+        players: int = 4,
+        window: int = 32,
+        interval: int = 8,
+    ) -> dict[str, Any]:
+        from app.providers.walden_provider import _SLOT_FINDER_JS
+
+        program = (
+            f"const SCRIPT = {json.dumps(_SLOT_FINDER_JS)};\n"
+            f"const ROWS = {json.dumps([[t, n] for t, n in rows])};\n"
+            f"const ARGS = {json.dumps([target.hour, target.minute, players, window, interval, [], '0', 4])};\n"
+            + _DOM_SHIM
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as fh:
+            fh.write(program)
+            path = fh.name
+        try:
+            proc = subprocess.run(
+                ["node", path], capture_output=True, text=True, timeout=30, check=True
+            )
+        finally:
+            os.unlink(path)
+        result: dict[str, Any] = json.loads(proc.stdout)
+        return result
+
+    def _times(self, out: dict[str, Any]) -> list[str]:
+        return [f"{c['hours']:02d}:{c['minutes']:02d}" for c in out["candidates"]]
+
+    def test_an_on_grid_request_is_unchanged(self) -> None:
+        """The case that already worked has to keep working exactly."""
+        rows = [("7:44 AM", 4), ("7:52 AM", 4), ("8:00 AM", 4), ("8:08 AM", 4), ("8:16 AM", 4)]
+
+        out = self._scan(rows, time(8, 0))
+
+        assert self._times(out) == ["08:00", "07:52", "08:08", "07:44", "08:16"]
+        assert all(c["aligned"] for c in out["candidates"])
+
+    def test_an_off_grid_request_keeps_its_fallbacks(self) -> None:
+        """The failure this change exists for.
+
+        Every one of these is a non-multiple of 8 from 8:00, so the old filter
+        dropped all five and the morning failed with "no suitable slot" - not a
+        lost race, a request never made.
+        """
+        rows = [("7:40 AM", 4), ("7:48 AM", 4), ("7:56 AM", 4), ("8:04 AM", 4), ("8:12 AM", 4)]
+
+        out = self._scan(rows, time(8, 0))
+
+        assert self._times(out) == ["07:56", "08:04", "07:48", "08:12", "07:40"]
+        assert not any(c["aligned"] for c in out["candidates"])
+
+    def test_an_aligned_slot_outranks_a_nearer_off_grid_one(self) -> None:
+        """The safety property: the slot reserved does not move.
+
+        8:02 is six minutes closer, and still loses. Without this the change
+        would quietly start booking different tee times than before.
+        """
+        out = self._scan([("8:02 AM", 4), ("8:08 AM", 4)], time(8, 0))
+
+        assert self._times(out) == ["08:08", "08:02"]
+
+    def test_a_full_sheet_says_capacity_not_grid(self) -> None:
+        """The distinction 2026-08-08 could not be read for."""
+        rows = [("7:52 AM", 0), ("8:00 AM", 0), ("8:08 AM", 0)]
+
+        out = self._scan(rows, time(8, 0))
+
+        assert out["candidates"] == []
+        assert out["rejected"]["capacity"] == 3
+        assert out["rejected"]["window"] == 0
+
+    def test_a_retained_off_grid_slot_is_never_called_dropped(self) -> None:
+        """A tally that blames a slot it kept is the bug this scan is fixing."""
+        out = self._scan([("8:02 AM", 4)], time(8, 0))
+
+        assert self._times(out) == ["08:02"]
+        assert not out["candidates"][0]["aligned"]
+        assert sum(out["rejected"].values()) == 0
+
+
 class TestPreWindowSheetCapture:
     """The sheet the fallback list was built from, kept until it is needed.
 
@@ -1936,18 +2068,82 @@ class TestPreWindowSheetCapture:
         assert provider._pre_window_sheet == "<html>tee sheet</html>"
         upload.assert_not_called()
 
-    def test_a_failed_morning_flushes_it(self, provider: WaldenGolfProvider) -> None:
+    def test_a_failed_morning_flushes_it(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """The upload happens once the morning turns out to need explaining."""
         provider._pre_window_sheet = "<html>tee sheet</html>"
+        monkeypatch.setenv("DEBUG_ARTIFACTS_BUCKET", "artifacts")
 
-        with patch.object(provider, "_capture_response_artifact") as upload:
+        with patch.object(provider, "_upload_bytes_to_gcs", return_value="gs://x") as upload:
             provider._flush_pre_window_sheet("blocked_reserve_sent")
 
         upload.assert_called_once_with(
-            "pre_window_sheet_blocked_reserve_sent", "<html>tee sheet</html>"
+            bucket_name="artifacts",
+            object_name=ANY,
+            content_type="text/html; charset=utf-8",
+            data=b"<html>tee sheet</html>",
         )
+        assert "pre_window_sheet_blocked_reserve_sent" in upload.call_args.kwargs["object_name"]
         # Cleared, so a second failure in the same run cannot re-upload a sheet
         # that no longer describes it.
+        assert provider._pre_window_sheet is None
+
+    def test_the_sheet_never_reaches_the_logs(
+        self,
+        provider: WaldenGolfProvider,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A tee sheet names other members, and logs are a wider audience.
+
+        _capture_response_artifact echoes the first 1000 characters of its
+        markup's visible text, which is why the sheet does not go through it.
+        """
+        sheet = "<html><body><div>07:52 AM</div><div>Reserved by Jane Q. Member</div></body></html>"
+        provider._pre_window_sheet = sheet
+        monkeypatch.setenv("DEBUG_ARTIFACTS_BUCKET", "artifacts")
+
+        with (
+            caplog.at_level(logging.DEBUG),
+            patch.object(provider, "_upload_bytes_to_gcs", return_value="gs://x"),
+        ):
+            provider._flush_pre_window_sheet("no_candidate")
+
+        logged = "\n".join(caplog.messages)
+        assert "Jane Q. Member" not in logged
+        assert "<div>" not in logged
+        # The size and the destination are what a post-mortem needs from the log.
+        assert "gs://x" in logged
+        assert f"{len(sheet)} bytes" in logged
+
+    def test_no_bucket_still_reports_the_size(
+        self,
+        provider: WaldenGolfProvider,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Nowhere to put it is worth saying, not worth failing over."""
+        provider._pre_window_sheet = "<html>tee sheet</html>"
+        monkeypatch.delenv("DEBUG_ARTIFACTS_BUCKET", raising=False)
+
+        with caplog.at_level(logging.INFO):
+            provider._flush_pre_window_sheet("no_candidate")
+
+        assert any("DEBUG_ARTIFACTS_BUCKET is unset" in m for m in caplog.messages)
+        assert provider._pre_window_sheet is None
+
+    def test_a_new_batch_drops_the_previous_sheet(self, provider: WaldenGolfProvider) -> None:
+        """A run must never flush the sheet a previous run staged.
+
+        A batch that fails before slot pre-location would otherwise upload the
+        last run's sheet under this morning's failure - a diagnostic describing
+        the wrong day, which is worse than having none.
+        """
+        provider._pre_window_sheet = "<html>yesterday</html>"
+
+        provider._book_multiple_tee_times_sync(date(2026, 8, 16), [], None)
+
         assert provider._pre_window_sheet is None
 
     def test_no_sheet_says_so_rather_than_going_quiet(


### PR DESCRIPTION
Follow-up to #141, which left this open:

> The empty fallback list (`0 fallback(s) behind it`) is still unexplained — the pre-window sheet the finder judged from is never captured, only the post-failure DOM.

That line cannot say whether the sheet was full or the finder threw bookable slots away. Both are addressed here.

## The grid filter could empty the whole list

```js
if (diff % intervalMinutes !== 0) continue;
```

`diff` is the distance from the *requested* time, so this only holds when the request itself sits on the sheet's grid. It came in with "configurable tee time interval" (#78) and the assumption was never stated.

Ask for **8:00** on a day running 7:40 / 7:48 / 7:56 / 8:04 / 8:12 and the diffs are 20, 12, 4, 4, 12 — not one of them a multiple of 8. Every slot is dropped, and the morning fails with `found no suitable Northgate slot`. That is not a lost race; it is a request that was never made.

Alignment is now a **ranking key** rather than a rejection. Aligned slots sort first, so the slot actually reserved is the one this finder would have picked before; misaligned ones queue behind it instead of vanishing.

| Case | Slots | Before | After |
|---|---|---|---|
| Request on the grid | 7:44 … 8:16, target 8:00 | `8:00 7:52 8:08 7:44 8:16` | **unchanged** |
| Request off the grid | 7:40 … 8:12, target 8:00 | **0 candidates — booking fails** | `7:56* 8:04* 7:48* 8:12* 7:40*` |
| Nearer off-grid vs aligned | 8:02, 8:08, target 8:00 | `8:08` | `8:08` then `8:02*` |
| Genuinely full sheet | all 0 capacity | 0 candidates | 0 candidates, `capacity=3` |

`*` = off-grid. The third row is the one that matters for safety: the primary pick does not move.

Those four rows are the assertions of `TestSlotFinderScript`, which runs the real script rather than a paraphrase of it — see Tests below.

## The log now says which of the two it was

The finder tallies why each row was dropped and reports it before the verdict:

```
BOOKING_DEBUG: Slot scan of 61 row(s) for 08:00 AM, 4 player(s), +/-32 min -
  0 candidate(s); dropped course=40, window=12, capacity=9
```

`capacity=9` reads "the sheet was full". A large `excluded` or `window` count would read differently. On 08-08 those were all the same line.

A slot that is off-grid but *kept* is never counted as dropped — it is reported as `(N off-grid)` beside the fallback count, off the candidate list. A tally that blamed a slot it went on to reserve would be the same kind of misleading line this scan exists to replace.

## And the sheet itself is kept

Staging holds the tee sheet the list was built from and uploads it **only if the morning ends without a booking** — most mornings book, and the sheet is worth nothing then. Deliberately not read on the 06:30 re-scan path, where a ~600KB `page_source` would be spent against the clock.

The post-failure DOM that was already captured is taken *after* the window opened and other members took slots, so it cannot answer what the finder had to work with. That was the gap.

The sheet goes to the artifact bucket and never through `_capture_response_artifact`, which logs the first 1000 characters of its markup's visible text — on a tee sheet, other members' names. This path logs context, byte count, and URI only. Every failed outcome flushes it, including the no-candidate return (the case it exists for) and chains that raised without a `path`; it is dropped at the start of each batch so a run can never flush the previous run's sheet.

## Tests

- `TestSlotFinderScript` — the script as a module constant, executed under node over a stand-in DOM. The four rows above, plus a retained off-grid slot never being counted as dropped. Mutation-checked: deleting the aligned-first comparator fails `test_an_aligned_slot_outranks_a_nearer_off_grid_one`.
- `TestFindTargetSlotJS` — the rejection tally, the off-grid flag, and back-compatibility with the pre-tally bare list.
- `TestPreWindowSheetCapture` — hold-don't-upload, flush-on-failure, cleared-after-flush, no-bucket, an unreadable DOM not breaking staging, member names staying out of the logs, and a new batch dropping the previous sheet.

857 passed, 3 skipped on CI; ruff 0.8.6 and mypy clean.

## Worth knowing

The script is exercised against a stand-in DOM, not a real Walden tee sheet. The comparator is now covered on CI and the coverage is mutation-checked, but no end-to-end run has exercised this against the live site — the tally and the captured sheet are what will settle it against a real morning.

I could not determine from the existing logs whether 08-08's empty list was a full Saturday-noon sheet or this filter; a prime midday slot being genuinely full is entirely plausible. That is the question the tally answers on the next run.

Deferred out of this PR and filed instead: #143 (Reserve-response captures log tee-sheet text — pre-existing, same `_capture_response_artifact` excerpt this PR routes around) and #144 (the provider is a shared singleton with no locking; the sequential-reuse case is fixed here, concurrent runs are not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved booking-slot selection by prioritizing aligned times while retaining suitable fallback options.
  - Enhanced handling of unavailable, blocked, failed, and unverifiable booking results.
  - Improved batch processing by clearing stale booking data between runs.
  - Added diagnostic capture for booking issues, with privacy-safe handling and non-blocking upload failures.
  - Improved compatibility with different slot-scan result formats and unreadable booking-page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->