### PR TITLE
fix: book ad-hoc tee times the way the 6:30 race does

### DIFF
--- a/.claude/skills/booking-postmortem/SKILL.md
+++ b/.claude/skills/booking-postmortem/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: booking-postmortem
+description: Diagnose why the morning's TeeTime booking run failed. Use when the user says the bot lost the race, didn't get the tee time, "we didn't beat the humans", or asks to check the booking logs for a given morning. Pulls Cloud Run logs and the GCS debug artifacts, classifies the failure, and reports what is and isn't established.
+---
+
+# Morning booking post-mortem
+
+The booking job fires at 06:28 CT and the window opens at 06:30:00 CT. Every
+morning it loses, the question is the same: did we lose the race, or did we
+refuse ourselves? This skill is the repeatable path to that answer.
+
+## 1. Get to latest first
+
+The branch in the working tree is usually behind. Diagnosing against stale code
+wastes the run — a fix may already be in.
+
+```bash
+git fetch origin && git checkout main && git pull --ff-only && git log --oneline -8
+```
+
+## 2. Pull the run
+
+Project `gen-lang-client-0822973627`, Cloud Run service `teetime`, region
+`us-central1`. During CDT, 06:30 CT = 11:30 UTC (CST: 12:30 UTC).
+
+**Use the Bash tool, not PowerShell** — PowerShell mangles the quoting inside
+the filter and gcloud rejects it with "Unparseable filter".
+
+```bash
+gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="teetime" AND timestamp>="2026-08-09T11:20:00Z" AND timestamp<="2026-08-09T11:40:00Z"' --project=gen-lang-client-0822973627 --format="value(timestamp,textPayload)" --limit=1000 --order=asc | grep -v discord.gateway > run.txt
+```
+
+`discord.gateway` DEBUG lines are heartbeat noise and one MESSAGE_CREATE event
+can be several hundred lines — always filter them out.
+
+To sweep several mornings at once and see whether a failure is new or chronic,
+loop the date and grep for the outcome lines:
+
+```
+Firing Reserve|Chain finished|No Reserve accepted|BATCH COMPLETE|Clock skew|arrives as the window|slot finder found
+```
+
+## 3. Read the run in order
+
+The run has a fixed shape. Walk it and note where it diverges:
+
+| Stage | Log marker | What to check |
+|---|---|---|
+| Login / navigate | `BATCH_BOOKING: Step 1..4` | Reached the tee sheet; date selected |
+| Slot scan | `Slot scan of N row(s)` | Candidate count, and the `dropped course=/window=` breakdown |
+| Pre-locate | `JS slot finder found slot` | `exact=True`, and **how many fallbacks** it kept |
+| Clock | `Clock skew measured` | probes, transitions, offset, one-way |
+| Lead | `Reserve will be sent Nms early` | Should be tens of ms, not hundreds |
+| Fire | `Firing Reserve k/6 ... Nms past the window` | Attempt 1 should be ≈ 0ms or slightly negative |
+| Outcome | `Chain finished - phase=..., success=..., blocked=...` | Phase says how far it got |
+
+`phase=complete, success=True` is **not** proof of a booking — the provider
+verifies against the member's reservations page afterwards
+(`RESERVATION_CHECK:`). Read that line before declaring a win.
+
+## 4. Pull the artifacts
+
+Failures upload to `gs://gen-lang-client-0822973627-teetime-debug-artifacts/`.
+The log lines print the exact paths; the naming is
+`walden/<reason>/<YYYYMMDD_HHMMSS>/<file>`.
+
+**Use `gcloud storage cp`, not `gsutil`** — gsutil is broken in this
+environment (`python3.13: command not found`).
+
+The four that matter:
+
+- `direct_http_blocked_reserve_sent/.../direct_http_response.html` — the club's
+  response. **Only the last attempt's**, which is the current diagnostic gap.
+- `pre_window_sheet_.../tee_sheet.html` — the sheet as staged before the window.
+  The control for any "was this in the response before we sent anything?" test.
+- `slot_blocked_by_other_user/.../page.html` — the browser DOM. Beware: the
+  direct-HTTP path never touches the browser, so the slot rows here are the
+  **pre-window render** and say nothing about who won. The countdown element is
+  gone because client-side JS removed it, not because the DOM refreshed.
+- `.../screenshot.png` — the rendered page.
+
+## 5. Test claims against the artifacts, don't infer from prose
+
+Two traps have each cost a morning:
+
+**The countdown in a Reserve response is stale.** A Reserve re-renders the view
+staged before the window, so it echoes that view's frozen countdown. Confirm by
+matching it to the pre-window sheet's `Booking Starts In : 00:0X:XX` — on
+2026-08-09 both read 70s. It is logged, never branched on. Don't re-derive
+"the window wasn't open" from it.
+
+**Check whether a "refusal" is actually a refusal** before believing it. The
+`teeSheetValidationErrorPopup` carries `ui-hidden-container` and no
+`aria-hidden`, which makes it *look* like a template that is always present. It
+is not: grep the pre-window sheet for the message text. On 2026-08-09 the
+pre-window sheet had zero occurrences and the Reserve responses had one, so the
+club genuinely refused.
+
+The project's own parser is the right tool for structural questions:
+
+```python
+import sys; sys.path.insert(0, r"C:\Users\DaxGarner\Documents\Projects\teetime")
+from app.providers.walden_http import parse_html
+from app.providers.walden_http_booker import _slot_time_of, _find_blocked_message_in
+```
+
+## 6. Classify
+
+- **Lost on the clock** — attempt 1 fired hundreds of ms past the window, or
+  `Clock skew unmeasurable`. Look at the probe target and RTTs.
+- **Lost on the slot list** — few or zero fallbacks kept, or the scan dropped
+  everything. Check the `dropped course=/window=` split.
+- **Refused at Reserve** — the club answered "This slot is blocked by another
+  user". This is the current standing failure; see below.
+- **Refused later in the chain** — `phase=player_count/tbd_guests/book_now`.
+  Read `responseMessage`; a club restriction (one round per member per day)
+  surfaces here as a `Restriction:` dialog.
+- **Chain completed, no reservation** — `success=True` but `RESERVATION_CHECK`
+  found nothing. The most dangerous class: it looks like a win in the summary.
+
+## 7. What is already ruled out
+
+Don't re-litigate these; each was established from artifacts, not reasoning:
+
+- **Timing is solved** (as of #141). The clock probe hits a static CSS asset and
+  measures cleanly; 2026-08-09 fired at −9ms with a 9ms lead.
+- **The chain works.** On 2026-08-04 the same direct-HTTP chain completed and
+  booked three times — at T+22s and T+8min, never in the race.
+- **The countdown is not the cause** (see above).
+- **The blocked popup is not a static-template false positive** (see above).
+- **A fresh post-window view does not fix it.** 2026-08-07 refreshed the sheet
+  at the window — countdown gone, 86/87 rows reservable — and the club refused
+  anyway with the same ViewState and component id. `refresh_at_window` is off
+  for this reason.
+
+## 8. Report
+
+State separately: what the run did, what is established from artifacts, what is
+hypothesis, and the single cheapest experiment that would discriminate. Note
+that per this project there is no local way to exercise booking — testing means
+deploying to main behind a flag, so an experiment costs a morning. Say which
+morning it would cost and what it would settle.

--- a/.claude/skills/booking-postmortem/SKILL.md
+++ b/.claude/skills/booking-postmortem/SKILL.md
@@ -18,25 +18,57 @@ wastes the run — a fix may already be in.
 git fetch origin && git checkout main && git pull --ff-only && git log --oneline -8
 ```
 
+One caution when the run being diagnosed is not this morning's: a commit to
+`main` redeploys, so `main` can have moved past the revision that actually
+executed. Check what ran before trusting the source:
+
+```bash
+gcloud run revisions list --service=teetime --region=us-central1 --project=gen-lang-client-0822973627 --limit=5 --format="table(name,creationTimestamp)"
+```
+
+If a deploy landed between the run and now, read the code at that revision's
+commit (`git show <sha>:<path>`, or a worktree) rather than at `main`.
+
 ## 2. Pull the run
 
 Project `gen-lang-client-0822973627`, Cloud Run service `teetime`, region
-`us-central1`. During CDT, 06:30 CT = 11:30 UTC (CST: 12:30 UTC).
+`us-central1`. The job fires at 06:28 CT and the window opens at 06:30 CT —
+11:30 UTC during CDT, 12:30 UTC during CST.
 
 **Use the Bash tool, not PowerShell** — PowerShell mangles the quoting inside
 the filter and gcloud rejects it with "Unparseable filter".
 
+Set the date once and derive the UTC bounds from it, so the same command works
+for any morning and picks the right offset either side of a DST change:
+
 ```bash
-gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="teetime" AND timestamp>="2026-08-09T11:20:00Z" AND timestamp<="2026-08-09T11:40:00Z"' --project=gen-lang-client-0822973627 --format="value(timestamp,textPayload)" --limit=1000 --order=asc | grep -v discord.gateway > run.txt
+DAY=2026-08-09
+read START END <<<"$(poetry run python - "$DAY" <<'PY'
+import sys
+from datetime import datetime
+from zoneinfo import ZoneInfo
+day = datetime.strptime(sys.argv[1], "%Y-%m-%d").replace(tzinfo=ZoneInfo("America/Chicago"))
+fmt = lambda d: d.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%dT%H:%M:%SZ")
+print(fmt(day.replace(hour=6, minute=20)), fmt(day.replace(hour=6, minute=40)))
+PY
+)"
+gcloud logging read "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"teetime\" AND timestamp>=\"$START\" AND timestamp<=\"$END\" AND textPayload!~\"discord\\.gateway\"" --project=gen-lang-client-0822973627 --format="value(timestamp,textPayload)" --limit=2000 --order=asc > run.txt
 ```
 
-`discord.gateway` DEBUG lines are heartbeat noise and one MESSAGE_CREATE event
-can be several hundred lines — always filter them out.
+Python rather than `date -d`: Git Bash here ignores `TZ=America/Chicago` when
+parsing (it returns the input unchanged), which would silently query the wrong
+five hours. `python -c` also swallows output through this shell — the heredoc
+form above is the one that works.
 
-To sweep several mornings at once and see whether a failure is new or chronic,
-loop the date and grep for the outcome lines:
+Exclude `discord.gateway` **in the query, not with a local `grep`**. It is
+heartbeat DEBUG noise, and `--limit` truncates server-side before a pipe ever
+sees the output — filtering locally can silently drop the `Firing Reserve` and
+`Chain finished` lines the whole post-mortem depends on.
 
-```
+To sweep several mornings and see whether a failure is new or chronic, loop
+`DAY` and grep the result for the outcome lines:
+
+```text
 Firing Reserve|Chain finished|No Reserve accepted|BATCH COMPLETE|Clock skew|arrives as the window|slot finder found
 ```
 
