### PR TITLE
fix: keep asking after a Reserve goes unanswered

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -146,8 +146,22 @@ class Settings(BaseSettings):
     # rung spacing whether or not it wins. Once the boundary is known this
     # collapses to a single well-chosen offset.
     #
+    # Spacing is bounded by how fast the club answers, not by what is written
+    # here. Rungs are slept to as absolute instants, so any rung whose moment has
+    # already passed when the previous response lands is skipped - and a Reserve
+    # round trip has measured 593ms and 647ms on the two lost mornings and 828ms
+    # on an uncontested ad-hoc booking. The previous 150/300/500/750 rungs
+    # therefore never once fired: attempt 1's answer arrived at ~860ms, past all
+    # four. A ladder written at that spacing reads like nine attempts and
+    # delivers three.
+    #
+    # These are spaced to survive a ~700ms round trip while still bracketing the
+    # known boundary: 900 sits just past the last observed refusal (817ms), 1300
+    # just past the earliest observed grant (1239ms), and the rest walk out well
+    # beyond it in case the boundary moves.
+    #
     # "0" restores the historical one-shot behaviour.
-    walden_reserve_sweep_offsets_ms: str = "0,150,300,500,750,1000,1250,1500,1750"
+    walden_reserve_sweep_offsets_ms: str = "0,900,1300,2000,3000,4500"
 
     # Write the per-attempt race ledger to the debug artifacts bucket.
     #

--- a/app/providers/walden_http.py
+++ b/app/providers/walden_http.py
@@ -202,6 +202,21 @@ class ViewExpiredError(DirectHttpError):
     """The server rejected our ViewState - the adopted session is stale."""
 
 
+class DirectHttpTimeoutError(DirectHttpError):
+    """A request was written to the socket and no answer arrived in time.
+
+    Separated from its parent because the two demand opposite responses. Most
+    DirectHttpErrors mean the step did not happen; a timeout means we cannot
+    tell. The request may have reached the club and been acted on, so the caller
+    may re-ask for the *same* thing but must not go on to ask for a different
+    one - a second tee time stacked on an invisible hold collides with the
+    club's one-round-per-member-per-day rule.
+
+    On 2026-08-13 and 08-14 this ended the race two rungs short of the offset
+    that had been granted on the two mornings before them.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Minimal HTML tree
 # ---------------------------------------------------------------------------
@@ -999,6 +1014,10 @@ class PrimeFacesSession:
                 http_response = self._client.post(
                     self.form_state.action_url, content=payload, timeout=timeout_s
                 )
+        except httpx.TimeoutException as exc:
+            # Checked before the general case below - TimeoutException is an
+            # HTTPError, so the order here is what makes the distinction exist.
+            raise DirectHttpTimeoutError(f"POST for {config.source} timed out: {exc}") from exc
         except httpx.HTTPError as exc:
             raise DirectHttpError(f"POST for {config.source} failed: {exc}") from exc
         received_at_ms = int(time_module.time() * 1000)

--- a/app/providers/walden_http.py
+++ b/app/providers/walden_http.py
@@ -214,6 +214,27 @@ class DirectHttpTimeoutError(DirectHttpError):
 
     On 2026-08-13 and 08-14 this ended the race two rungs short of the offset
     that had been granted on the two mornings before them.
+
+    Read and write timeouts only. See :class:`DirectHttpConnectionError` for the
+    ones that are *not* uncertain.
+    """
+
+
+class DirectHttpConnectionError(DirectHttpError):
+    """No connection was ever established, so nothing reached the club.
+
+    The distinction from :class:`DirectHttpTimeoutError` is the whole point.
+    ``httpx.TimeoutException`` covers ConnectTimeout and PoolTimeout as well as
+    ReadTimeout and WriteTimeout, but the first two fire *before* any byte is
+    written: one could not open the socket, the other could not take a
+    connection from the pool. ConnectError is the same case without the clock
+    running out.
+
+    Folding those into the uncertain bucket would be doubly costly. The caller
+    would close its fallback list against a hold that cannot exist, and it would
+    leave the phase past PRE_SUBMIT_PHASES - which is what tells the provider a
+    Selenium retry is unsafe. A 6:30 that cannot open a socket can still be won
+    by the browser chain, and this keeps that door open.
     """
 
 
@@ -1014,9 +1035,16 @@ class PrimeFacesSession:
                 http_response = self._client.post(
                     self.form_state.action_url, content=payload, timeout=timeout_s
                 )
+        except (httpx.ConnectTimeout, httpx.PoolTimeout, httpx.ConnectError) as exc:
+            # Before the TimeoutException case: the first two are subclasses of
+            # it, and this ordering is the only thing separating "never sent"
+            # from "sent, outcome unknown".
+            raise DirectHttpConnectionError(
+                f"POST for {config.source} never connected: {exc}"
+            ) from exc
         except httpx.TimeoutException as exc:
-            # Checked before the general case below - TimeoutException is an
-            # HTTPError, so the order here is what makes the distinction exist.
+            # Read and write timeouts. Checked before the general case below -
+            # TimeoutException is an HTTPError, so the order makes it reachable.
             raise DirectHttpTimeoutError(f"POST for {config.source} timed out: {exc}") from exc
         except httpx.HTTPError as exc:
             raise DirectHttpError(f"POST for {config.source} failed: {exc}") from exc

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -56,6 +56,7 @@ from app.providers.walden_dom_schema import DOM
 from app.providers.walden_http import (
     AbConfig,
     DirectHttpError,
+    DirectHttpTimeoutError,
     Node,
     PartialResponse,
     PrimeFacesSession,
@@ -173,19 +174,34 @@ _RESERVE_MAX_ATTEMPTS = 6
 
 # Stop *starting* attempts once the race is this far gone. An attempt already in
 # flight is allowed to finish - abandoning it would not un-send it.
-_RESERVE_DEADLINE_MS = 6000
+#
+# 6000 was sized when a timeout ended the run outright, so it only ever had to
+# bound a healthy ladder. Now that a stalled Reserve is survivable, one stall
+# can spend 3s of it, and 6000 would leave a ladder that survived the stall with
+# no room left to walk. The club has granted slots at ~1.24s and the member
+# wants the tee time whenever it comes, so asking out to 10s costs nothing on a
+# morning already being lost.
+_RESERVE_DEADLINE_MS = 10000
 
 # Budget for a single Reserve POST, well under the session default. The deadline
 # above cannot cancel a request already handed to the socket, so without this a
 # single stalled Reserve spends the entire race and the fallback list - the
-# thing that exists to survive exactly this - is never walked. Round trips have
-# run 230-535ms; one that has not answered in this long has lost anyway.
+# thing that exists to survive exactly this - is never walked.
 #
-# A timeout is deliberately left terminal rather than advancing to the next tee
-# time. The request may well have reached the club, and reserving a second slot
-# on top of a hold we cannot see would collide with the one-round-per-day rule -
-# trading a lost morning for a booking mess.
-_RESERVE_TIMEOUT_S = 2.0
+# Sized against measured round trips, and the earlier 2.0s was sized against a
+# stale set of them. "230-535ms" came from runs that predate the sweep; the two
+# mornings of 2026-08-13/14 answered in 593ms and 647ms, and an uncontested
+# ad-hoc booking on 08-14 - no race, quiet server, warm connection - took 828ms.
+# 2.0s was therefore barely 2.4x a quiet day, and rung 6 blew through it on both
+# mornings, ending each run two rungs short of the offset that had been granted
+# on 08-08 and 08-12.
+#
+# Raised rather than lowered, and not raised further, because the timeout now
+# trades against _RESERVE_DEADLINE_MS instead of ending the run: every second
+# spent waiting on a stalled request is a second of ladder not walked. This is
+# ~3.6x a quiet-day round trip, which leaves a stall recoverable inside the
+# deadline below.
+_RESERVE_TIMEOUT_S = 3.0
 
 # Marks a chain result as this path's. The provider handles both this and the JS
 # chain's results through the same branches, but only this one leaves the browser
@@ -691,6 +707,20 @@ class DirectHttpBooker:
         ``result.attempt_log``, so a morning spent losing still narrows where the
         club's boundary actually sits.
 
+        A Reserve that never answers is survivable but contagious. It used to end
+        the run, which on 2026-08-13 and 08-14 stopped the ladder at +1000ms -
+        two rungs short of the ~1.24s that had been granted on the two mornings
+        before. So a timeout now continues the ladder, but only ever onto the
+        *same* slot: the request may have reached the club, and a second tee time
+        stacked on a hold we cannot see would collide with the one-round-per-day
+        rule. Once anything has timed out the fallback list is closed for the
+        rest of the run, because that risk does not expire with the attempt.
+
+        Note the ladder cannot be walked faster than the club answers. Rungs
+        closer together than one round trip - ~600-830ms in every run measured -
+        are already in the past when the previous answer lands and are skipped,
+        so the configured 150/300/500/750 rungs have never fired.
+
         Returns:
             The response granting a slot, or None with ``result`` describing the
             refusal that ended it.
@@ -698,6 +728,8 @@ class DirectHttpBooker:
         started = time_module.perf_counter()
         slot_time = self._slot_time
         remaining = list(self._fallback_times)
+        # Latches on the first timeout and never clears; see the docstring.
+        timed_out = False
         # Untimed bookings have no window to sweep around; the first rung is
         # already spent by the precision wait in _run_chain.
         rungs = list(self._sweep_offsets_ms[1:]) if target_timestamp_ms is not None else []
@@ -736,7 +768,81 @@ class DirectHttpBooker:
             # and a browser retry in the second case races our own reservation.
             result.phase = PHASE_RESERVE_SENT
             view_state = _view_state_fingerprint(self.session)
-            response = self.session.post(config, body=body, timeout_s=_RESERVE_TIMEOUT_S)
+            # Read here rather than reused from `reserveSentAtMs` above, and kept
+            # for every attempt rather than the first: an answered request takes
+            # this from the response's own send timestamp, so this value is only
+            # ever consumed when there is no response to take it from. The log
+            # line and fingerprint between the two reads are real work, and the
+            # closer read is the honest one for the ledger.
+            sent_ms_past_window = (
+                int(time_module.time() * 1000) - target_timestamp_ms
+                if target_timestamp_ms is not None
+                else None
+            )
+            try:
+                response = self.session.post(config, body=body, timeout_s=_RESERVE_TIMEOUT_S)
+            except DirectHttpTimeoutError as exc:
+                timed_out = True
+                last_reason = str(exc)
+                # Recorded like any other attempt. The ledger previously lost the
+                # attempt that decided both mornings, so a run whose ladder was
+                # cut short read as "1 attempt, every attempt refused".
+                observation = ReserveObservation(
+                    attempt=attempt,
+                    slot_time=slot_time,
+                    source=config.source,
+                    view_state=view_state,
+                    verdict=RESERVE_TIMEDOUT,
+                    reason=str(exc),
+                    sent_ms_past_window=sent_ms_past_window,
+                    round_trip_ms=int(_RESERVE_TIMEOUT_S * 1000),
+                )
+                result.attempt_log.append(observation)
+                _log_reserve_observation(observation)
+
+                # Checked here as well as after a refusal: the refusal path is
+                # `continue`d past, and without this a run that only ever timed
+                # out would spend a full _RESERVE_TIMEOUT_S per remaining rung.
+                spent_ms = (time_module.perf_counter() - started) * 1000
+                if spent_ms >= _RESERVE_DEADLINE_MS or target_timestamp_ms is None:
+                    logger.warning(
+                        "DIRECT_HTTP: Reserve %d never answered and %dms is spent; stopping "
+                        "rather than asking for a different tee time",
+                        attempt,
+                        int(spent_ms),
+                    )
+                    break
+
+                # Deliberately not _next_future_rung. A stall of seconds has
+                # already carried us past every offset the ladder was there to
+                # explore, so its *schedule* is moot - but its length is still
+                # the budget for how many more times to ask. Take the next rung
+                # whether or not its instant has passed; sleep_until no-ops on
+                # one already gone, which fires the retry at once. That is the
+                # right move anyway: the club granted at ~1.24s on 08-08 and
+                # 08-12, and a stall leaves us well past that.
+                if not rungs:
+                    logger.warning(
+                        "DIRECT_HTTP: Reserve %d never answered and the ladder is spent; "
+                        "stopping rather than asking for a different tee time",
+                        attempt,
+                    )
+                    break
+                stall_rung_ms = rungs.pop(0)
+                # Re-staged from nothing: there is no response to relocate the
+                # button in, so the previously staged config and body are sent
+                # again unchanged. Same slot, same ViewState - which is exactly
+                # the request 08-08 and 08-12 had accepted a rung later.
+                logger.info(
+                    "DIRECT_HTTP: Reserve %d never answered after %dms; asking again for %s "
+                    "at +%dms (same slot only - the club may already be holding it)",
+                    attempt,
+                    int(spent_ms),
+                    slot_time.strftime("%I:%M %p") if slot_time else "the staged slot",
+                    stall_rung_ms,
+                )
+                sleep_until(target_timestamp_ms + stall_rung_ms - int(round(self._lead_ms)))
+                continue
             result.final_markup = response.markup
 
             # One parse, three questions now. At ~190ms for a 500KB sheet this
@@ -806,7 +912,19 @@ class DirectHttpBooker:
                 continue
 
             # The ladder is spent. A refusal this far past the window is the
-            # kind the fallback list was built for.
+            # kind the fallback list was built for - unless a Reserve went
+            # unanswered earlier, in which case the club may be holding the slot
+            # we just asked about and a different tee time would be a second
+            # booking on the same day. Losing the morning beats that.
+            if timed_out:
+                logger.warning(
+                    "DIRECT_HTTP: %s, but an earlier Reserve never answered - not trying "
+                    "another tee time, as the club may be holding %s",
+                    observation.reason,
+                    slot_time.strftime("%I:%M %p") if slot_time else "the staged slot",
+                )
+                break
+
             next_candidate = self._next_candidate(document, response.markup, remaining)
             if next_candidate is None:
                 logger.warning(
@@ -821,14 +939,21 @@ class DirectHttpBooker:
                 slot_time.strftime("%I:%M %p"),
             )
 
-        result.blocked = True
+        # Only a run the club actually refused is "blocked". One that ended
+        # because a Reserve never answered gets reported as a plain failure, the
+        # same shape the raised timeout produced before it was survivable, and
+        # for the same reason: `blocked` selects the "another member took it"
+        # message for the member, and it feeds the untimed retry - which must
+        # never re-fire at a slot the club may be silently holding.
+        result.blocked = not timed_out
         result.error = last_reason or "Slot blocked by another user"
         logger.warning(
-            "DIRECT_HTTP: No Reserve accepted after %d attempt(s) over %dms - tried %s",
+            "DIRECT_HTTP: No Reserve accepted after %d attempt(s) over %dms - tried %s%s",
             result.timing.get("reserveAttempts", 0),
             int((time_module.perf_counter() - started) * 1000),
             ", ".join(t.strftime("%I:%M %p") for t in result.distinct_attempted_times())
             or "nothing",
+            "; at least one Reserve never answered, so the outcome is unknown" if timed_out else "",
         )
         return None
 
@@ -1411,6 +1536,11 @@ def _is_message_container(node: Node) -> bool:
 RESERVE_ACCEPTED = "accepted"
 RESERVE_REFUSED = "refused"
 RESERVE_UNKNOWN = "unknown"
+# No response at all, as against RESERVE_UNKNOWN's "a response we cannot read".
+# The distinction is the whole point: an unreadable response says the club
+# answered, a timeout says we do not know whether it acted. Only the latter
+# closes the fallback list off for the rest of the run.
+RESERVE_TIMEDOUT = "timeout"
 
 # The populated header of the booking form the club returns once it has given us
 # the slot: "Reservation at </label><label>04:53 PM". Populated is the point -

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -55,6 +55,7 @@ from typing import Any
 from app.providers.walden_dom_schema import DOM
 from app.providers.walden_http import (
     AbConfig,
+    DirectHttpConnectionError,
     DirectHttpError,
     DirectHttpTimeoutError,
     Node,
@@ -781,6 +782,15 @@ class DirectHttpBooker:
             )
             try:
                 response = self.session.post(config, body=body, timeout_s=_RESERVE_TIMEOUT_S)
+            except DirectHttpConnectionError:
+                # The phase was advanced before the call because a request on the
+                # socket cannot be told from one that was answered and lost. This
+                # is the one case where it can: no connection was established, so
+                # nothing was submitted. Rolling the phase back is what keeps the
+                # browser chain available - past PRE_SUBMIT_PHASES the provider
+                # treats a retry as racing our own booking and reports instead.
+                result.phase = PHASE_RESERVE_STAGED
+                raise
             except DirectHttpTimeoutError as exc:
                 timed_out = True
                 last_reason = str(exc)

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -5549,9 +5549,19 @@ class WaldenGolfProvider(ReservationProvider):
                     furthest,
                 )
         elif attempts:
+            # Nothing granted and nothing refused, so every attempt either never
+            # answered or came back unclassifiable. Those are opposite facts -
+            # RESERVE_UNKNOWN means the club *did* reply and the parser could not
+            # read it - and reporting them as one would send a post-mortem
+            # looking for a network fault that never happened.
+            never_answered = [o for o in attempts if o.verdict == RESERVE_TIMEDOUT]
+            unreadable = len(attempts) - len(never_answered)
             logger.warning(
-                "RACE_LEDGER: no attempt was answered - %d Reserve(s) sent, none returned",
+                "RACE_LEDGER: no attempt was granted or refused - %d Reserve(s) sent, "
+                "%d never answered, %d answered unreadably",
                 len(attempts),
+                len(never_answered),
+                unreadable,
             )
 
         if not bucket_name:

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -44,6 +44,7 @@ from app.providers.walden_http_booker import (
     PRE_SUBMIT_PHASES,
     RESERVE_ACCEPTED,
     RESERVE_REFUSED,
+    RESERVE_TIMEDOUT,
     DirectHttpBooker,
     container_message_text,
 )
@@ -5524,12 +5525,22 @@ class WaldenGolfProvider(ReservationProvider):
                 f"; last refusal was +{last_refused}ms" if last_refused is not None else "",
             )
         elif refused:
+            # Timeouts are called out rather than folded in: an attempt that
+            # never answered is not a refusal, and a run that ends on one has not
+            # established that the club said no out to the offsets it reached.
+            timed_out = [o for o in attempts if o.verdict == RESERVE_TIMEDOUT]
             logger.warning(
-                "RACE_LEDGER: every attempt refused, out to +%sms past the window",
+                "RACE_LEDGER: every attempt refused, out to +%sms past the window%s",
                 max(
                     (o.sent_ms_past_window for o in refused if o.sent_ms_past_window is not None),
                     default="?",
                 ),
+                f"; {len(timed_out)} attempt(s) never answered" if timed_out else "",
+            )
+        elif attempts:
+            logger.warning(
+                "RACE_LEDGER: no attempt was answered - %d Reserve(s) sent, none returned",
+                len(attempts),
             )
 
         if not bucket_name:

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -5525,18 +5525,29 @@ class WaldenGolfProvider(ReservationProvider):
                 f"; last refusal was +{last_refused}ms" if last_refused is not None else "",
             )
         elif refused:
-            # Timeouts are called out rather than folded in: an attempt that
-            # never answered is not a refusal, and a run that ends on one has not
-            # established that the club said no out to the offsets it reached.
+            # Timeouts are counted separately rather than folded in. An attempt
+            # that never answered is not a refusal, so "every attempt refused"
+            # would be false whenever one is present - and this line is what a
+            # post-mortem reads first to decide whether the club's boundary was
+            # actually probed out to the offsets the ladder reached.
             timed_out = [o for o in attempts if o.verdict == RESERVE_TIMEDOUT]
