### PR TITLE
Post-mortem for the 2026-08-13 booking run, and read-only artifact access

### DIFF
--- a/docs/booking-post-mortem-2026-08-13.md
+++ b/docs/booking-post-mortem-2026-08-13.md
@@ -105,6 +105,32 @@ POST is reported as contention, whatever the cause.
 
 ---
 
+## The alert was not late — it fired inside the window minute
+
+The `7:30 AM` on the notification is Discord rendering in the viewing device's
+local timezone, and the member's phone is on ET. The club is on CT, so that
+timestamp is **06:30 CT** — the window minute itself, not an hour after it.
+
+Two consequences:
+
+- **The whole run fit inside ~60 seconds of 06:30:00.** Login, sheet scan, the
+  Reserve ladder, the remaining chain steps, the reservations check and the
+  notification all completed within that minute. Any theory that has the bot
+  grinding for minutes before giving up is out.
+- **The 06:28 job fired on time and the pipeline ran end to end.** Whatever went
+  wrong went wrong inside the booking logic, not in scheduling or delivery.
+
+Caveat: this assumes the phone was on ET this morning too, not just now. The
+`send_booking_failure` log timestamp confirms it to the second and is worth
+reading anyway, since seconds-past-window is what the ledger has to be aligned
+against.
+
+Worth carrying forward as a standing hazard: the member reads in ET, the club
+runs in CT, and every log line and artifact name is in one or the other. A
+one-hour misread is available at every step of every future post-mortem.
+
+---
+
 ## The shared login breaks the verification oracle
 
 `_reservation_exists` asks the member's reservations page whether the tee time
@@ -144,7 +170,7 @@ unusually valuable even if the race was lost fairly.
 | Did the reservations check say False, or fail to read | `RESERVATION_CHECK:` |
 | Was 08:00 already gone when the bot scanned the sheet | `pre_window_sheet_.../tee_sheet.html`, `Slot scan of N row(s)` |
 | Did the 6:30 run report this, or a later attempt | count of `/jobs/execute-due-bookings` invocations |
-| Is the 7:30 alert an hour late, or 06:30 CT on an ET clock | the log timestamp of the `send_booking_failure` call |
+| Exact second the failure was sent (to align the ledger) | timestamp of the `send_booking_failure` call |
 
 A refusal at attempt 1 (+0ms) cannot be explained by a *completed* manual
 booking — nobody clicks through four players and Book Now in zero milliseconds.
@@ -184,9 +210,12 @@ is testable without a booking: log in twice as the same member, stage a view in
 session A, log in as session B, then act in session A. `scripts/probe_direct_http.py`
 already does read-only component work with an adopted cookie jar and is the
 natural place to extend. Needs `WALDEN_MEMBER_NUMBER` / `WALDEN_PASSWORD`.
-Worth asking whether he was logged in on 08-06/07/09 — and specifically whether
-he was *not* on 08-12, the 5:00 PM afternoon slot that still saw ~1.2s of
-refusals with nobody competing.
+The obvious way to kill this hypothesis cheaply would be 08-12 — the 5:00 PM
+afternoon slot that still saw ~1.2s of refusals with nobody plausibly competing.
+If his father was not logged in that afternoon, the ~1s boundary is independent
+of him and C dies. **The member does not know**, so that test is unavailable and
+C stays alive until the concurrent-session probe runs. The artifacts cannot
+settle it either — no log line records whether a second human was signed in.
 
 **A (weakened). The bot got the hold and misreported it.** Still consistent with
 findings 2 and 3, but it no longer has the screenshot behind it. The ledger's