@@ -96,10 +128,10 @@ is not: grep the pre-window sheet for the message text. On 2026-08-09 the
 pre-window sheet had zero occurrences and the Reserve responses had one, so the
 club genuinely refused.
 
-The project's own parser is the right tool for structural questions:
+The project's own parser is the right tool for structural questions. Run it
+from the repository root so the import resolves on any checkout:
 
 ```python
-import sys; sys.path.insert(0, r"C:\Users\DaxGarner\Documents\Projects\teetime")
 from app.providers.walden_http import parse_html
 from app.providers.walden_http_booker import _slot_time_of, _find_blocked_message_in
 ```

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -34,14 +34,26 @@ git checkout -b fix/<short-slug> && git push -u origin fix/<short-slug>
 
 ## 3. Wait
 
-Poll rather than sleeping in the foreground, and run it in the background:
+Poll rather than sleeping in the foreground. Pass `run_in_background: true` to
+the Bash tool — the loop itself is an ordinary foreground loop, the tool is what
+detaches it and notifies you on exit.
+
+The loop must **fail closed**. An auth error, a network blip, or an empty result
+all produce output with no `pending` in it, and a naive check reads that as
+"settled":
 
 ```bash
 for i in $(seq 1 40); do
-  out=$(gh pr checks <N> 2>&1)
-  if ! echo "$out" | grep -q "pending"; then echo "$out"; exit 0; fi
+  if ! out=$(gh pr checks <N> 2>&1); then
+    # gh exits non-zero when checks are still pending *and* on real errors, so
+    # distinguish them rather than treating any failure as either one.
+    if ! grep -q "pending" <<<"$out"; then echo "gh failed:"; echo "$out"; exit 2; fi
+  elif ! grep -q "pending" <<<"$out"; then
+    echo "$out"; exit 0
+  fi
   sleep 20
 done
+echo "still pending after 800s"; gh pr checks <N>; exit 1
 ```
 
 CodeRabbit posts an initial summary comment within a minute of the PR opening —
@@ -50,12 +62,26 @@ that is **not** the review. The review lands later as inline comments.
 ## 4. Read the review properly
 
 Inline comments do not appear in `gh pr view --json comments`. That field only