-            logger.warning(
-                "RACE_LEDGER: every attempt refused, out to +%sms past the window%s",
-                max(
-                    (o.sent_ms_past_window for o in refused if o.sent_ms_past_window is not None),
-                    default="?",
-                ),
-                f"; {len(timed_out)} attempt(s) never answered" if timed_out else "",
+            furthest = max(
+                (o.sent_ms_past_window for o in refused if o.sent_ms_past_window is not None),
+                default="?",
             )
+            if timed_out:
+                logger.warning(
+                    "RACE_LEDGER: no attempt was granted - %d refused (out to +%sms past the "
+                    "window), %d never answered",
+                    len(refused),
+                    furthest,
+                    len(timed_out),
+                )
+            else:
+                logger.warning(
+                    "RACE_LEDGER: every attempt refused, out to +%sms past the window",
+                    furthest,
+                )
         elif attempts:
             logger.warning(
                 "RACE_LEDGER: no attempt was answered - %d Reserve(s) sent, none returned",

--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -885,12 +885,24 @@ class BookingService:
                 # send its reply until this returns. Awaiting it here means any
                 # crash during the attempt takes the user's reply down with it,
                 # leaving them with silence. The caller now acknowledges
-                # immediately and execute_booking sends the real outcome when
-                # it lands.
+                # immediately and the batch reports the real outcome when it
+                # lands.
+                #
+                # As a batch of one, deliberately. The 6:30 race is itself a
+                # batch of one, and every race behaviour - fallback ranking, the
+                # clock probe, refresh-at-window, the sweep ladder, the precision
+                # wait, the race ledger - is gated on `execute_at` being set,
+                # which only the batch path supplies. Routed through
+                # execute_booking instead, an ad-hoc booking took a path that
+                # structurally could not be timed: book_tee_time has no
+                # execute_at parameter, so all six switched off and the 08-14
+                # ad-hoc booking ran untimed with walden_adhoc_execute_delay_s
+                # set to 90. That left the machinery deciding the only booking
+                # that matters exercised once a day, unobserved.
                 created_booking.status = BookingStatus.IN_PROGRESS
                 await database_service.update_booking(created_booking)
                 if not defer_execution:
-                    self._spawn_booking_execution(booking_id_opt)
+                    self._spawn_bookings_batch_execution([booking_id_opt])
 
         return created_booking
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -263,10 +263,18 @@ variable "walden_reserve_sweep_offsets_ms" {
     rung spacing whether or not it wins. Once it is known, collapse this to one
     well-chosen offset.
 
+    Spacing is bounded by how fast the club answers, not by what is set here.
+    Rungs are slept to as absolute instants, so one whose moment has already
+    passed when the previous response lands is skipped - and a Reserve round trip
+    has measured 593ms and 647ms on the two lost mornings and 828ms on an
+    uncontested ad-hoc booking. The previous 150/300/500/750 rungs never once
+    fired: attempt 1's answer arrived ~860ms in, past all four. Rungs spaced
+    tighter than a round trip make the ladder read longer than it runs.
+
     "0" restores the historical single shot on the instant.
   EOT
   type        = string
-  default     = "0,150,300,500,750,1000,1250,1500,1750"
+  default     = "0,900,1300,2000,3000,4500"
 
   validation {
     # Whitespace is tolerated because the parser in app/config.py strips it, and

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -333,7 +333,13 @@ class TestBookingServiceImmediateExecution:
     async def test_create_booking_executes_immediately_when_past(
         self, booking_service: BookingService
     ) -> None:
-        """Test that booking is executed immediately when execution time is in the past."""
+        """An open window books now, as a batch of one so it takes the timed path.
+
+        The batch entry point is the only one that accepts an ``execute_at``, and
+        every race behaviour is gated on it. Routed through the single-booking
+        path this booked untimed no matter what walden_adhoc_execute_delay_s
+        said, which is what the 2026-08-14 ad-hoc booking did.
+        """
         import pytz
 
         # Request for Dec 29, 2025 at 8:00 AM CT
@@ -374,18 +380,34 @@ class TestBookingServiceImmediateExecution:
 
             mock_db.update_booking = AsyncMock(side_effect=update_booking_side_effect)
 
-            mock_provider = MagicMock()
-            mock_provider.book_tee_time = AsyncMock(
-                return_value=BookingResult(
-                    success=True,
-                    booked_time=time(8, 0),
-                    confirmation_number="CONF123",
+            from app.providers.base import BatchBookingItemResult, BatchBookingResult
+
+            async def book_multiple(
+                target_date: date, requests: list, execute_at: datetime | None = None
+            ) -> BatchBookingResult:
+                return BatchBookingResult(
+                    results=[
+                        BatchBookingItemResult(
+                            booking_id=item.booking_id,
+                            result=BookingResult(
+                                success=True,
+                                booked_time=time(8, 0),
+                                confirmation_number="CONF123",
+                            ),
+                        )
+                        for item in requests
+                    ],
+                    total_succeeded=len(requests),
                 )
-            )
+
+            mock_provider = MagicMock()
+            mock_provider.book_tee_time = AsyncMock()
+            mock_provider.book_multiple_tee_times = AsyncMock(side_effect=book_multiple)
             booking_service.set_reservation_provider(mock_provider)
 
             with patch("app.services.booking_service.sms_service") as mock_sms:
                 mock_sms.send_booking_confirmation = AsyncMock()
+                mock_sms.send_booking_failure = AsyncMock()
 
                 with patch.object(CTDateTime, "now") as mock_ct_now:
                     tz = pytz.timezone("America/Chicago")
@@ -401,7 +423,11 @@ class TestBookingServiceImmediateExecution:
                     assert result.status == BookingStatus.IN_PROGRESS
                     await booking_service.wait_for_background_bookings()
 
-            mock_provider.book_tee_time.assert_called_once()
+            # The batch path, not the single one - and carrying an execute_at,
+            # which is what switches the race behaviours on.
+            mock_provider.book_multiple_tee_times.assert_awaited_once()
+            assert mock_provider.book_tee_time.await_count == 0
+            assert mock_provider.book_multiple_tee_times.await_args.kwargs["execute_at"] is not None
 
     @pytest.mark.asyncio
     async def test_create_booking_schedules_when_future(
@@ -479,18 +505,34 @@ class TestBookingServiceImmediateExecution:
 
             mock_db.update_booking = AsyncMock(side_effect=update_booking_side_effect)
 
-            mock_provider = MagicMock()
-            mock_provider.book_tee_time = AsyncMock(
-                return_value=BookingResult(
-                    success=True,
-                    booked_time=time(8, 0),
-                    confirmation_number="CONF123",
+            from app.providers.base import BatchBookingItemResult, BatchBookingResult
+
+            async def book_multiple(
+                target_date: date, requests: list, execute_at: datetime | None = None
+            ) -> BatchBookingResult:
+                return BatchBookingResult(
+                    results=[
+                        BatchBookingItemResult(
+                            booking_id=item.booking_id,
+                            result=BookingResult(
+                                success=True,
+                                booked_time=time(8, 0),
+                                confirmation_number="CONF123",
+                            ),
+                        )
+                        for item in requests
+                    ],
+                    total_succeeded=len(requests),
                 )
-            )
+
+            mock_provider = MagicMock()
+            mock_provider.book_tee_time = AsyncMock()
+            mock_provider.book_multiple_tee_times = AsyncMock(side_effect=book_multiple)
             booking_service.set_reservation_provider(mock_provider)
 
             with patch("app.services.booking_service.sms_service") as mock_sms:
                 mock_sms.send_booking_confirmation = AsyncMock()
+                mock_sms.send_booking_failure = AsyncMock()
 
                 with patch.object(CTDateTime, "now") as mock_ct_now:
                     tz = pytz.timezone("America/Chicago")
@@ -502,7 +544,8 @@ class TestBookingServiceImmediateExecution:
                     assert result.status == BookingStatus.IN_PROGRESS
                     await booking_service.wait_for_background_bookings()
 
-            mock_provider.book_tee_time.assert_called_once()
+            mock_provider.book_multiple_tee_times.assert_awaited_once()
+            assert mock_provider.book_tee_time.await_count == 0
 
 
 class TestBookingServiceConfirmIntentImmediateExecution:
@@ -2805,9 +2848,22 @@ class TestImmediateBookingDoesNotBlockReply:
         )
         release = asyncio.Event()
 
-        async def slow_booking(**_kwargs: object) -> BookingResult:
+        from app.providers.base import BatchBookingItemResult, BatchBookingResult
+
+        async def slow_booking(
+            target_date: date, requests: list, execute_at: datetime | None = None
+        ) -> BatchBookingResult:
             await release.wait()
-            return BookingResult(success=True, booked_time=time(8, 0))
+            return BatchBookingResult(
+                results=[
+                    BatchBookingItemResult(
+                        booking_id=item.booking_id,
+                        result=BookingResult(success=True, booked_time=time(8, 0)),
+                    )
+                    for item in requests
+                ],
+                total_succeeded=len(requests),
+            )
 
         with patch("app.services.booking_service.database_service") as mock_db:
             mock_db.create_booking = AsyncMock(side_effect=lambda b: b)
@@ -2822,11 +2878,13 @@ class TestImmediateBookingDoesNotBlockReply:
             )
 
             mock_provider = MagicMock()
-            mock_provider.book_tee_time = AsyncMock(side_effect=slow_booking)
+            mock_provider.book_tee_time = AsyncMock()
+            mock_provider.book_multiple_tee_times = AsyncMock(side_effect=slow_booking)
             booking_service.set_reservation_provider(mock_provider)
 
             with patch("app.services.booking_service.sms_service") as mock_sms:
                 mock_sms.send_booking_confirmation = AsyncMock()
+                mock_sms.send_booking_failure = AsyncMock()
 
                 with patch.object(CTDateTime, "now") as mock_ct_now:
                     tz = pytz.timezone("America/Chicago")

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -1792,6 +1792,115 @@ class TestReserveSweep:
         assert result.distinct_attempted_times() == [RESERVE_SLOT_TIME, SLOT_B_TIME]
 
 
+class StallingRecorder(ChainRecorder):
+    """A ChainRecorder where chosen attempts never answer.
+
+    Models the failure of 2026-08-13 and 08-14 exactly: the Reserve is written
+    to the socket and the club returns nothing before the budget runs out.
+    """
+
+    def __init__(self, pages: list[str], stall_on: set[int]) -> None:
+        """``stall_on`` holds 1-based attempt numbers that time out."""
+        super().__init__(pages)
+        self.stall_on = stall_on
+        # Answered requests only. The canned pages are the *replies* the club
+        # makes, so a request it never answers must not consume one - indexing
+        # on every request instead would silently hand the next attempt the page
+        # meant for this one.
+        self.answered = 0
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        """Answer as usual, unless this attempt is one of the stalled ones."""
+        params = dict(urllib.parse.parse_qsl(request.content.decode()))
+        # Recorded before any raise, so a stalled request still counts as sent -
+        # which is the entire reason it cannot be treated as a no-op.
+        self.requests.append(params)
+        self.sources.append(params.get("javax.faces.source", ""))
+        if len(self.sources) in self.stall_on:
+            raise httpx.ReadTimeout("The read operation timed out", request=request)
+        page = self.pages[min(self.answered, len(self.pages) - 1)]
+        self.answered += 1
+        return httpx.Response(200, text=partial_response(page, f"vs-{len(self.sources)}"))
+
+
+class TestReserveTimeoutKeepsTheLadderWalking:
+    """A Reserve that never answers must not end the race.
+
+    On 2026-08-13 and 08-14 attempt 2 fired at +1000ms, hit the 2s budget and
+    raised, which ended the run at phase=reserve_sent with the ladder's 1250,
+    1500 and 1750 rungs unfired - and ~1.24s is exactly where the club had
+    granted the slot on 08-08 and 08-12.
+
+    It stays contagious in one direction: the request may have reached the club,
+    so the same slot may be asked for again, but no *other* tee time may be,
+    now or later in the run. A second booking stacked on an invisible hold
+    collides with the club's one-round-per-member-per-day rule.
+    """
+
+    def test_a_stalled_reserve_asks_the_same_slot_again(self) -> None:
+        """The rung after a timeout is the slot we want, not the next one down."""
+        recorder = StallingRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE], stall_on={1})
+        result = sweep_booker(recorder, 0, 300).book(1, target_timestamp_ms=window_about_to_open())
+
+        assert result.success, result.error
+        assert recorder.sources[:2] == [RESERVE_ID, RESERVE_ID]
+        assert result.booked_slot_time == RESERVE_SLOT_TIME
+
+    def test_a_stalled_reserve_never_walks_to_a_fallback(self) -> None:
+        """Even a later refusal must not move us onto a different tee time."""
+        recorder = StallingRecorder(
+            [blocked_sheet(*ALL_THREE), PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE], stall_on={1}
+        )
+        result = sweep_booker(recorder, 0, 300).book(1, target_timestamp_ms=window_about_to_open())
+
+        assert SLOT_B_ID not in recorder.sources
+        assert SLOT_C_ID not in recorder.sources
+        assert result.distinct_attempted_times() == [RESERVE_SLOT_TIME]
+
+    def test_a_stall_with_the_ladder_spent_stops_without_claiming_blocked(self) -> None:
+        """ "We never heard back" is not "another member took it".
+
+        `blocked` picks the member-facing "someone else got it" message and gates
+        the untimed retry, which must never re-fire at a slot the club may be
+        holding.
+        """
+        recorder = StallingRecorder([blocked_sheet(*ALL_THREE)], stall_on={1})
+        result = sweep_booker(recorder, 0).book(1, target_timestamp_ms=window_about_to_open())
+
+        assert not result.success
+        assert not result.blocked
+        assert recorder.sources == [RESERVE_ID]
+
+    def test_the_stalled_attempt_is_recorded_in_the_ledger(self) -> None:
+        """The attempt that decided both mornings left no row at all.
+
+        The ledger read "1 attempt, every attempt refused" for a run whose second
+        Reserve was the one that mattered.
+        """
+        from app.providers.walden_http_booker import RESERVE_TIMEDOUT
+
+        recorder = StallingRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE], stall_on={1})
+        result = sweep_booker(recorder, 0, 300).book(1, target_timestamp_ms=window_about_to_open())
+
+        assert [o.verdict for o in result.attempt_log][:1] == [RESERVE_TIMEDOUT]
+        assert result.attempt_log[0].slot_time == RESERVE_SLOT_TIME
+
+    def test_consecutive_stalls_still_reach_a_later_rung(self) -> None:
+        """The stall itself carries us past the remaining rungs' instants.
+
+        _next_future_rung would discard every one of them and end the run, which
+        is the bug this whole class exists for. After a stall the ladder's length
+        is the budget; its schedule is moot.
+        """
+        recorder = StallingRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE], stall_on={1, 2})
+        result = sweep_booker(recorder, 0, 300, 600).book(
+            1, target_timestamp_ms=window_about_to_open()
+        )
+
+        assert result.success, result.error
+        assert recorder.sources[:3] == [RESERVE_ID, RESERVE_ID, RESERVE_ID]
+
+
 class TestStagingTheLadder:
     """The ladder as it arrives through the public staging path."""
 

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -32,6 +32,7 @@ from app.providers.walden_http import (
 from app.providers.walden_http_booker import (
     PHASE_BOOK_NOW,
     PHASE_RESERVE_SENT,
+    PHASE_RESERVE_STAGED,
     PHASE_VIEW_REFRESH,
     PRE_SUBMIT_PHASES,
     DirectHttpBooker,
@@ -965,11 +966,20 @@ class TestDirectHttpBooker:
         assert result.error is not None and "Book Now" in result.error
 
     def test_transport_failure_is_reported_not_raised(self) -> None:
-        """A dropped connection becomes a result, not an exception."""
+        """A connection that never opened becomes a result, not an exception.
+
+        The phase is pre-submit on purpose. httpx raises ConnectError only from
+        establishing the connection, so no byte of the Reserve was written and a
+        Selenium retry cannot race a booking that does not exist. This used to
+        assert PHASE_RESERVE_SENT, which was safe but pessimistic: past
+        PRE_SUBMIT_PHASES the provider reports the failure instead of retrying,
+        so a 6:30 that could not open a socket was given up on rather than
+        handed to the browser chain that could still have won it.
+        """
 
         def handler(request: httpx.Request) -> httpx.Response:
             """Mock transport handler for one test case."""
-            raise httpx.ConnectError("connection reset")
+            raise httpx.ConnectError("connection refused")
 
         session = make_session(FormState.from_html(TEE_SHEET), handler)
         booker = DirectHttpBooker(session)
@@ -978,8 +988,9 @@ class TestDirectHttpBooker:
         result = booker.book(4)
 
         assert not result.success
-        assert result.phase == PHASE_RESERVE_SENT
-        assert result.error is not None and "connection reset" in result.error
+        assert result.phase == PHASE_RESERVE_STAGED
+        assert result.phase in PRE_SUBMIT_PHASES
+        assert result.error is not None and "connection refused" in result.error
 
     def test_book_without_prepare_is_rejected(self) -> None:
         """Misuse is a pre-submit result, so the caller falls back rather than
@@ -1799,15 +1810,35 @@ class StallingRecorder(ChainRecorder):
     to the socket and the club returns nothing before the budget runs out.
     """
 
-    def __init__(self, pages: list[str], stall_on: set[int]) -> None:
-        """``stall_on`` holds 1-based attempt numbers that time out."""
+    def __init__(
+        self,
+        pages: list[str],
+        stall_on: set[int],
+        *,
+        stall_delay_s: float = 0.0,
+        error: type[httpx.HTTPError] = httpx.ReadTimeout,
+    ) -> None:
+        """``stall_on`` holds 1-based attempt numbers that fail.
+
+        ``stall_delay_s`` burns real time before failing. A stall that raises
+        instantly leaves the ladder's later rungs still in the future, where
+        _next_future_rung would hand one back and a test could not tell the
+        rung-schedule fix from a plain catch-and-continue. ``error`` selects
+        which httpx failure to raise, since the four timeout subclasses do not
+        all mean the same thing.
+        """
         super().__init__(pages)
         self.stall_on = stall_on
+        self.stall_delay_s = stall_delay_s
+        self.error = error
         # Answered requests only. The canned pages are the *replies* the club
         # makes, so a request it never answers must not consume one - indexing
         # on every request instead would silently hand the next attempt the page
         # meant for this one.
         self.answered = 0
+        # Milliseconds past the window each request left at, so a test can show
+        # a rung's instant had already gone by when its retry fired.
+        self.sent_at_ms: list[int] = []
 
     def __call__(self, request: httpx.Request) -> httpx.Response:
         """Answer as usual, unless this attempt is one of the stalled ones."""
@@ -1816,8 +1847,11 @@ class StallingRecorder(ChainRecorder):
         # which is the entire reason it cannot be treated as a no-op.
         self.requests.append(params)
         self.sources.append(params.get("javax.faces.source", ""))
+        self.sent_at_ms.append(int(time_module.time() * 1000))
         if len(self.sources) in self.stall_on:
-            raise httpx.ReadTimeout("The read operation timed out", request=request)
+            if self.stall_delay_s:
+                time_module.sleep(self.stall_delay_s)
+            raise self.error("stalled by the test", request=request)
         page = self.pages[min(self.answered, len(self.pages) - 1)]
         self.answered += 1
         return httpx.Response(200, text=partial_response(page, f"vs-{len(self.sources)}"))
@@ -1888,17 +1922,74 @@ class TestReserveTimeoutKeepsTheLadderWalking:
     def test_consecutive_stalls_still_reach_a_later_rung(self) -> None:
         """The stall itself carries us past the remaining rungs' instants.
 
-        _next_future_rung would discard every one of them and end the run, which
-        is the bug this whole class exists for. After a stall the ladder's length
-        is the budget; its schedule is moot.
+        This is the case a plain catch-and-continue does not survive. A real
+        stall costs seconds, so by the time it raises every remaining rung is in
+        the past, _next_future_rung discards all of them and the run ends with
+        the ladder unwalked - which is exactly what 08-13 and 08-14 did. After a
+        stall the ladder's length is still a budget; only its schedule is moot.
+
+        The rungs are tight and the stall deliberately slower than all of them,
+        so the retries provably fire after both instants have gone by rather
+        than merely happening to be next in the list.
         """
-        recorder = StallingRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE], stall_on={1, 2})
-        result = sweep_booker(recorder, 0, 300, 600).book(
-            1, target_timestamp_ms=window_about_to_open()
+        target = window_about_to_open()
+        recorder = StallingRecorder(
+            [PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE], stall_on={1, 2}, stall_delay_s=0.15
         )
+        result = sweep_booker(recorder, 0, 60, 120).book(1, target_timestamp_ms=target)
 
         assert result.success, result.error
         assert recorder.sources[:3] == [RESERVE_ID, RESERVE_ID, RESERVE_ID]
+        # Both retries left after the last rung's instant, so neither could have
+        # come from _next_future_rung - it would have returned None for both.
+        assert recorder.sent_at_ms[1] - target > 120
+        assert recorder.sent_at_ms[2] - target > 120
+
+    def test_a_reserve_that_never_connected_stays_pre_submit(self) -> None:
+        """ConnectTimeout is not uncertainty - nothing was ever written.
+
+        httpx.TimeoutException covers ConnectTimeout and PoolTimeout as well as
+        ReadTimeout, but those two fire before any byte reaches the socket.
+        Treating them as post-send would close the fallback list against a hold
+        that cannot exist and, worse, leave the phase past PRE_SUBMIT_PHASES -
+        which is what tells the provider a Selenium retry would race our own
+        booking. A 6:30 that cannot open a socket can still be won by the
+        browser chain.
+        """
+        recorder = StallingRecorder(
+            [PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE],
+            stall_on={1},
+            error=httpx.ConnectTimeout,
+        )
+        result = sweep_booker(recorder, 0, 300).book(1, target_timestamp_ms=window_about_to_open())
+
+        assert not result.success
+        assert result.phase == PHASE_RESERVE_STAGED
+        assert result.phase in PRE_SUBMIT_PHASES
+        # Not swept and not blocked: there is no hold to protect, so the run is
+        # simply handed back for the browser chain to retry.
+        assert recorder.sources == [RESERVE_ID]
+        assert not result.blocked
+
+    def test_a_pool_timeout_is_also_pre_submit(self) -> None:
+        """The other half of the never-sent pair, for the same reason."""
+        recorder = StallingRecorder(
+            [PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE], stall_on={1}, error=httpx.PoolTimeout
+        )
+        result = sweep_booker(recorder, 0, 300).book(1, target_timestamp_ms=window_about_to_open())
+
+        assert not result.success
+        assert result.phase in PRE_SUBMIT_PHASES
+
+    def test_a_write_timeout_is_treated_as_uncertain(self) -> None:
+        """A partly-written request may still have landed, so it sweeps on."""
+        recorder = StallingRecorder(
+            [PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE], stall_on={1}, error=httpx.WriteTimeout
+        )
+        result = sweep_booker(recorder, 0, 300).book(1, target_timestamp_ms=window_about_to_open())
+
+        assert result.success, result.error
+        assert recorder.sources[:2] == [RESERVE_ID, RESERVE_ID]
 
 
 class TestStagingTheLadder:


### PR DESCRIPTION
## Why

The 6:30 runs on **2026-08-13 and 08-14** were identical, and neither lost the way we assumed.

Both fired attempt 1 on time (−7ms and −14ms, with a measured clock lead) and were refused. Both then fired attempt 2 at +1000ms and **never heard back**. The 2.0s read timeout raised out of the sweep loop, ending the chain at `phase=reserve_sent` with the 1250, 1500 and 1750 rungs unfired.

~1.24s is exactly where the club had granted this same request before — 1291ms on 08-08, 1239ms on 08-12. So both mornings died two rungs short of the offset that has actually worked, twice.

```
Reserve 1 -> refused  - sent -14ms past the window, club clock 1ms past, round trip 647ms
Reserve 2/14 ... 1000ms past the window
Chain failed in phase reserve_sent: POST ... failed: The read operation timed out
RACE_LEDGER: 1 attempt(s) - #1 05:00 PM @-14ms -> refused
```

The timeout was deliberately terminal, and the reasoning was sound: a timed-out request may have reached the club, and booking a second slot on top of an invisible hold collides with the one-round-per-member-per-day rule. That constraint is preserved here — it just no longer costs the whole ladder.

### What the ledgers also settle

`serverMsPastWindow` reads `1` on both mornings, i.e. the club stamped its refusal inside the `11:30:00` second. The `Date` header is second-resolution so this does not pin the offset, but a club clock running the ~1s behind ours that a 1.24s boundary would require must have stamped `11:29:59`. It did not, on either morning. The boundary looks like the club's own rather than a clock we misread — which is the question the sweep was built to answer.

## What changed

**A timeout continues the ladder, onto the same slot only.** The flag latches, so once anything has timed out the fallback list stays closed for the rest of the run — including after a later refusal, since the hold risk does not expire with the attempt.

**Raising the timeout alone would have changed nothing.** After a stall every remaining rung is already in the past, and `_next_future_rung` discards all of them, so the run ended anyway. On a stall the next rung is now taken whether or not its instant has passed — the ladder's length is still a budget, its schedule is not — and `sleep_until` no-ops on a past instant, firing the retry immediately. That is right regardless: a stall leaves us well past the boundary, where the club has been accepting.

**Ad-hoc bookings spawn as a batch of one.** Every race behaviour is gated on `execute_at`, which only the batch entry point supplies. `book_tee_time` has no such parameter, so the single-booking path *structurally could not be timed* — the 08-14 ad-hoc booking ran fully untimed (`sweep=0ms, fallbacks=none`, no clock probe, no ledger) with `walden_adhoc_execute_delay_s` set to 90. The 6:30 race is itself a batch of one, so this makes an ad-hoc booking the same code rather than a parallel path, and turns every one into a rehearsal of the race.

**The sweep ladder is re-spaced** to `0,900,1300,2000,3000,4500`. Rungs are slept to as absolute instants and a Reserve round trip has measured 593ms and 647ms on the lost mornings and 828ms on an uncontested ad-hoc booking, so `150/300/500/750` were already past when attempt 1 answered at ~860ms — they have never once fired. 900 sits just past the last observed refusal (817ms), 1300 just past the earliest observed grant (1239ms).

**Timed-out attempts get a ledger row.** Both mornings logged `1 attempt(s) ... every attempt refused` for runs whose *second* Reserve decided them.

**`result.blocked` is false when a run ends on a timeout**, since it selects the "another member took it" message and gates the untimed retry.

## Accepted costs

- **A losing morning now takes longer.** Attempt deadline 6s → 10s and timeout 2.0s → 3.0s, so a thoroughly stalled run can spend ~10s in the sweep instead of ~3s. Deliberate: the member wants the tee time whenever it arrives, and every path after this point is worse.
- **More Reserves for the same slot.** A stalled attempt is re-asked, so the club may receive two POSTs for one slot with no answer to the first. Safe by construction (same slot cannot become two bookings) but it is more load than before.
- **`_spawn_booking_execution` is now dead in production.** Left in place rather than grown into this PR — #148 tracks removing it and repointing the three background-task-lifecycle tests that still reference it.
- **Ad-hoc bookings now wait ~90s before firing Reserve.** Already true for multi-request ad-hoc bookings since #145; this extends it to single ones. It buys the rehearsal.

## Changed, not added, tests

Three tests in `TestBookingServiceImmediateExecution` / `TestImmediateBookingDoesNotBlockReply` asserted `book_tee_time` was called. That assertion **encoded the bug**: it pinned the single-booking path that cannot carry an `execute_at`. They now assert `book_multiple_tee_times` is awaited and that it carries a non-null `execute_at`, which is the property that actually matters.

New: `TestReserveTimeoutKeepsTheLadderWalking` (5 cases) with a `StallingRecorder` double reproducing 08-13/08-14 — including `test_consecutive_stalls_still_reach_a_later_rung`, which fails against the naive "just catch the timeout" fix.

## Not verified

- **No real refusal has exercised this.** Booking cannot be run locally; the first genuine test is the next 6:30, or an ad-hoc booking that the club refuses.
- **terraform not installed locally**, so `terraform validate` never ran here. The `variables.tf` change is a default string and its regex validation accepts it.
- The 828ms uncontested round trip is a single sample.

Local gate green: 904 passed / 3 skipped, `ruff check .`, `ruff format --check .`, `mypy app`.

Related: #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer handling and reporting for reservation requests that time out after being sent.
  - Timed-out reservation attempts can retry the same time slot while preventing duplicate fallback reservations.
  - Booking responses now detect newly returned blocking messages.

- **Improvements**
  - Immediate bookings now use the same tracked execution and reporting flow as batch bookings.
  - Reservation sweep timing uses wider, response-time-aware intervals.
  - Connection failures and unanswered reservation attempts are reported more distinctly.

- **Bug Fixes**
  - Timeout-only reservation attempts are now reported as failures rather than blocked results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->