--- a/docs/booking-post-mortem-2026-08-13.md
+++ b/docs/booking-post-mortem-2026-08-13.md
@@ -1,0 +1,173 @@
+# Booking post-mortem: 2026-08-13
+
+**Target:** Thursday 2026-08-20, 08:00 AM, 4 players, Northgate
+**Window:** Thursday 2026-08-13 06:30:00 CT (job fires 06:28)
+**Reported to the member:** `Unable to book tee time for Thursday, August 20 at
+08:00 AM for 4 players: Reservation Alert: This slot is blocked by another user.`
+**Code that ran:** `cffa99a` (#146) merged 2026-08-12 20:53 CT — the first
+morning with the Reserve ladder, the shape-based verdict, and the race ledger.
+
+---
+
+## Headline
+
+The tee sheet afterwards shows 08:00 AM held by `Garner, Ron` with three
+`(Garner, Ron)` TBD guests — the shape of a four-player booking by the
+logged-in member — while 07:53 and 08:38 are still Available. So the most
+likely reading is that the club gave us the tee time and the run told the
+member it had not.
+
+The reason the member was given is provably not a verdict. It is the inert,
+view-scoped validation popup, and it is what this code reports for *any*
+direct-HTTP failure at or past the Reserve POST, whatever the actual cause.
+
+---
+
+## Established from artifacts, no logs required
+
+**1. The member-facing string is the popup, and the popup rides along on
+responses the club accepted.** `find_response_message()` returns exactly the
+reported sentence from all five saved Reserve responses — including both the
+club *accepted*:
+
+```python
+import gzip, pathlib
+from app.providers.walden_http import parse_html
+from app.providers.walden_http_booker import classify_reserve_response, find_response_message
+
+for p in sorted(pathlib.Path("tests/fixtures/reserve_responses").glob("*.gz")):
+    markup = gzip.open(p, "rt", errors="replace").read()
+    print(p.name, classify_reserve_response(parse_html(markup), markup)[0],
+          repr(find_response_message(markup)))
+```
+
+| fixture | verdict | `find_response_message()` |
+|---|---|---|
+| 20260806_refused | refused | `Reservation Alert: This slot is blocked by another user.` |
+| 20260807_refused | refused | `Reservation Alert: This slot is blocked by another user.` |
+| **20260808_accepted** | **accepted** | `Reservation Alert: This slot is blocked by another user.` |
+| 20260809_refused | refused | `Reservation Alert: This slot is blocked by another user.` |
+| **20260812_accepted** | **accepted** | `Reservation Alert: This slot is blocked by another user.` |
+
+`Reservation Alert:` is the popup's `ui-dialog-title` and
+`This slot is blocked by another user.` its content label, inside
+`teeSheetValidationErrorPopup`. `find_response_message()` skips containers with
+`aria-hidden="true"` and containers under a hidden ancestor; this dialog carries
+`class="ui-hidden-container"` and **no** `aria-hidden`, so it is always
+collected. This is the trap #146 closed for the *verdict*, still open on the
+*message*.
+
+**2. Which code path reported the failure.** The string reached the member as
+`site_message`, i.e. `chain_result["responseMessage"]` through
+`_member_facing_failure` — `walden_provider.py:3285` (chain failed at a phase)
+or `:3356` (chain completed, response did not confirm). It cannot have come from
+the blocked-verdict branch at `:3221`, which passes `site_message=None` and would
+have read `Slot blocked by another user` with no `Reservation Alert:` prefix.
+
+**#146's ladder and classifier are therefore not the source of this failure
+report.** Whatever went wrong, the Reserve verdict was not it.
+
+The browser path is also an unlikely source: `_extract_booking_error_message`
+filters on `is_displayed()` and joins with `" | "`, where the direct-HTTP path
+joins with `"; "` and has no visibility test to apply.
+
+**3. `unchecked` was False.** The message carries no
+`(the member's reservations page could not be checked)` suffix. Per branch:
+
+- via `:3356` — `unchecked = held is None`, so `held is False`: the reservations
+  page **was read and did not list the tee time**.
+- via `:3285` — `held is False`, or `phase ∈ PRE_SUBMIT_PHASES` (nothing reached
+  the server, which the tee sheet contradicts), or the browser path ran.
+
+The most consistent reading is that `_reservation_exists` returned False for a
+reservation the club's own tee sheet shows. That False is load-bearing twice
+over: it suppresses the "could not be checked" caveat, and it sets
+`verified_not_reserved`, which is the gate for sending a second Reserve.
+
+**4. This is a standing reporting defect, independent of this morning.**
+`find_response_message`'s docstring says "nothing branches on it" — true, but
+`_member_facing_failure` *prefers* it over the technical account, so it is the
+only thing the member ever sees. Every direct-HTTP failure at or past the
+Reserve POST is reported as contention.
+
+---
+
+## Not established — the logs and the ledger could not be pulled
+
+No Cloud Run logs and no GCS artifacts were read for this post-mortem. This
+container has no `gcloud` and no credentials: `dl.google.com` returns 403 under
+the egress policy, and the GCS JSON API answers anonymous 401 on the debug
+bucket. Nothing below is inferred from the run's own record, because none of it
+was available.
+
+This morning should be the first with `walden/race/20260813_*/ledger.jsonl`
+(`walden_capture_race_ledger` defaults on and the scheduled path passes a target
+timestamp), which makes the missing evidence unusually valuable.
+
+---
+
+## Open questions, and what settles each
+
+| Question | Where the answer is |
+|---|---|
+| Did the club grant the slot, and at which rung? | `RACE_LEDGER: club granted ... at +Nms past the window` |
+| Clock difference or server-side grace period (§7a)? | `serverMsPastWindow` in `ledger.jsonl` — first morning it exists |
+| How far did the chain get? | `DIRECT_HTTP: Chain finished - phase=..., success=..., blocked=...` |
+| Did the reservations check say False, or could it not read? | `RESERVATION_CHECK:` |
+| Did the 6:30 run book it, or a later attempt? | count of `/jobs/execute-due-bookings` invocations |
+
+Pull with the skill's recipe at `DAY=2026-08-13`, then:
+
+```bash
+gcloud storage cp -r "gs://gen-lang-client-0822973627-teetime-debug-artifacts/walden/race/20260813_*" .
+jq -c '{attempt,sentMsPastWindow,serverMsPastWindow,verdict,sheetRows,reservationFormSlot}' ledger.jsonl
+```
+
+**The notification timestamp is itself unresolved.** Discord shows 7:30 AM. If
+the member's client is on ET that is 06:30 CT — the race reporting on itself. If
+it is on CT, the alert landed roughly an hour after a job that fires at 06:28
+with a 300s scheduler deadline and a Reserve budget of 6s, which no code path
+explains: it would mean a second attempt or an hour-long session. Worth noting
+that a Reserve fired an hour past the window against a slot *we already hold*
+would be refused, and the club words that refusal identically.
+
+---
+
+## Hypotheses
+
+**A (favoured).** The ladder crossed the boundary and the club accepted; the
+chain or the post-chain verification then misreported. The tee sheet, the ruled
+-out blocked-verdict branch, and `unchecked=False` all fit. What remains open is
+which step failed and why the reservations page came back empty.
+
+**B.** The 08:00 booking came from something other than the 6:30 race — a later
+automated attempt, or a manual booking after the alert. Then the alert may be a
+genuine loss and the tee sheet says nothing about the run. The invocation count
+and the notification's real local time discriminate.
+
+---
+
+## Recommendations
+
+1. **Stop the view-scoped popup from becoming the member-facing reason.** Apply
+   the same test `_find_new_blocked_message` already applies — only a message
+   that was not already there counts — to `find_response_message` at
+   `walden_http_booker.py:541` and `:658`, or exclude the popup unless something
+   in the payload actually shows it. Until then every failure reads as
+   contention and the real cause is invisible in the alert.
+2. **Log what the reservations check read on a miss.** `_reservation_exists`
+   logs the matched row on a hit and nothing on a False.
+   `_reservation_row_matches` requires `"tee time"` in the row text *and* the
+   date as `MM/DD/YYYY` or `MM/DD/YY`; if the dashboard renders either
+   differently the answer is False, which reads as "not booked" on a booking we
+   hold and unlocks a second Reserve.
+3. Once the ledger is read, the phase names the step to harden.
+
+**Cost:** none of this needs a morning. Item 1 is already settled against
+`tests/fixtures/reserve_responses/`. This morning's outcome is in logs and a
+ledger that already exist — only a missing ledger would push the question onto
+another day.
+
+**Today:** confirm directly on the member's reservations page whether the 08:00
+slot is held. It decides whether anyone needs to act, and the row's rendering is
+the input to recommendation 2.

--- a/docs/booking-post-mortem-2026-08-13.md
+++ b/docs/booking-post-mortem-2026-08-13.md
@@ -7,28 +7,40 @@
 **Code that ran:** `cffa99a` (#146) merged 2026-08-12 20:53 CT — the first
 morning with the Reserve ladder, the shape-based verdict, and the race ledger.
 
----
-
-## Headline
-
-The tee sheet afterwards shows 08:00 AM held by `Garner, Ron` with three
-`(Garner, Ron)` TBD guests — the shape of a four-player booking by the
-logged-in member — while 07:53 and 08:38 are still Available. So the most
-likely reading is that the club gave us the tee time and the run told the
-member it had not.
-
-The reason the member was given is provably not a verdict. It is the inert,
-view-scoped validation popup, and it is what this code reports for *any*
-direct-HTTP failure at or past the Reserve POST, whatever the actual cause.
+**Status: open.** No Cloud Run logs and no debug artifacts have been read. The
+findings below stand on the checked-in fixtures and on the code alone; the
+questions in "Still open" are the ones the artifacts settle, and none of them
+should be acted on before that.
 
 ---
 
-## Established from artifacts, no logs required
+## The fact that reframes this morning
 
-**1. The member-facing string is the popup, and the popup rides along on
-responses the club accepted.** `find_response_message()` returns exactly the
-reported sentence from all five saved Reserve responses — including both the
-club *accepted*:
+The bot books as Ron Garner. So does the member's father, by hand, from the same
+account, racing the same 06:30 window for the same slots — on this morning
+included.
+
+That has three consequences, and they matter more than anything the screenshot
+shows:
+
+1. **The tee sheet cannot say who booked it.** `Garner, Ron` plus three
+   `(Garner, Ron)` TBD guests at 08:00 is what a four-player booking on this
+   account looks like whether the bot made it or his father did. Any reading of
+   the screenshot as evidence that the bot's Reserve succeeded is withdrawn.
+2. **"Blocked by another user" may be literally true this morning.** If his
+   father completed the booking first, the club's refusal is honest and the bot
+   simply lost the race — the first morning of the five where contention is a
+   live explanation rather than a phrase the club uses for everything.
+3. **The verification oracle is no longer sound** — see below. This one holds
+   regardless of what happened this morning.
+
+---
+
+## Established from the checked-in fixtures
+
+**1. The member-facing sentence is the inert popup, not a verdict.**
+`find_response_message()` returns exactly the reported sentence from all five
+saved Reserve responses, including both the club *accepted*:
 
 ```python
 import gzip, pathlib
@@ -52,122 +64,154 @@ for p in sorted(pathlib.Path("tests/fixtures/reserve_responses").glob("*.gz")):
 `Reservation Alert:` is the popup's `ui-dialog-title` and
 `This slot is blocked by another user.` its content label, inside
 `teeSheetValidationErrorPopup`. `find_response_message()` skips containers with
-`aria-hidden="true"` and containers under a hidden ancestor; this dialog carries
+`aria-hidden="true"` or a hidden ancestor; this dialog carries
 `class="ui-hidden-container"` and **no** `aria-hidden`, so it is always
 collected. This is the trap #146 closed for the *verdict*, still open on the
 *message*.
+
+The point survives the reframing above: even if the club really was refusing
+this morning, the alert the member received is not evidence of it. The same
+sentence arrives when the club accepts.
 
 **2. Which code path reported the failure.** The string reached the member as
 `site_message`, i.e. `chain_result["responseMessage"]` through
 `_member_facing_failure` — `walden_provider.py:3285` (chain failed at a phase)
 or `:3356` (chain completed, response did not confirm). It cannot have come from
-the blocked-verdict branch at `:3221`, which passes `site_message=None` and would
-have read `Slot blocked by another user` with no `Reservation Alert:` prefix.
+the blocked-verdict branch at `:3221`, which passes `site_message=None` and
+would have read `Slot blocked by another user` with no `Reservation Alert:`
+prefix.
 
-**#146's ladder and classifier are therefore not the source of this failure
-report.** Whatever went wrong, the Reserve verdict was not it.
+So whatever happened, **the run did not report a refused Reserve verdict.** It
+reported a chain-step failure or an unconfirmed booking. #146's ladder and
+classifier are not the source of this alert. The browser path is an unlikely
+source too: `_extract_booking_error_message` filters on `is_displayed()` and
+joins with `" | "`, where the direct-HTTP path joins with `"; "` and has no
+visibility test available to it.
 
-The browser path is also an unlikely source: `_extract_booking_error_message`
-filters on `is_displayed()` and joins with `" | "`, where the direct-HTTP path
-joins with `"; "` and has no visibility test to apply.
+**3. `unchecked` was False.** The alert carries no
+`(the member's reservations page could not be checked)` suffix. Via `:3356` that
+means `held is False`; via `:3285` it means `held is False`, or
+`phase ∈ PRE_SUBMIT_PHASES`, or the browser path ran. So on the likeliest
+branches the reservations page was read and did **not** list the tee time. That
+False is load-bearing twice: it suppresses the "could not be checked" caveat,
+and it sets `verified_not_reserved`, which is the gate for sending a second
+Reserve.
 
-**3. `unchecked` was False.** The message carries no
-`(the member's reservations page could not be checked)` suffix. Per branch:
-
-- via `:3356` — `unchecked = held is None`, so `held is False`: the reservations
-  page **was read and did not list the tee time**.
-- via `:3285` — `held is False`, or `phase ∈ PRE_SUBMIT_PHASES` (nothing reached
-  the server, which the tee sheet contradicts), or the browser path ran.
-
-The most consistent reading is that `_reservation_exists` returned False for a
-reservation the club's own tee sheet shows. That False is load-bearing twice
-over: it suppresses the "could not be checked" caveat, and it sets
-`verified_not_reserved`, which is the gate for sending a second Reserve.
-
-**4. This is a standing reporting defect, independent of this morning.**
-`find_response_message`'s docstring says "nothing branches on it" — true, but
-`_member_facing_failure` *prefers* it over the technical account, so it is the
-only thing the member ever sees. Every direct-HTTP failure at or past the
-Reserve POST is reported as contention.
+**4. A standing reporting defect, independent of this morning.**
+`find_response_message`'s docstring notes that nothing branches on it — true,
+but `_member_facing_failure` *prefers* it over the technical account, so it is
+the only thing the member sees. Every direct-HTTP failure at or past the Reserve
+POST is reported as contention, whatever the cause.
 
 ---
 
-## Not established — the logs and the ledger could not be pulled
+## The shared login breaks the verification oracle
 
-No Cloud Run logs and no GCS artifacts were read for this post-mortem. This
-container has no `gcloud` and no credentials: `dl.google.com` returns 403 under
-the egress policy, and the GCS JSON API answers anonymous 401 on the debug
-bucket. Nothing below is inferred from the run's own record, because none of it
-was available.
+`_reservation_exists` asks the member's reservations page whether the tee time
+was booked. With two actors on one account that question no longer means what
+the code needs it to mean:
 
-This morning should be the first with `walden/race/20260813_*/ledger.jsonl`
-(`walden_capture_race_ledger` defaults on and the scheduled path passes a target
-timestamp), which makes the missing evidence unusually valuable.
+- **False success.** If his father's booking has landed by the time the check
+  runs, the page lists the tee time and the provider returns
+  `success=True` — "blocked at phase X but the reservation is on the member's
+  reservations page" (`walden_provider.py:3209`). The bot would claim a slot it
+  did not win. The member gets a confirmation either way, so this is benign for
+  the golf and corrosive for the diagnosis: it would look like the bot winning
+  races it is losing.
+- **Misleading False.** `held is False` only means nothing was booked *yet* — it
+  depends on whether his father had finished clicking through player count, three
+  TBD guests, and Book Now when the check ran, seconds after the window. It is
+  not evidence that the bot's own Reserve failed.
+
+Both directions are silent. Nothing in the reservations row identifies which
+session created it.
 
 ---
 
-## Open questions, and what settles each
+## Still open — what the artifacts settle
+
+Nothing below has been checked. `walden/race/20260813_*/` should be the first
+race ledger ever written (`walden_capture_race_ledger` defaults on, and the
+scheduled path passes a target timestamp), which makes this morning's artifacts
+unusually valuable even if the race was lost fairly.
 
 | Question | Where the answer is |
 |---|---|
-| Did the club grant the slot, and at which rung? | `RACE_LEDGER: club granted ... at +Nms past the window` |
-| Clock difference or server-side grace period (§7a)? | `serverMsPastWindow` in `ledger.jsonl` — first morning it exists |
-| How far did the chain get? | `DIRECT_HTTP: Chain finished - phase=..., success=..., blocked=...` |
-| Did the reservations check say False, or could it not read? | `RESERVATION_CHECK:` |
-| Did the 6:30 run book it, or a later attempt? | count of `/jobs/execute-due-bookings` invocations |
+| Did the club grant a slot at any rung, or refuse the whole ladder? | `RACE_LEDGER: club granted ... at +Nms` vs. `every attempt refused, out to +Nms` |
+| Do refusals continue past ~2s? (the first real evidence for contention) | `ledger.jsonl` — `sentMsPastWindow` on the last refusal |
+| Clock difference or server-side grace period (§7a of the skill) | `serverMsPastWindow` — the club's own `Date` header, first morning it exists |
+| How far did the chain get, and which step broke | `DIRECT_HTTP: Chain finished - phase=..., success=..., blocked=...` |
+| Did the reservations check say False, or fail to read | `RESERVATION_CHECK:` |
+| Was 08:00 already gone when the bot scanned the sheet | `pre_window_sheet_.../tee_sheet.html`, `Slot scan of N row(s)` |
+| Did the 6:30 run report this, or a later attempt | count of `/jobs/execute-due-bookings` invocations |
+| Is the 7:30 alert an hour late, or 06:30 CT on an ET clock | the log timestamp of the `send_booking_failure` call |
 
-Pull with the skill's recipe at `DAY=2026-08-13`, then:
+A refusal at attempt 1 (+0ms) cannot be explained by a *completed* manual
+booking — nobody clicks through four players and Book Now in zero milliseconds.
+It could be explained by a *hold* his father's session had already taken. Which
+of those the morning was is exactly what the ledger's per-attempt timeline, read
+against his father's plausible click times, decides.
+
+### Fetching them
+
+This post-mortem was written in an environment with no `gcloud` binary and no
+credentials (`dl.google.com` refused by egress policy, anonymous 401 on the
+debug bucket), so the fetch has to run somewhere authenticated:
 
 ```bash
+DAY=2026-08-13   # then the skill's log recipe for START/END
+gcloud storage ls -r "gs://gen-lang-client-0822973627-teetime-debug-artifacts/walden/**/20260813_*"
 gcloud storage cp -r "gs://gen-lang-client-0822973627-teetime-debug-artifacts/walden/race/20260813_*" .
 jq -c '{attempt,sentMsPastWindow,serverMsPastWindow,verdict,sheetRows,reservationFormSlot}' ledger.jsonl
 ```
 
-**The notification timestamp is itself unresolved.** Discord shows 7:30 AM. If
-the member's client is on ET that is 06:30 CT — the race reporting on itself. If
-it is on CT, the alert landed roughly an hour after a job that fires at 06:28
-with a 300s scheduler deadline and a Reserve budget of 6s, which no code path
-explains: it would mean a second attempt or an hour-long session. Worth noting
-that a Reserve fired an hour past the window against a slot *we already hold*
-would be refused, and the club words that refusal identically.
+---
+
+## Hypotheses, re-ranked
+
+**B (now favoured). His father won the slot by hand.** The club's refusal was
+truthful, the ladder was refused all the way out, and the bot lost a fair race.
+Signature: no `accepted` row in the ledger, refusals continuing well past the
+~1s boundary the previous five mornings established, and 08:00 unavailable on
+any post-window sheet the run captured.
+
+**C (new, and cheap to test off-race). Self-contention on one member account.**
+Two concurrent logins as the same member — his father's browser and the bot's
+Selenium session — may share or clobber server-side JSF state on the club's
+portal, and the club's "another user" could be the bot's own account in another
+session. This would predict refusals that track *his father being awake*, which
+is testable without a booking: log in twice as the same member, stage a view in
+session A, log in as session B, then act in session A. `scripts/probe_direct_http.py`
+already does read-only component work with an adopted cookie jar and is the
+natural place to extend. Needs `WALDEN_MEMBER_NUMBER` / `WALDEN_PASSWORD`.
+Worth asking whether he was logged in on 08-06/07/09 — and specifically whether
+he was *not* on 08-12, the 5:00 PM afternoon slot that still saw ~1.2s of
+refusals with nobody competing.
+
+**A (weakened). The bot got the hold and misreported it.** Still consistent with
+findings 2 and 3, but it no longer has the screenshot behind it. The ledger's
+verdict rows decide it outright.
 
 ---
 
-## Hypotheses
-
-**A (favoured).** The ladder crossed the boundary and the club accepted; the
-chain or the post-chain verification then misreported. The tee sheet, the ruled
--out blocked-verdict branch, and `unchecked=False` all fit. What remains open is
-which step failed and why the reservations page came back empty.
-
-**B.** The 08:00 booking came from something other than the 6:30 race — a later
-automated attempt, or a manual booking after the alert. Then the alert may be a
-genuine loss and the tee sheet says nothing about the run. The invocation count
-and the notification's real local time discriminate.
-
----
-
-## Recommendations
+## Recommendations — none to be acted on before the artifacts are read
 
 1. **Stop the view-scoped popup from becoming the member-facing reason.** Apply
-   the same test `_find_new_blocked_message` already applies — only a message
-   that was not already there counts — to `find_response_message` at
+   the test `_find_new_blocked_message` already applies — only a message that was
+   not already there counts — to `find_response_message` at
    `walden_http_booker.py:541` and `:658`, or exclude the popup unless something
-   in the payload actually shows it. Until then every failure reads as
-   contention and the real cause is invisible in the alert.
-2. **Log what the reservations check read on a miss.** `_reservation_exists`
-   logs the matched row on a hit and nothing on a False.
-   `_reservation_row_matches` requires `"tee time"` in the row text *and* the
-   date as `MM/DD/YYYY` or `MM/DD/YY`; if the dashboard renders either
-   differently the answer is False, which reads as "not booked" on a booking we
-   hold and unlocks a second Reserve.
-3. Once the ledger is read, the phase names the step to harden.
-
-**Cost:** none of this needs a morning. Item 1 is already settled against
-`tests/fixtures/reserve_responses/`. This morning's outcome is in logs and a
-ledger that already exist — only a missing ledger would push the question onto
-another day.
-
-**Today:** confirm directly on the member's reservations page whether the 08:00
-slot is held. It decides whether anyone needs to act, and the row's rendering is
-the input to recommendation 2.
+   in the payload actually shows it. This one is settled on fixtures and does not
+   depend on the artifacts; it is safe whichever way this morning went, and until
+   it lands every failure alert reads as contention.
+2. **Make the reservations check say what it saw**, and treat its answer as
+   account-wide rather than bot-specific. It logs the matched row on a hit and
+   nothing on a False, and `_reservation_row_matches` requires `"tee time"` plus
+   an `MM/DD/YYYY`-style date. With a second human on the login, a `True` is not
+   proof the bot booked it and a `False` is not proof nobody did — anything
+   gated on it (`verified_not_reserved`, and the success report at `:3209`)
+   inherits that.
+3. **Decide what losing to a family member should do.** Both actors want the same
+   tee time and only one can have it. If his father's manual booking is an
+   acceptable outcome, the honest report is "already booked on your account at
+   08:00", not "unable to book" — and the reservations check already has the
+   information to say so.

--- a/docs/debug-artifact-access.md
+++ b/docs/debug-artifact-access.md
@@ -1,0 +1,127 @@
+# Giving a remote session read access to the debug artifacts
+
+A booking post-mortem runs on two things the bot leaves behind: the debug
+artifacts in GCS and the Cloud Run logs. A Claude Code on the web session can
+reach neither by default, which is why the 2026-08-13 post-mortem had to be
+written from fixtures and code alone.
+
+This is what closes that gap. It is read-only and scoped to one bucket and the
+project's logs.
+
+## What is not needed
+
+- **The `gcloud` CLI.** `WaldenProvider._upload_bytes_to_gcs` already does GCS
+  I/O with `google.auth` + `httpx` against the JSON API, with no
+  `google-cloud-storage` dependency. `scripts/fetch_debug_artifacts.py` reads
+  them back the same way, with read-only scopes. Both libraries are already in
+  the venv.
+- **A network policy change.** `storage.googleapis.com`,
+  `logging.googleapis.com` and `oauth2.googleapis.com` are all reachable from a
+  remote session today; an unauthenticated bucket request returns a genuine GCS
+  `401`, not a proxy block. (`dl.google.com` *is* refused, which is why
+  installing the CLI fails — but the CLI is not the path.)
+
+The only missing piece is a credential.
+
+## Setting it up
+
+### 1. A read-only service account
+
+```bash
+PROJECT=gen-lang-client-0822973627
+SA=teetime-artifact-reader@$PROJECT.iam.gserviceaccount.com
+
+gcloud iam service-accounts create teetime-artifact-reader \
+  --project=$PROJECT \
+  --display-name="Read-only debug artifact + log access for post-mortems"
+
+gcloud storage buckets add-iam-policy-binding gs://$PROJECT-teetime-debug-artifacts \
+  --member=serviceAccount:$SA --role=roles/storage.objectViewer
+
+gcloud projects add-iam-policy-binding $PROJECT \
+  --member=serviceAccount:$SA --role=roles/logging.viewer
+
+gcloud iam service-accounts keys create key.json --iam-account=$SA
+base64 -w0 key.json          # macOS: base64 -i key.json
+```
+
+Make this a dedicated account. Do not reuse the Cloud Run runtime service
+account — that one can *write* to the bucket and holds whatever else the service
+needs.
+
+### 2. Environment variables
+
+In the environment's settings ([Claude Code on the web
+docs](https://code.claude.com/docs/en/claude-code-on-the-web)):
+
+| Variable | Value |
+|---|---|
+| `GCP_KEY_B64` | the base64 blob from step 1 |
+| `GOOGLE_APPLICATION_CREDENTIALS` | `/tmp/gcp-key.json` |
+| `DEBUG_ARTIFACTS_BUCKET` | `gen-lang-client-0822973627-teetime-debug-artifacts` (optional; the script defaults to it) |
+
+### 3. Setup script
+
+```bash
+echo "$GCP_KEY_B64" | base64 -d > /tmp/gcp-key.json
+chmod 600 /tmp/gcp-key.json
+```
+
+Set `GOOGLE_APPLICATION_CREDENTIALS` as an environment variable rather than
+exporting it from the setup script. The agent's shell does not inherit the
+script's exports, but environment-level variables are present on every call.
+
+### 4. Verify
+
+```bash
+poetry run python scripts/fetch_debug_artifacts.py list --date 20260813
+```
+
+A listing means it works. A `403` names the missing role; a credentials error
+means ADC never found the key file.
+
+## Using it
+
+```bash
+# What exists for a morning
+poetry run python scripts/fetch_debug_artifacts.py list --date 20260813
+
+# Pull it down; ledgers are summarized automatically
+poetry run python scripts/fetch_debug_artifacts.py fetch --date 20260813 --out ./artifacts
+
+# Cloud Run logs, in CT wall-clock
+poetry run python scripts/fetch_debug_artifacts.py logs \
+  --date 2026-08-13 --from 06:20 --to 08:00 --out run.txt
+```
+
+### The two clocks
+
+Artifact object names come from `datetime.now()` inside Cloud Run, and nothing
+sets `TZ` there, so **artifact dates are UTC**. The member reads in ET and the
+club runs in CT. A 06:30 CT run lands under the same date stamp either way; an
+evening run does not. `logs` takes CT times and converts them, so pass the times
+you mean.
+
+## Without a stored key
+
+`GCP_ACCESS_TOKEN` takes precedence over ADC, so a session can be handed a
+short-lived token instead:
+
+```bash
+export GCP_ACCESS_TOKEN=$(gcloud auth print-access-token)
+```
+
+It expires in about an hour and nothing is stored. Fine for a one-off; the
+service account is what makes a morning-after check unattended.
+
+## Costs and hygiene
+
+- A service-account key is long-lived and does not expire on its own. Delete it
+  when the investigation is done:
+  `gcloud iam service-accounts keys delete KEY_ID --iam-account=$SA`.
+- The artifacts contain live club session HTML — ViewState, and on tee-sheet
+  captures other members' names. `_flush_pre_window_sheet` deliberately keeps
+  that material out of application logs and puts it only in the bucket, so
+  bucket read access is a wider grant than log access.
+- The two roles above are the whole grant. Neither one can write, delete, or
+  book anything.

--- a/docs/debug-artifact-access.md
+++ b/docs/debug-artifact-access.md
@@ -25,6 +25,10 @@ The only missing piece is a credential.
 
 ## Setting it up
 
+**Run steps 1 and 2 on your own machine, not in a remote session.** They need
+`gcloud` and an identity that can edit IAM, and a remote session has neither —
+which is the whole reason this document exists. Only step 4 runs in a session.
+
 ### 1. A read-only service account
 
 ```bash

--- a/scripts/fetch_debug_artifacts.py
+++ b/scripts/fetch_debug_artifacts.py
@@ -1,0 +1,292 @@
+"""
+Pull the debug artifacts and Cloud Run logs a booking post-mortem runs on.
+
+The bot already writes to GCS with nothing but ``google.auth`` and ``httpx``
+(:meth:`WaldenProvider._upload_bytes_to_gcs`), so reading them back needs no
+``gcloud`` binary and no ``google-cloud-storage`` dependency - the same two
+libraries, the same JSON APIs, read-only scopes.
+
+Credentials, in order of preference:
+    1. ``GCP_ACCESS_TOKEN`` - a pasted short-lived token
+       (``gcloud auth print-access-token``). Nothing is stored; it expires in
+       about an hour.
+    2. Application Default Credentials - ``GOOGLE_APPLICATION_CREDENTIALS``
+       pointing at a service-account key. See docs/debug-artifact-access.md for
+       the read-only service account this expects.
+
+Usage::
+
+    python scripts/fetch_debug_artifacts.py list  --date 20260813
+    python scripts/fetch_debug_artifacts.py fetch --date 20260813 --out ./artifacts
+    python scripts/fetch_debug_artifacts.py logs  --date 2026-08-13 --from 06:20 --to 08:00
+    python scripts/fetch_debug_artifacts.py ledger ./artifacts/walden/race/*/ledger.jsonl
+
+A note on the two clocks, because every post-mortem trips over it. Object names
+come from :func:`datetime.now` inside Cloud Run, and nothing sets ``TZ`` there,
+so **artifact dates are UTC**. The member and the club are on CT. A 6:30 AM CT
+run lands under the same date either way; an evening run does not. ``logs``
+takes CT wall-clock times and converts them, so pass the times you actually
+mean.
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from urllib.parse import quote
+from zoneinfo import ZoneInfo
+
+import httpx
+
+try:
+    import google.auth
+    from google.auth.transport.requests import Request as GoogleAuthRequest
+except ImportError:  # pragma: no cover - only bites outside the project venv
+    google = None  # type: ignore[assignment]
+
+DEFAULT_PROJECT = "gen-lang-client-0822973627"
+DEFAULT_BUCKET = f"{DEFAULT_PROJECT}-teetime-debug-artifacts"
+DEFAULT_SERVICE = "teetime"
+CLUB_TZ = ZoneInfo("America/Chicago")
+
+SCOPES = [
+    "https://www.googleapis.com/auth/devstorage.read_only",
+    "https://www.googleapis.com/auth/logging.read",
+]
+
+
+def access_token() -> str:
+    """Return a bearer token, from a pasted token or from ADC."""
+    pasted = os.getenv("GCP_ACCESS_TOKEN")
+    if pasted:
+        return pasted.strip()
+
+    if google is None:
+        sys.exit(
+            "No GCP_ACCESS_TOKEN set and google-auth is not importable.\n"
+            "Run inside the project venv (poetry run) or paste a token:\n"
+            "  export GCP_ACCESS_TOKEN=$(gcloud auth print-access-token)"
+        )
+
+    try:
+        credentials, _ = google.auth.default(scopes=SCOPES)
+        credentials.refresh(GoogleAuthRequest())
+    except Exception as exc:  # noqa: BLE001 - the message matters more than the type
+        sys.exit(
+            f"Could not obtain credentials: {exc}\n"
+            "Set GOOGLE_APPLICATION_CREDENTIALS to a service-account key, or paste a token:\n"
+            "  export GCP_ACCESS_TOKEN=$(gcloud auth print-access-token)"
+        )
+
+    if not credentials.token:
+        sys.exit("Credentials produced no access token.")
+    return str(credentials.token)
+
+
+def list_objects(bucket: str, prefix: str, contains: str | None) -> list[dict]:
+    """List objects under a prefix, optionally filtered by a substring."""
+    token = access_token()
+    url = f"https://storage.googleapis.com/storage/v1/b/{bucket}/o"
+    headers = {"Authorization": f"Bearer {token}"}
+    params: dict[str, str] = {"prefix": prefix, "maxResults": "1000"}
+
+    found: list[dict] = []
+    with httpx.Client(timeout=60.0) as client:
+        while True:
+            resp = client.get(url, params=params, headers=headers)
+            if resp.status_code == 403:
+                sys.exit(
+                    f"403 listing gs://{bucket}. The credential lacks "
+                    "storage.objects.list - grant roles/storage.objectViewer on the bucket."
+                )
+            resp.raise_for_status()
+            body = resp.json()
+            for item in body.get("items", []):
+                if contains is None or contains in item["name"]:
+                    found.append(item)
+            page_token = body.get("nextPageToken")
+            if not page_token:
+                break
+            params["pageToken"] = page_token
+
+    return sorted(found, key=lambda i: i["name"])
+
+
+def download(bucket: str, name: str, destination: Path) -> int:
+    """Download one object, returning bytes written."""
+    token = access_token()
+    url = f"https://storage.googleapis.com/storage/v1/b/{bucket}/o/{quote(name, safe='')}"
+    with httpx.Client(timeout=120.0) as client:
+        resp = client.get(
+            url, params={"alt": "media"}, headers={"Authorization": f"Bearer {token}"}
+        )
+        resp.raise_for_status()
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(resp.content)
+    return len(resp.content)
+
+
+def read_logs(project: str, service: str, start: datetime, end: datetime) -> list[tuple[str, str]]:
+    """Read Cloud Run log entries in a UTC window, oldest first."""
+    token = access_token()
+    log_filter = (
+        'resource.type="cloud_run_revision" '
+        f'AND resource.labels.service_name="{service}" '
+        f'AND timestamp>="{start.strftime("%Y-%m-%dT%H:%M:%SZ")}" '
+        f'AND timestamp<="{end.strftime("%Y-%m-%dT%H:%M:%SZ")}" '
+        'AND textPayload!~"discord\\.gateway"'
+    )
+    body = {
+        "resourceNames": [f"projects/{project}"],
+        "filter": log_filter,
+        "orderBy": "timestamp asc",
+        "pageSize": 1000,
+    }
+
+    entries: list[tuple[str, str]] = []
+    with httpx.Client(timeout=120.0) as client:
+        while True:
+            resp = client.post(
+                "https://logging.googleapis.com/v2/entries:list",
+                json=body,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            if resp.status_code == 403:
+                sys.exit(
+                    f"403 reading logs for {project}. The credential lacks logging.logEntries.list "
+                    "- grant roles/logging.viewer on the project."
+                )
+            resp.raise_for_status()
+            payload = resp.json()
+            for entry in payload.get("entries", []):
+                text = entry.get("textPayload")
+                if text is None:
+                    text = json.dumps(entry.get("jsonPayload", {}), default=str)
+                entries.append((entry.get("timestamp", ""), text))
+            page_token = payload.get("nextPageToken")
+            if not page_token:
+                break
+            body["pageToken"] = page_token
+
+    return entries
+
+
+def summarize_ledger(path: Path) -> None:
+    """Print a race ledger compactly - one line per attempt, then the boundary."""
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    if not rows:
+        print(f"{path}: empty")
+        return
+
+    print(f"{path} - {len(rows)} attempt(s)")
+    header = f"{'#':>3}  {'sent+ms':>8}  {'server+ms':>9}  {'verdict':<9}  {'slot':<9}  {'form slot':<9}  reason"
+    print(header)
+    print("-" * len(header))
+    for row in rows:
+        print(
+            f"{row.get('attempt', '?'):>3}  "
+            f"{row.get('sentMsPastWindow', '?'):>8}  "
+            f"{row.get('serverMsPastWindow', '?'):>9}  "
+            f"{str(row.get('verdict', '?')):<9}  "
+            f"{str(row.get('slot') or '-'):<9}  "
+            f"{str(row.get('reservationFormSlot') or '-'):<9}  "
+            f"{(row.get('reason') or '')[:60]}"
+        )
+
+    refused = [r for r in rows if r.get("verdict") == "refused"]
+    granted = [r for r in rows if r.get("verdict") == "accepted"]
+    print()
+    if granted:
+        print(f"GRANTED at +{granted[0].get('sentMsPastWindow', '?')}ms - the club gave us a slot.")
+    elif refused:
+        offsets = [r["sentMsPastWindow"] for r in refused if r.get("sentMsPastWindow") is not None]
+        print(
+            f"EVERY attempt refused, out to +{max(offsets) if offsets else '?'}ms. "
+            "Refusals past ~2s are the first real evidence of contention."
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--bucket", default=os.getenv("DEBUG_ARTIFACTS_BUCKET", DEFAULT_BUCKET))
+    parser.add_argument("--project", default=DEFAULT_PROJECT)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_list = sub.add_parser("list", help="list artifacts (optionally for one date)")
+    p_list.add_argument("--date", help="UTC date stamp in object names, e.g. 20260813")
+    p_list.add_argument("--prefix", default="walden/")
+
+    p_fetch = sub.add_parser("fetch", help="download artifacts for a date")
+    p_fetch.add_argument("--date", required=True, help="UTC date stamp, e.g. 20260813")
+    p_fetch.add_argument("--prefix", default="walden/")
+    p_fetch.add_argument("--out", default="./artifacts", type=Path)
+
+    p_logs = sub.add_parser("logs", help="read Cloud Run logs for a CT window")
+    p_logs.add_argument("--date", required=True, help="CT calendar date, e.g. 2026-08-13")
+    p_logs.add_argument("--from", dest="start", default="06:20", help="CT start time HH:MM")
+    p_logs.add_argument("--to", dest="end", default="08:00", help="CT end time HH:MM")
+    p_logs.add_argument("--service", default=DEFAULT_SERVICE)
+    p_logs.add_argument("--out", type=Path, help="write here instead of stdout")
+
+    p_ledger = sub.add_parser("ledger", help="summarize a downloaded ledger.jsonl")
+    p_ledger.add_argument("path", type=Path)
+
+    args = parser.parse_args()
+
+    if args.command == "list":
+        items = list_objects(args.bucket, args.prefix, args.date)
+        if not items:
+            print(
+                f"No objects under {args.prefix}" + (f" matching {args.date}" if args.date else "")
+            )
+            return
+        for item in items:
+            print(f"{int(item.get('size', 0)):>10}  {item.get('updated', '')}  {item['name']}")
+        print(f"\n{len(items)} object(s)")
+
+    elif args.command == "fetch":
+        items = list_objects(args.bucket, args.prefix, args.date)
+        if not items:
+            print(f"No objects matching {args.date} - nothing was written for that date.")
+            return
+        for item in items:
+            destination = args.out / item["name"]
+            written = download(args.bucket, item["name"], destination)
+            print(f"{written:>10} bytes  {destination}")
+        print(f"\n{len(items)} object(s) -> {args.out}")
+
+        for item in items:
+            if item["name"].endswith("ledger.jsonl"):
+                print()
+                summarize_ledger(args.out / item["name"])
+
+    elif args.command == "logs":
+        day = datetime.strptime(args.date, "%Y-%m-%d")
+        start_ct = day.replace(
+            hour=int(args.start.split(":")[0]), minute=int(args.start.split(":")[1])
+        ).replace(tzinfo=CLUB_TZ)
+        end_ct = day.replace(
+            hour=int(args.end.split(":")[0]), minute=int(args.end.split(":")[1])
+        ).replace(tzinfo=CLUB_TZ)
+        if end_ct <= start_ct:
+            end_ct += timedelta(days=1)
+
+        entries = read_logs(args.project, args.service, start_ct, end_ct)
+        lines = [f"{timestamp} {text}" for timestamp, text in entries]
+        if args.out:
+            args.out.write_text("\n".join(lines) + "\n")
+            print(f"{len(lines)} log line(s) -> {args.out}")
+        else:
+            print("\n".join(lines))
+            print(f"\n{len(lines)} log line(s)", file=sys.stderr)
+
+    elif args.command == "ledger":
+        summarize_ledger(args.path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_debug_artifacts.py
+++ b/scripts/fetch_debug_artifacts.py
@@ -33,7 +33,7 @@ import argparse
 import json
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from urllib.parse import quote
 from zoneinfo import ZoneInfo
@@ -114,6 +114,23 @@ def list_objects(bucket: str, prefix: str, contains: str | None) -> list[dict]:
     return sorted(found, key=lambda i: i["name"])
 
 
+def _contained_destination(root: Path, object_name: str) -> Path | None:
+    """Map an object name under ``root``, or None if it would escape.
+
+    Object names are strings the bucket hands us, and GCS is happy to store one
+    containing ``../`` segments even though it forbids an object named exactly
+    ``..``. Ours never do - :meth:`WaldenProvider._upload_bytes_to_gcs` builds
+    them from a fixed prefix and a timestamp - but this writes to a real
+    filesystem on the strength of a name we did not construct, so it checks.
+    """
+    candidate = (root / object_name).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate
+
+
 def download(bucket: str, name: str, destination: Path) -> int:
     """Download one object, returning bytes written."""
     token = access_token()
@@ -128,14 +145,27 @@ def download(bucket: str, name: str, destination: Path) -> int:
     return len(resp.content)
 
 
+def _as_utc_z(moment: datetime) -> str:
+    """Format an aware datetime as the RFC3339 UTC the Logging API expects.
+
+    The ``Z`` is a claim about the offset, not decoration. Formatting a Central
+    Time value with it directly tells the API 06:20 UTC when the caller meant
+    06:20 CT - a five-hour error in summer that lands the window nowhere near
+    the booking run and returns an empty result set that reads like "no logs".
+    """
+    if moment.tzinfo is None:
+        raise ValueError("refusing to guess the timezone of a naive datetime")
+    return moment.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def read_logs(project: str, service: str, start: datetime, end: datetime) -> list[tuple[str, str]]:
-    """Read Cloud Run log entries in a UTC window, oldest first."""
+    """Read Cloud Run log entries between two aware datetimes, oldest first."""
     token = access_token()
     log_filter = (
         'resource.type="cloud_run_revision" '
         f'AND resource.labels.service_name="{service}" '
-        f'AND timestamp>="{start.strftime("%Y-%m-%dT%H:%M:%SZ")}" '
-        f'AND timestamp<="{end.strftime("%Y-%m-%dT%H:%M:%SZ")}" '
+        f'AND timestamp>="{_as_utc_z(start)}" '
+        f'AND timestamp<="{_as_utc_z(end)}" '
         'AND textPayload!~"discord\\.gateway"'
     )
     body = {
@@ -253,16 +283,24 @@ def main() -> None:
         if not items:
             print(f"No objects matching {args.date} - nothing was written for that date.")
             return
+        root = args.out.resolve()
+        written_count = 0
         for item in items:
-            destination = args.out / item["name"]
+            destination = _contained_destination(root, item["name"])
+            if destination is None:
+                print(f"{'SKIPPED':>10}  {item['name']} - would land outside {root}")
+                continue
             written = download(args.bucket, item["name"], destination)
+            written_count += 1
             print(f"{written:>10} bytes  {destination}")
-        print(f"\n{len(items)} object(s) -> {args.out}")
+        print(f"\n{written_count} object(s) -> {root}")
 
         for item in items:
             if item["name"].endswith("ledger.jsonl"):
-                print()
-                summarize_ledger(args.out / item["name"])
+                destination = _contained_destination(root, item["name"])
+                if destination is not None and destination.exists():
+                    print()
+                    summarize_ledger(destination)
 
     elif args.command == "logs":
         day = datetime.strptime(args.date, "%Y-%m-%d")


### PR DESCRIPTION
Post-mortem for the 08:00 AM / Thursday 2026-08-20 booking that reported
`Reservation Alert: This slot is blocked by another user.`, plus the tooling that
lets a remote session read the artifacts it could not.

No change to booking behaviour — the provider is untouched. **The post-mortem is
marked open:** no Cloud Run logs and no GCS debug artifacts have been read.

## The fact that reframes the morning

The bot books as Ron Garner. So does the member's father, by hand, from the same
account, racing the same 06:30 window — this morning included.

- **The tee sheet cannot say who booked it.** `Garner, Ron` plus three
  `(Garner, Ron)` TBD guests is what a four-player booking on this account looks
  like whoever made it. The earlier reading of the screenshot as evidence the
  bot's Reserve succeeded is withdrawn.
- **"Blocked by another user" may be literally true this morning** — the first of
  five mornings where contention is a live explanation rather than a phrase the
  club uses for everything.
- **The verification oracle breaks in both directions.** If the father's booking
  lands before `RESERVATION_CHECK` runs, the reservations page lists the tee time
  and the provider reports success at `walden_provider.py:3209` on a slot the bot
  lost. If it lands after, `held=False` says nothing about the bot's own Reserve.
  Nothing in the row identifies which session created it, and
  `verified_not_reserved` is gated on it.

## The alert was not late — it fired inside the window minute

Discord renders in the viewing device's timezone and the member's phone is on ET;
the club is on CT. So the `7:30 AM` notification is **06:30 CT** — the window
minute itself. The whole run fit inside ~60 seconds of 06:30:00, which rules out
any reading where the bot ground away for minutes, and confirms the 06:28 job
fired on time with the pipeline running end to end. Whatever went wrong went
wrong inside the booking logic.

Recorded as a standing hazard: the member reads in ET, the club runs in CT, and a
one-hour misread is available at every step of every future post-mortem.

## What still stands, on the checked-in fixtures

- `find_response_message()` returns **exactly** the sentence the member was sent
  from all five saved Reserve responses, including both the club accepted. The
  popup is `ui-hidden-container` with no `aria-hidden`, so the hidden-container
  filter never catches it. This is the trap #146 closed for the *verdict*, still
  open on the *message* — so the alert is not evidence of a refusal even if a
  refusal is what happened.
- That string reaches the member as `site_message`, which rules out the
  blocked-verdict branch at `walden_provider.py:3221` — and with it #146's ladder
  and classifier — as the source of this report. The run reported a chain-step
  failure or an unconfirmed booking.
- No `(the member's reservations page could not be checked)` suffix means
  `unchecked` was False.
- Standing defect, independent of this morning: every direct-HTTP failure at or
  past the Reserve POST is reported to the member as contention, because
  `_member_facing_failure` prefers the popup text over the technical account.

## Hypotheses, re-ranked

1. **The father won the slot by hand** (favoured) — no `accepted` row in the
   ledger, refusals continuing past the ~1s boundary the previous mornings set.
2. **Self-contention on one member account** (new, testable off-race) — two
   concurrent logins as the same member may clobber server-side JSF state, and
   the club's "another user" could be the bot's own account in another session.
   The cheap test that would have killed it — 08-12's uncontested afternoon slot,
   which still saw ~1.2s of refusals — is unavailable: the member does not know
   whether his father was logged in, and no artifact records a second human being
   signed in.
3. **The bot got the hold and misreported it** (weakened) — no longer has the
   screenshot behind it.

## Closing the access gap

The post-mortem had to be written from fixtures and code because a remote session
could reach neither the bucket nor the logs. The `gcloud` CLI was never the
missing piece: `_upload_bytes_to_gcs` already does GCS I/O with `google.auth` +
`httpx` against the JSON API, both already in the venv, and
`storage`/`logging`/`oauth2.googleapis.com` are all reachable today — the bucket
returns a genuine GCS `401`, not a proxy block. Only a credential was missing.

- **`scripts/fetch_debug_artifacts.py`** — list and fetch artifacts for a date,
  read Cloud Run logs for a CT window, and summarize a race ledger into one line
  per attempt plus the boundary. Takes ADC or a pasted `GCP_ACCESS_TOKEN`; its
  403s name the missing role rather than the status code.
- **`docs/debug-artifact-access.md`** — the read-only service account
  (`storage.objectViewer` on the bucket, `logging.viewer` on the project), the
  two environment variables, the setup-script line, and what the grant costs:
  the artifacts hold live club session HTML and other members' names, which
  `_flush_pre_window_sheet` deliberately keeps out of application logs, so bucket
  read is a wider grant than log read.

Both also record the clock trap — artifact names are UTC because nothing sets
`TZ` in Cloud Run, while the member reads ET and the club runs CT.

## Recommendations recorded — none to be acted on before the artifacts are read

1. Apply `_find_new_blocked_message`'s "only a changed message counts" test to
   `find_response_message` (`walden_http_booker.py:541`, `:658`). Settled on
   fixtures; safe whichever way this morning went.
2. Make `_reservation_exists` say what it saw, and treat its answer as
   account-wide rather than bot-specific.
3. Decide what losing to a family member should report — "already booked on your
   account at 08:00" rather than "unable to book".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5gti4nb1ZYNqNFAgMgP68

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5gti4nb1ZYNqNFAgMgP68)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a detailed post-mortem for the August 13, 2026 booking incident, including findings, unresolved questions, and recommendations for clearer booking status reporting.
  * Added guidance for securely accessing diagnostic artifacts and service logs, including permissions, time zones, credential handling, and cleanup precautions.

* **Tools**
  * Added a read-only diagnostic utility for retrieving debug artifacts, reviewing filtered service logs, and summarizing booking records with clearer error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->