-holds issue-level comments. Fetch both:
+holds issue-level comments. Fetch both, and **project `id`** — step 6 needs it
+to reply, and re-fetching just to get it is pure friction:
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/<N>/comments --jq '.[] | {path, line, body}'
+gh api repos/{owner}/{repo}/pulls/<N>/comments --jq '.[] | {id, path, line, body}'
 gh pr view <N> --json comments --jq '.comments[] | {author: .author.login, body}'
 ```
+
+Checks going green is not proof the inline comments have landed, especially on
+a re-review after a push. If the comment list looks unchanged from before your
+push, wait and re-fetch before concluding the review found nothing.
+
+Two mechanics worth knowing:
+
+- The single-comment route is `/pulls/comments/{id}`, **not**
+  `/pulls/<N>/comments/{id}` — the latter 404s. Easiest is to fetch the list
+  once and filter locally.
+- Findings are wrapped in `<details>` blocks and emoji-heavy. When parsing with
+  Python, set `PYTHONIOENCODING=utf-8` or strip to ASCII; this console is cp1252
+  and will raise `UnicodeEncodeError` on the severity emoji.
 
 CodeRabbit marks its findings with severity and often collapses detail inside
 `<details>` blocks — read the whole body, not the first line. It also posts
@@ -77,6 +103,20 @@ The reviewer is a tool, not an authority. For each finding, decide:
 
 Do not "fix" something you believe is correct just to clear the review.
 
+**Ignore the severity labels; read the reasoning.** They are unreliable in both
+directions. On #145 a finding tagged `🔵 Trivial | 💤 Low value` pointed out that
+a terraform `type = number` accepts `90.5`, which `tostring` emits as `"90.5"`
+into a setting typed `int` — a container that will not boot, surfacing as a
+failed deploy rather than a failed plan. Meanwhile some `🟠 Major` items were
+documentation nits. Judge each one on what it says.
+
+**Run the suggested fix before committing it.** CodeRabbit's proposed diffs are
+plausible-looking and environment-blind. On #145 the suggested timezone handling
+(`TZ=America/Chicago date -d ...`) is silently wrong here — Git Bash ignores
+`TZ` when parsing and returns the input unchanged, so the "fix" would have
+queried the wrong five hours and found nothing. Verify, then commit what you
+verified, and leave a note saying why the obvious version was rejected.
+
 ## 6. Reply
 
 Reply to each substantive finding. Inline replies thread properly:
@@ -96,11 +136,22 @@ per nit.
 Run the full local gate before pushing — CI is slower than you are:
 
 ```bash
-poetry run pytest -q && poetry run ruff check app tests && poetry run ruff format --check app tests && poetry run mypy app
+poetry run pytest -q && poetry run ruff check . && poetry run ruff format --check . && poetry run mypy app
 ```
 
-Always `poetry run` — the venv lives outside the repo. Push, then re-poll;
-CodeRabbit re-reviews each push.
+Ruff over `.`, not `app tests` — that is what both CI jobs run, and scoping
+narrower locally lets a lint error in a file outside those two directories pass
+here and fail there.
+
+This gate is deliberately **stricter than CI in one respect**: CI marks mypy
+`continue-on-error: true` (pre-existing type errors), so a type regression will
+not fail the build. Keep it fatal locally so new ones do not accumulate.
+
+Always `poetry run` — the local venv lives outside the repo, under Poetry's
+cache. (CI is configured `virtualenvs-in-project`, so there it is `.venv`; both
+need `poetry run` either way.)
+
+Push, then re-poll; CodeRabbit re-reviews each push.
 
 ## 8. Report, and stop
 

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: ship-pr
+description: Open a PR, wait for CodeRabbit and CI, then work through the review comments. Use when the user says to create a PR and handle the review, respond to review comments, address CodeRabbit feedback, or asks what the bot said about a PR.
+---
+
+# Ship a PR through review
+
+This repo reviews every PR with **CodeRabbit** (a GitHub App, so it does not
+appear in `.github/workflows/` — only `test.yml` does). Checks are `CodeRabbit`,
+`lint`, and `test`.
+
+## 1. Branch and push
+
+Never commit to `main` — a commit there redeploys to Cloud Run. Branch first.
+
+```bash
+git checkout -b fix/<short-slug> && git push -u origin fix/<short-slug>
+```
+
+## 2. Open it
+
+`gh pr create` with a heredoc body. What makes these PRs reviewable:
+
+- **Why before what.** Lead with the failure or observation that forced the
+  change, not a summary of the diff.
+- **State the accepted costs.** Regressions in latency, UX, or reliability that
+  the change knowingly buys. A reviewer who finds one you didn't name assumes
+  you missed it.
+- **Flag what you could not verify** (e.g. terraform CLI is not installed
+  locally, so `validate` never runs here).
+- **Call out changed-not-added tests** and why the old assertion encoded the
+  behaviour being replaced. This is the single most common source of review
+  pushback.
+
+## 3. Wait
+
+Poll rather than sleeping in the foreground, and run it in the background:
+
+```bash
+for i in $(seq 1 40); do
+  out=$(gh pr checks <N> 2>&1)
+  if ! echo "$out" | grep -q "pending"; then echo "$out"; exit 0; fi
+  sleep 20
+done
+```
+
+CodeRabbit posts an initial summary comment within a minute of the PR opening —
+that is **not** the review. The review lands later as inline comments.
+
+## 4. Read the review properly
+
+Inline comments do not appear in `gh pr view --json comments`. That field only
+holds issue-level comments. Fetch both:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<N>/comments --jq '.[] | {path, line, body}'
+gh pr view <N> --json comments --jq '.comments[] | {author: .author.login, body}'
+```
+
+CodeRabbit marks its findings with severity and often collapses detail inside
+`<details>` blocks — read the whole body, not the first line. It also posts
+"Nitpick" and "Outside diff range" sections that are advisory.
+
+## 5. Judge each comment before acting
+
+The reviewer is a tool, not an authority. For each finding, decide:
+
+- **Real bug** → fix it, and add the test that would have caught it.
+- **Real but out of scope** → say so, and spawn a follow-up rather than growing
+  the PR.
+- **Wrong** → say why, plainly and without hedging. A confident bot assertion
+  that contradicts the code is still wrong. Verify against the code before
+  agreeing *or* disagreeing — do not take a finding at face value, and do not
+  reflexively defend the diff either.
+- **Style preference** → apply it if it matches surrounding code, decline if it
+  does not.
+
+Do not "fix" something you believe is correct just to clear the review.
+
+## 6. Reply
+
+Reply to each substantive finding. Inline replies thread properly:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<N>/comments/<COMMENT_ID>/replies -f body="..."
+```
+
+For a general reply: `gh pr comment <N> --body "..."`.
+
+Group the response: what you fixed, what you're deferring and why, what you
+think is wrong and why. One comment covering several findings beats a thread
+per nit.
+
+## 7. Push fixes and re-verify
+
+Run the full local gate before pushing — CI is slower than you are:
+
+```bash
+poetry run pytest -q && poetry run ruff check app tests && poetry run ruff format --check app tests && poetry run mypy app
+```
+
+Always `poetry run` — the venv lives outside the repo. Push, then re-poll;
+CodeRabbit re-reviews each push.
+
+## 8. Report, and stop
+
+Summarize for the user: what the review caught that was real, what you pushed
+back on, and what state the PR is in.
+
+**Do not merge.** Merging to `main` deploys this service. That call is the
+user's, always, unless they have explicitly said to merge in this session.

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -69,7 +69,7 @@ to reply, and re-fetching just to get it is pure friction:
 
 ```bash
 gh api repos/{owner}/{repo}/pulls/<N>/comments --paginate \
-  --jq '.[] | select(.in_reply_to_id == null) | {id, path, line, body}'
+  --jq '.[] | select(.in_reply_to_id == null) | {id, created_at, path, line, body}'
 gh pr view <N> --json comments --jq '.comments[] | {author: .author.login, body}'
 ```
 

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -45,8 +45,10 @@ all produce output with no `pending` in it, and a naive check reads that as
 ```bash
 for i in $(seq 1 40); do
   if ! out=$(gh pr checks <N> 2>&1); then
-    # gh exits non-zero when checks are still pending *and* on real errors, so
-    # distinguish them rather than treating any failure as either one.
+    # A non-zero exit means either "still pending" (documented as 8) or a real
+    # failure, so the output decides which. Verified the failure case: a bad PR
+    # number exits 1 with "Could not resolve to a PullRequest" and no "pending",
+    # which the old loop reported as a completed review.
     if ! grep -q "pending" <<<"$out"; then echo "gh failed:"; echo "$out"; exit 2; fi
   elif ! grep -q "pending" <<<"$out"; then
     echo "$out"; exit 0
@@ -66,26 +68,32 @@ holds issue-level comments. Fetch both, and **project `id`** — step 6 needs it
 to reply, and re-fetching just to get it is pure friction:
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/<N>/comments --jq '.[] | {id, path, line, body}'
+gh api repos/{owner}/{repo}/pulls/<N>/comments --paginate \
+  --jq '.[] | select(.in_reply_to_id == null) | {id, path, line, body}'
 gh pr view <N> --json comments --jq '.comments[] | {author: .author.login, body}'
 ```
+
+`select(.in_reply_to_id == null)` is not optional. The endpoint returns replies
+alongside findings, so once you have answered a round the list is mostly your
+own text, and the reply API needs the *parent* id — a reply's id will not
+thread. Filtering also makes "did this push add findings?" answerable by
+sorting the survivors on `created_at`.
 
 Checks going green is not proof the inline comments have landed, especially on
 a re-review after a push. If the comment list looks unchanged from before your
 push, wait and re-fetch before concluding the review found nothing.
 
-Two mechanics worth knowing:
+Three mechanics worth knowing:
 
 - The single-comment route is `/pulls/comments/{id}`, **not**
   `/pulls/<N>/comments/{id}` — the latter 404s. Easiest is to fetch the list
   once and filter locally.
-- Findings are wrapped in `<details>` blocks and emoji-heavy. When parsing with
-  Python, set `PYTHONIOENCODING=utf-8` or strip to ASCII; this console is cp1252
-  and will raise `UnicodeEncodeError` on the severity emoji.
-
-CodeRabbit marks its findings with severity and often collapses detail inside
-`<details>` blocks — read the whole body, not the first line. It also posts
-"Nitpick" and "Outside diff range" sections that are advisory.
+- CodeRabbit collapses most of each finding inside `<details>` blocks, so a
+  one-line-per-comment summary shows only the severity tag. Read the whole
+  body. "Nitpick" and "Outside diff range" sections are advisory.
+- The bodies are emoji-heavy. When parsing with Python, set
+  `PYTHONIOENCODING=utf-8` or strip to ASCII; this console is cp1252 and will
+  raise `UnicodeEncodeError` on the severity emoji.
 
 ## 5. Judge each comment before acting
 

--- a/app/config.py
+++ b/app/config.py
@@ -93,6 +93,40 @@ class Settings(BaseSettings):
     # ad-hoc bookings back on the original Selenium flow.
     walden_fast_booking_immediate: bool = True
 
+    # Seconds an ad-hoc booking waits before firing Reserve, instead of firing
+    # as soon as the sheet is staged.
+    #
+    # This exists to make ad-hoc bookings run the *same* code as the 6:30 race.
+    # Every timed-path behaviour - slot pre-location, clock-skew probing, the
+    # precision wait, and above all a session that has sat idle since it was
+    # staged - is gated on `execute_at` being set, not on the hour being 06:30.
+    # Firing ad-hoc immediately meant the machinery that decides the only
+    # booking that matters was exercised once a day, unobserved, against slots
+    # a dozen members were racing us for.
+    #
+    # With a delay set, a Tuesday-afternoon booking nobody is competing for
+    # runs the whole race path. A refusal there cannot be another member, so it
+    # is a refusal we caused - which is the thing five straight lost mornings
+    # could not distinguish. 90s brackets the ~68s the 6:30 job stages ahead;
+    # sweep it (15/60/120/300) to find out whether failures track the wait.
+    #
+    # 0 restores the old fire-immediately behaviour.
+    walden_adhoc_execute_delay_s: int = 90
+
+    # After an ad-hoc booking is refused on the timed path above, re-attempt it
+    # on the untimed one - a fresh session firing Reserve straight away, which
+    # is exactly what ad-hoc bookings did before the delay existed.
+    #
+    # Two jobs. It keeps ad-hoc bookings working while the timed path is under
+    # suspicion, and it turns every one of them into a controlled pair: same
+    # tee time, same day, same code, minutes apart, differing only in the wait.
+    # A timed refusal followed by an untimed success is the comparison that
+    # settles what the club's "blocked by another user" actually means.
+    #
+    # Only ever attempted for a result that carries `verified_not_reserved`, so
+    # a Reserve whose outcome is unknown is never sent twice.
+    walden_adhoc_untimed_retry: bool = True
+
     user_phone_number: str = ""
 
     database_url: str = "sqlite+aiosqlite:///./teetime.db"

--- a/app/providers/base.py
+++ b/app/providers/base.py
@@ -25,6 +25,16 @@ class BookingResult:
     error_message: str | None = None
     alternatives: str | None = None
     fallback_reason: str | None = None
+    # Set only when this attempt is known to have reserved nothing: either it
+    # stopped before the Reserve POST, or the club refused it and the member's
+    # reservations page was then read and found empty.
+    #
+    # This is what makes re-attempting the same tee time safe. The default is
+    # False for "we do not know", not "nothing was booked" - a Reserve on the
+    # wire whose response was lost looks identical to one never sent, and
+    # re-attempting that one risks a second reservation the club counts against
+    # the one-round-per-day rule.
+    verified_not_reserved: bool = False
 
 
 @dataclass

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -3212,6 +3212,14 @@ class WaldenGolfProvider(ReservationProvider):
                     ),
                     booked_time=booked_time,
                     course_name=self.NORTHGATE_COURSE_NAME,
+                    # Two ways to know this refusal left nothing behind: it
+                    # stopped before anything reached the server, or it did not
+                    # and the reservations page was read and came back empty.
+                    # `blocked_held is None` is the third case - asked and could
+                    # not tell - and stays unsafe.
+                    verified_not_reserved=(
+                        blocked_phase in PRE_SUBMIT_PHASES or blocked_held is False
+                    ),
                 )
 
             if not chain_result.get("success"):

--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -1018,6 +1018,12 @@ class BookingService:
         Only results carrying ``verified_not_reserved`` are retried - a Reserve
         whose outcome could not be established is never sent twice, because a
         second reservation would collide with the club's one-round-per-day rule.
+
+        Never raises. This is a diagnostic control bolted onto a booking that
+        has already run and already has an outcome; letting a second browser
+        session's failure escape would lose those outcomes and report the
+        driver's exception to a member whose timed attempt came back with a
+        perfectly readable reason from the club.
         """
         if not settings.walden_adhoc_untimed_retry or settings.walden_adhoc_execute_delay_s <= 0:
             return results
@@ -1038,7 +1044,13 @@ class BookingService:
         )
         # A fresh session, firing at once - the configuration ad-hoc bookings
         # used before the delay existed, so the retry is the control.
-        retried = dict(await self.execute_bookings_batch(retryable, execute_at=None))
+        try:
+            retried = dict(await self.execute_bookings_batch(retryable, execute_at=None))
+        except Exception:
+            logger.exception(
+                "ADHOC_TIMED: The untimed retry failed to run; keeping the timed results"
+            )
+            return results
 
         merged: list[tuple[str, BookingResult]] = []
         for booking_id, result in results:

--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -956,7 +956,10 @@ class BookingService:
             return
 
         try:
-            results = await self.execute_bookings_batch(bookings, execute_at=None)
+            results = await self.execute_bookings_batch(
+                bookings, execute_at=self._adhoc_execute_at()
+            )
+            results = await self._retry_blocked_untimed(bookings, results)
         except Exception as e:
             logger.exception("Batch booking attempt failed for %s", booking_ids)
             for booking in bookings:
@@ -979,6 +982,80 @@ class BookingService:
                 await self._try_notify_unreported_booking(
                     booking, "The booking attempt ended without reporting a result."
                 )
+
+    def _adhoc_execute_at(self) -> datetime | None:
+        """When an ad-hoc booking should fire Reserve, or None to fire at once.
+
+        An ad-hoc booking has no window to hit, so any wait here is bought
+        deliberately: it is what routes the booking through the same timed path
+        the 6:30 race uses - pre-location, clock probing, the precision wait,
+        and a session left to age before Reserve goes out. See
+        ``walden_adhoc_execute_delay_s``.
+        """
+        delay_s = settings.walden_adhoc_execute_delay_s
+        if delay_s <= 0:
+            return None
+        execute_at = CTDateTime.to_naive_ct(CTDateTime.now()) + timedelta(seconds=delay_s)
+        logger.info(
+            "ADHOC_TIMED: Booking on the timed path - Reserve fires at %s CT (in %ds)",
+            execute_at.strftime("%H:%M:%S"),
+            delay_s,
+        )
+        return execute_at
+
+    async def _retry_blocked_untimed(
+        self,
+        bookings: list[TeeTimeBooking],
+        results: list[tuple[str, BookingResult]],
+    ) -> list[tuple[str, BookingResult]]:
+        """Re-attempt refused ad-hoc bookings with no wait, and report the pair.
+
+        The delay above is the only difference between the two attempts, which
+        is what makes the pair worth reading: same tee time, same day, same
+        code, minutes apart. A refusal that clears on the retry is one the wait
+        caused, not another member.
+
+        Only results carrying ``verified_not_reserved`` are retried - a Reserve
+        whose outcome could not be established is never sent twice, because a
+        second reservation would collide with the club's one-round-per-day rule.
+        """
+        if not settings.walden_adhoc_untimed_retry or settings.walden_adhoc_execute_delay_s <= 0:
+            return results
+
+        by_id = {booking.id: booking for booking in bookings if booking.id is not None}
+        retryable = [
+            by_id[booking_id]
+            for booking_id, result in results
+            if not result.success and result.verified_not_reserved and booking_id in by_id
+        ]
+        if not retryable:
+            return results
+
+        logger.info(
+            "ADHOC_TIMED: %d booking(s) refused on the timed path with nothing reserved; "
+            "re-attempting untimed to isolate the wait",
+            len(retryable),
+        )
+        # A fresh session, firing at once - the configuration ad-hoc bookings
+        # used before the delay existed, so the retry is the control.
+        retried = dict(await self.execute_bookings_batch(retryable, execute_at=None))
+
+        merged: list[tuple[str, BookingResult]] = []
+        for booking_id, result in results:
+            retry = retried.get(booking_id)
+            if retry is None:
+                merged.append((booking_id, result))
+                continue
+            logger.info(
+                "ADHOC_TIMED: %s - timed attempt refused (%s), untimed retry %s",
+                booking_id,
+                result.error_message,
+                f"booked {retry.booked_time}"
+                if retry.success
+                else f"also failed: {retry.error_message}",
+            )
+            merged.append((booking_id, retry))
+        return merged
 
     async def _try_notify_booking_result(
         self, booking: TeeTimeBooking, result: BookingResult

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -244,6 +244,16 @@ resource "google_cloud_run_v2_service" "teetime" {
       }
 
       env {
+        name  = "WALDEN_ADHOC_EXECUTE_DELAY_S"
+        value = tostring(var.walden_adhoc_execute_delay_s)
+      }
+
+      env {
+        name  = "WALDEN_ADHOC_UNTIMED_RETRY"
+        value = tostring(var.walden_adhoc_untimed_retry)
+      }
+
+      env {
         name  = "WALDEN_FAST_BOOKING_IMMEDIATE"
         value = tostring(var.walden_fast_booking_immediate)
       }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -196,6 +196,16 @@ variable "walden_adhoc_execute_delay_s" {
   EOT
   type        = number
   default     = 90
+
+  validation {
+    # Whole seconds, and not negative. The setting is read into an `int`, so a
+    # fractional value reaches the container as "90.5" and stops it booting -
+    # a deploy-time failure for something a plan can catch. The upper bound is
+    # a sanity rail: past ten minutes the ad-hoc booking has stopped being a
+    # booking, and Cloud Run's request budget is not the place to find out.
+    condition     = var.walden_adhoc_execute_delay_s == floor(var.walden_adhoc_execute_delay_s) && var.walden_adhoc_execute_delay_s >= 0 && var.walden_adhoc_execute_delay_s <= 600
+    error_message = "walden_adhoc_execute_delay_s must be a whole number of seconds between 0 and 600."
+  }
 }
 
 variable "walden_adhoc_untimed_retry" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -175,6 +175,48 @@ variable "walden_refresh_view_at_window" {
   default     = false
 }
 
+variable "walden_adhoc_execute_delay_s" {
+  description = <<-EOT
+    Seconds an ad-hoc booking waits before firing Reserve, instead of firing as
+    soon as the tee sheet is staged.
+
+    The wait is the point. Every timed-path behaviour - slot pre-location,
+    clock-skew probing, the precision wait, and a session left to age before
+    Reserve goes out - is gated on execute_at being set, not on the hour being
+    06:30. Firing ad-hoc immediately left the machinery that decides the only
+    booking that matters exercised once a day, unobserved, against slots a
+    dozen members were racing us for.
+
+    With a delay, a Tuesday-afternoon booking nobody wants runs the whole race
+    path, where a refusal cannot be another member and so is one we caused.
+
+    90s brackets the ~68s the 6:30 job stages ahead. Sweep it (15/60/120/300)
+    to find out whether refusals track the length of the wait. 0 restores the
+    old fire-immediately behaviour.
+  EOT
+  type        = number
+  default     = 90
+}
+
+variable "walden_adhoc_untimed_retry" {
+  description = <<-EOT
+    After an ad-hoc booking is refused on the timed path, re-attempt it on the
+    untimed one - a fresh session firing Reserve at once, which is what ad-hoc
+    bookings did before the delay existed.
+
+    Keeps ad-hoc bookings working while the timed path is under suspicion, and
+    turns each one into a controlled pair: same tee time, same day, same code,
+    minutes apart, differing only in the wait. A timed refusal that clears on
+    the untimed retry is the comparison that says what the club's "blocked by
+    another user" actually means.
+
+    Only results known to have reserved nothing are retried, so a Reserve whose
+    outcome could not be established is never sent twice.
+  EOT
+  type        = bool
+  default     = true
+}
+
 variable "walden_measure_clock_skew" {
   description = <<-EOT
     Probe the club's clock while staging, and send the Reserve early enough to

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.config import settings
 from app.models.schemas import (
     BookingStatus,
     ConversationState,
@@ -2344,8 +2345,12 @@ class TestImmediateMultiBookingRunsAsOneBatch:
 
         batch_requests = provider.book_multiple_tee_times.await_args.kwargs["requests"]
         assert [item.target_time for item in batch_requests] == [time(17, 0), time(17, 8)]
-        # Off-race, so nothing to wait for before firing.
-        assert provider.book_multiple_tee_times.await_args.kwargs["execute_at"] is None
+        # Off-race, but deliberately not fired at once: ad-hoc bookings run the
+        # same timed path as the 6:30 job so that path gets exercised somewhere
+        # a refusal is readable. `now` is pinned above, so this is exact.
+        assert provider.book_multiple_tee_times.await_args.kwargs["execute_at"] == self.NOW_CT + (
+            timedelta(seconds=settings.walden_adhoc_execute_delay_s)
+        )
 
         # Both outcomes still reach the user, in the channel they asked from.
         assert mock_sms.send_booking_confirmation.await_count == 2
@@ -2899,3 +2904,180 @@ class TestImmediateBookingDoesNotBlockReply:
             await booking_service.wait_for_background_bookings()
 
         assert not booking_service._background_tasks
+
+
+class TestAdhocBookingsRunTheTimedPath:
+    """Ad-hoc bookings fire Reserve on a delay, the way the 6:30 race does.
+
+    Every behaviour that decides the 6:30 booking - slot pre-location, clock
+    probing, the precision wait, and a session left to age before Reserve goes
+    out - is gated on `execute_at` being set rather than on the hour. Firing
+    ad-hoc bookings immediately meant that machinery ran once a day, unobserved,
+    against slots other members were racing us for, and five straight lost
+    mornings could not say whether the club's "blocked by another user" was a
+    member or something we did to ourselves.
+
+    Routing ad-hoc bookings through the same path makes that answerable: a
+    refusal on a Tuesday afternoon nobody is competing for cannot be a member.
+    """
+
+    @staticmethod
+    def _booking(booking_id: str) -> TeeTimeBooking:
+        return TeeTimeBooking(
+            id=booking_id,
+            phone_number="+15551234567",
+            request=TeeTimeRequest(
+                requested_date=date(2025, 12, 20),
+                requested_time=time(14, 0),
+                num_players=4,
+            ),
+            status=BookingStatus.SCHEDULED,
+            scheduled_execution_time=datetime(2025, 12, 20, 6, 30),
+        )
+
+    @staticmethod
+    def _blocked(*, verified: bool) -> BookingResult:
+        return BookingResult(
+            success=False,
+            error_message="Slot blocked by another user",
+            verified_not_reserved=verified,
+        )
+
+    async def _run(
+        self,
+        service: BookingService,
+        results: list[list[tuple[str, BookingResult]]],
+        *,
+        delay_s: int = 90,
+        retry: bool = True,
+    ) -> list[tuple[datetime | None, list[str]]]:
+        """Drive _run_bookings_batch, recording each batch call's execute_at.
+
+        Returns one (execute_at, booking_ids) per call, which is what the
+        timed-then-untimed pairing is asserted on.
+        """
+        booking = self._booking("adhoc1")
+        calls: list[tuple[datetime | None, list[str]]] = []
+        pending = list(results)
+
+        async def fake_batch(
+            bookings: list[TeeTimeBooking], execute_at: datetime | None = None
+        ) -> list[tuple[str, BookingResult]]:
+            calls.append((execute_at, [b.id or "" for b in bookings]))
+            return pending.pop(0)
+
+        service.execute_bookings_batch = AsyncMock(side_effect=fake_batch)  # type: ignore[method-assign]
+        service.get_booking = AsyncMock(return_value=booking)  # type: ignore[method-assign]
+        service._try_notify_booking_result = AsyncMock()  # type: ignore[method-assign]
+        service._try_notify_unreported_booking = AsyncMock()  # type: ignore[method-assign]
+
+        with patch("app.services.booking_service.settings") as mock_settings:
+            mock_settings.walden_adhoc_execute_delay_s = delay_s
+            mock_settings.walden_adhoc_untimed_retry = retry
+            await service._run_bookings_batch(["adhoc1"])
+
+        return calls
+
+    @pytest.mark.asyncio
+    async def test_adhoc_booking_is_scheduled_rather_than_fired_at_once(
+        self, booking_service: BookingService
+    ) -> None:
+        """The first attempt carries a future execute_at, not None."""
+        calls = await self._run(
+            booking_service,
+            [[("adhoc1", BookingResult(success=True, booked_time=time(14, 0)))]],
+        )
+
+        assert len(calls) == 1
+        execute_at, _ = calls[0]
+        assert execute_at is not None
+        # Roughly the configured wait; the exact instant depends on when the
+        # call was made, so only the ballpark is meaningful.
+        delta = (execute_at - CTDateTime.to_naive_ct(CTDateTime.now())).total_seconds()
+        assert 80 <= delta <= 90
+
+    @pytest.mark.asyncio
+    async def test_zero_delay_restores_firing_immediately(
+        self, booking_service: BookingService
+    ) -> None:
+        """A delay of 0 is the way back to the old ad-hoc behaviour."""
+        calls = await self._run(
+            booking_service,
+            [[("adhoc1", BookingResult(success=True, booked_time=time(14, 0)))]],
+            delay_s=0,
+        )
+
+        assert calls == [(None, ["adhoc1"])]
+
+    @pytest.mark.asyncio
+    async def test_a_verified_refusal_is_retried_without_the_wait(
+        self, booking_service: BookingService
+    ) -> None:
+        """The retry is the control: same booking, same code, no delay."""
+        calls = await self._run(
+            booking_service,
+            [
+                [("adhoc1", self._blocked(verified=True))],
+                [("adhoc1", BookingResult(success=True, booked_time=time(14, 0)))],
+            ],
+        )
+
+        assert len(calls) == 2
+        assert calls[0][0] is not None, "first attempt should be the timed one"
+        assert calls[1] == (None, ["adhoc1"]), "retry should fire immediately"
+
+    @pytest.mark.asyncio
+    async def test_the_retry_result_is_the_one_reported(
+        self, booking_service: BookingService
+    ) -> None:
+        """A booking rescued by the retry is reported as the success it is."""
+        booked = BookingResult(success=True, booked_time=time(14, 0))
+        booking_service._try_notify_booking_result = AsyncMock()  # type: ignore[method-assign]
+        await self._run(
+            booking_service,
+            [[("adhoc1", self._blocked(verified=True))], [("adhoc1", booked)]],
+        )
+
+        reported = booking_service._try_notify_booking_result.await_args_list  # type: ignore[attr-defined]
+        assert len(reported) == 1
+        assert reported[0].args[1] is booked
+
+    @pytest.mark.asyncio
+    async def test_an_unverified_refusal_is_never_sent_twice(
+        self, booking_service: BookingService
+    ) -> None:
+        """The safety property: an unknown outcome is not re-attempted.
+
+        A Reserve on the wire whose response was lost is indistinguishable from
+        one never sent. Retrying that would risk a second reservation, which the
+        club counts against the one-round-per-day rule.
+        """
+        calls = await self._run(
+            booking_service,
+            [[("adhoc1", self._blocked(verified=False))]],
+        )
+
+        assert len(calls) == 1, "an unverified refusal must not be retried"
+
+    @pytest.mark.asyncio
+    async def test_a_successful_booking_is_not_retried(
+        self, booking_service: BookingService
+    ) -> None:
+        """Nothing to isolate when the timed path worked."""
+        calls = await self._run(
+            booking_service,
+            [[("adhoc1", BookingResult(success=True, booked_time=time(14, 0)))]],
+        )
+
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_can_be_switched_off(self, booking_service: BookingService) -> None:
+        """With the retry off, a refusal stands - the raw timed-path behaviour."""
+        calls = await self._run(
+            booking_service,
+            [[("adhoc1", self._blocked(verified=True))]],
+            retry=False,
+        )
+
+        assert len(calls) == 1

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -2950,13 +2950,14 @@ class TestAdhocBookingsRunTheTimedPath:
         *,
         delay_s: int = 90,
         retry: bool = True,
+        booking_ids: tuple[str, ...] = ("adhoc1",),
     ) -> list[tuple[datetime | None, list[str]]]:
         """Drive _run_bookings_batch, recording each batch call's execute_at.
 
         Returns one (execute_at, booking_ids) per call, which is what the
         timed-then-untimed pairing is asserted on.
         """
-        booking = self._booking("adhoc1")
+        by_id = {booking_id: self._booking(booking_id) for booking_id in booking_ids}
         calls: list[tuple[datetime | None, list[str]]] = []
         pending = list(results)
 
@@ -2966,15 +2967,18 @@ class TestAdhocBookingsRunTheTimedPath:
             calls.append((execute_at, [b.id or "" for b in bookings]))
             return pending.pop(0)
 
+        async def fake_get(booking_id: str) -> TeeTimeBooking | None:
+            return by_id.get(booking_id)
+
         service.execute_bookings_batch = AsyncMock(side_effect=fake_batch)  # type: ignore[method-assign]
-        service.get_booking = AsyncMock(return_value=booking)  # type: ignore[method-assign]
+        service.get_booking = AsyncMock(side_effect=fake_get)  # type: ignore[method-assign]
         service._try_notify_booking_result = AsyncMock()  # type: ignore[method-assign]
         service._try_notify_unreported_booking = AsyncMock()  # type: ignore[method-assign]
 
         with patch("app.services.booking_service.settings") as mock_settings:
             mock_settings.walden_adhoc_execute_delay_s = delay_s
             mock_settings.walden_adhoc_untimed_retry = retry
-            await service._run_bookings_batch(["adhoc1"])
+            await service._run_bookings_batch(list(booking_ids))
 
         return calls
 
@@ -3032,7 +3036,6 @@ class TestAdhocBookingsRunTheTimedPath:
     ) -> None:
         """A booking rescued by the retry is reported as the success it is."""
         booked = BookingResult(success=True, booked_time=time(14, 0))
-        booking_service._try_notify_booking_result = AsyncMock()  # type: ignore[method-assign]
         await self._run(
             booking_service,
             [[("adhoc1", self._blocked(verified=True))], [("adhoc1", booked)]],
@@ -3081,3 +3084,73 @@ class TestAdhocBookingsRunTheTimedPath:
         )
 
         assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_neighbours_retry_does_not_disturb_a_booking_that_worked(
+        self, booking_service: BookingService
+    ) -> None:
+        """Only the refused booking is re-attempted, and only it is rewritten.
+
+        Two tee times go out together; one is refused and one is booked. The
+        retry carries just the refused one, and the booked one has to come back
+        through the merge untouched - it is already a reservation, and reporting
+        a neighbour's retry against it would tell the member the wrong outcome.
+        """
+        first = BookingResult(success=True, booked_time=time(14, 0))
+        rescued = BookingResult(success=True, booked_time=time(14, 8))
+        calls = await self._run(
+            booking_service,
+            [
+                [("adhoc1", first), ("adhoc2", self._blocked(verified=True))],
+                [("adhoc2", rescued)],
+            ],
+            booking_ids=("adhoc1", "adhoc2"),
+        )
+
+        assert calls[0][1] == ["adhoc1", "adhoc2"]
+        assert calls[1] == (None, ["adhoc2"]), "only the refused booking is retried"
+
+        reported = {
+            call.args[0].id: call.args[1]
+            for call in booking_service._try_notify_booking_result.await_args_list  # type: ignore[attr-defined]
+        }
+        assert reported["adhoc1"] is first, "the booked tee time must survive the merge"
+        assert reported["adhoc2"] is rescued
+
+    @pytest.mark.asyncio
+    async def test_a_failing_retry_leaves_the_timed_results_intact(
+        self, booking_service: BookingService
+    ) -> None:
+        """The retry is a control, so its own failure must not lose an outcome.
+
+        It runs a second browser session, which can die for reasons that say
+        nothing about the booking. Letting that escape would replace the club's
+        readable refusal with a driver stack trace for every booking in the run.
+        """
+        refusal = self._blocked(verified=True)
+        booking = self._booking("adhoc1")
+        calls: list[datetime | None] = []
+
+        async def fake_batch(
+            bookings: list[TeeTimeBooking], execute_at: datetime | None = None
+        ) -> list[tuple[str, BookingResult]]:
+            calls.append(execute_at)
+            if execute_at is None:
+                raise RuntimeError("chromedriver died")
+            return [("adhoc1", refusal)]
+
+        booking_service.execute_bookings_batch = AsyncMock(side_effect=fake_batch)  # type: ignore[method-assign]
+        booking_service.get_booking = AsyncMock(return_value=booking)  # type: ignore[method-assign]
+        booking_service._try_notify_booking_result = AsyncMock()  # type: ignore[method-assign]
+        booking_service._try_notify_unreported_booking = AsyncMock()  # type: ignore[method-assign]
+
+        with patch("app.services.booking_service.settings") as mock_settings:
+            mock_settings.walden_adhoc_execute_delay_s = 90
+            mock_settings.walden_adhoc_untimed_retry = True
+            await booking_service._run_bookings_batch(["adhoc1"])
+
+        assert len(calls) == 2, "the retry should have been attempted"
+        reported = booking_service._try_notify_booking_result.await_args_list  # type: ignore[attr-defined]
+        assert len(reported) == 1
+        assert reported[0].args[1] is refusal, "the club's own refusal is what the member hears"
+        booking_service._try_notify_unreported_booking.assert_not_awaited()  # type: ignore[attr-defined]

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -3781,6 +3781,10 @@ class TestBlockedSlotResolution:
         assert result.error_message == "Slot blocked by another user"
         reservation_check.assert_not_called()
         artifact_capture.assert_not_called()
+        # The safety rule holds for this chain too. Its phase is past the
+        # Reserve and the reservations page was never read, so whether the slot
+        # is held is unknown - and unknown must not authorise a second attempt.
+        assert result.verified_not_reserved is False
 
 
 class TestBrowserErrorMessageExtraction:

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -3722,6 +3722,49 @@ class TestBlockedSlotResolution:
         assert result.error_message == "Slot blocked by another user"
         reservation_check.assert_not_called()
 
+    def test_a_refusal_with_the_page_read_empty_is_safe_to_re_attempt(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reserve went out, the club refused it, and no reservation exists.
+
+        This is what lets the ad-hoc path retry the same tee time untimed and
+        turn a lost booking into the timed/untimed pair that says whether the
+        wait caused the refusal.
+        """
+        result, _, _ = self._book(
+            provider, monkeypatch, self._blocked_chain(), reservation_exists=False
+        )
+
+        assert result.verified_not_reserved is True
+
+    def test_a_refusal_before_reserve_was_sent_is_safe_to_re_attempt(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nothing reached the server, so nothing can have been held."""
+        result, _, _ = self._book(
+            provider,
+            monkeypatch,
+            self._blocked_chain(phase=PHASE_RESERVE_STAGED),
+            reservation_exists=None,
+        )
+
+        assert result.verified_not_reserved is True
+
+    def test_an_unreadable_reservations_page_is_not_safe_to_re_attempt(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The safety property behind the ad-hoc retry.
+
+        A Reserve on the wire whose outcome could not be established looks
+        exactly like one never sent. Re-attempting it risks a second
+        reservation, which the club counts against one round per member per day.
+        """
+        result, _, _ = self._book(
+            provider, monkeypatch, self._blocked_chain(), reservation_exists=None
+        )
+
+        assert result.verified_not_reserved is False
+
     def test_a_js_chain_block_answers_from_the_browser(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Why

Five straight mornings ended with the club answering every Reserve `This slot is blocked by another user`, and no way to tell whether that meant a member beat us or we refused ourselves.

The one configuration that has ever produced a confirmed booking is the ad-hoc path, and it differs from the race in one respect that matters: it fires Reserve ~2s after staging, where the 6:30 job fires ~68s after.

Everything the race does differently — slot pre-location, clock-skew probing, the precision wait, and a session left to age before Reserve goes out — is gated on `execute_at` being set, not on the hour being 06:30. So the machinery deciding the only booking that matters ran once a day, unobserved, against slots a dozen members were racing us for.

## What

Ad-hoc bookings now set `execute_at` to a configurable delay ahead and run the same path. A refusal on a Tuesday afternoon nobody is competing for cannot be another member — which is the distinction five lost mornings could not draw.

- **`walden_adhoc_execute_delay_s`** (default 90s, brackets the ~68s the job stages ahead). Sweep it (15/60/120/300) to find out whether refusals track the length of the wait. `0` restores fire-immediately.
- **`walden_adhoc_untimed_retry`** (default on) — a refused ad-hoc booking is re-attempted untimed: a fresh session firing at once, which is exactly the old ad-hoc configuration, so the retry is a proper control. Each ad-hoc booking becomes a controlled pair — same tee time, same day, same code, minutes apart, differing only in the wait.
- **`BookingResult.verified_not_reserved`** — the safety gate on that retry.

Nothing in the provider needed touching: Step 7 already computes its delay from whatever `execute_at` it is handed.

## The safety property

Only a result carrying `verified_not_reserved` is retried. A Reserve on the wire whose outcome could not be established looks exactly like one never sent, and a second reservation would collide with the club's one-round-per-member-per-day rule.

The provider already asked the reservations page after a blocked verdict and already distinguished three outcomes — held, verified absent, couldn't tell. The new field surfaces which one; only verified-absent (or a stop before the Reserve POST) is retried.

## Reading the results

| Outcome | Meaning |
|---|---|
| Timed refused, untimed succeeds | The wait causes it — we lose to our own code |
| Both succeed | Timed machinery is sound; we are genuinely outraced at 6:30 |
| Both refused | Something in the booking itself, unrelated to timing |

## Notes

- One existing assertion changed rather than added: `test_both_bookings_run_in_a_single_batched_attempt` asserted `execute_at is None` with the comment "Off-race, so nothing to wait for before firing" — that assertion *was* the old behaviour. Its actual subject (two bookings, one session) is untouched.
- Accepted cost: ad-hoc bookings get ~90s slower, and if the reading is right the timed attempt fails before the retry rescues it. A rescued booking is still a real reservation consuming that date's allowance.
- Terraform CLI unavailable locally, so `validate` did not run here; the two new variable blocks mirror the existing ones structurally.
- Also adds the `booking-postmortem` skill: the log query, artifact paths, and the causes already ruled out with the evidence that ruled them out.

## Test plan

- [x] 867 tests pass, ruff + mypy clean
- [x] New: 7 tests on the ad-hoc timed path (delay applied, 0 restores old behaviour, verified refusal retried untimed, retry result reported, **unverified refusal never sent twice**, success not retried, retry switchable)
- [x] New: 3 provider tests on `verified_not_reserved` (page read empty → safe; pre-submit → safe; unreadable page → not safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Ad-hoc bookings now use a configurable timed execution delay.
  - Confirmed non-reservations can automatically retry immediately through the untimed path.
  - Retry behavior and execution delay can be configured during deployment.

- **Bug Fixes**
  - Prevented retries when reservation status is uncertain, reducing duplicate-booking risk.
  - Booking results now distinguish confirmed non-reservations from unknown outcomes.

- **Documentation**
  - Added workflows for diagnosing failed morning bookings and safely shipping pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->