### PR TITLE
fix: time the race from 06:30:01, where the sheet actually opens

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -155,13 +155,52 @@ class Settings(BaseSettings):
     # four. A ladder written at that spacing reads like nine attempts and
     # delivers three.
     #
-    # These are spaced to survive a ~700ms round trip while still bracketing the
-    # known boundary: 900 sits just past the last observed refusal (817ms), 1300
-    # just past the earliest observed grant (1239ms), and the rest walk out well
-    # beyond it in case the boundary moves.
+    # The first rung is the aim point, and as of 2026-08-15 it is no longer 0.
+    # Every refusal on record arrived under +1000ms (-60, -14, -7, 0, 0, 812,
+    # 817) and every grant over +1200ms (1239, 1240, 1291), and the club stamped
+    # its refusals inside the 06:30:00 second and its grant inside 06:30:01. The
+    # boundary that fits all of it is the club's own second tick: it refuses
+    # while its clock still reads 06:30:00. Firing at 0ms therefore spends the
+    # first request on a certain no, which is what every morning has done.
+    #
+    # 1030 arrives 30ms past that tick. Rungs are offsets of *arrival* on the
+    # club's clock - the lead subtracts the measured offset and flight time - so
+    # this is 30ms of margin against the tick measurement, which the tightened
+    # clock probe pins to roughly +-15ms.
+    #
+    # 1250 is kept as the second rung because it is where the club has actually
+    # granted three times. It is fired without waiting for 1030's answer (see
+    # walden_reserve_pipeline_opening_pair), so aiming earlier cannot cost the
+    # offset that has been winning.
+    #
+    # Each rung is also a measurement. The ledger records which offsets were
+    # refused and which was granted, so a morning narrows the boundary whether or
+    # not it wins - and a grant at 1030 is the first evidence that the boundary
+    # is the tick rather than something later.
+    #
+    # Spacing past the pair is bounded by how fast the club answers, not by what
+    # is written here. Rungs are slept to as absolute instants, so any rung whose
+    # moment has passed when the previous response lands is skipped - and a
+    # Reserve round trip has measured 593-828ms.
     #
     # "0" restores the historical one-shot behaviour.
-    walden_reserve_sweep_offsets_ms: str = "0,900,1300,2000,3000,4500"
+    walden_reserve_sweep_offsets_ms: str = "1030,1250,2000,3000,4500"
+
+    # Fire the first two rungs without waiting for the first one's answer.
+    #
+    # Serialised, the ladder cannot ask twice inside one round trip: 08-15 fired
+    # at -60ms, got its refusal back at +940ms, and by then the 900 rung was gone
+    # so the next question went at +1240ms. Aiming the first rung at the tick
+    # (1030) without this would make the second rung ~1780ms - later than the
+    # offset that has won three times - so a mis-measured tick would cost the
+    # morning rather than one rung.
+    #
+    # Pipelined, the pair brackets the boundary in one round trip and the run is
+    # no worse off than a serial 1250 even if 1030 is refused. Both requests are
+    # for the *same* slot, so the second cannot reserve a second tee time and
+    # collide with the one-round-per-day rule; the worst case is that the club
+    # grants the same hold twice.
+    walden_reserve_pipeline_opening_pair: bool = True
 
     # Write the per-attempt race ledger to the debug artifacts bucket.
     #

--- a/app/config.py
+++ b/app/config.py
@@ -204,7 +204,27 @@ class Settings(BaseSettings):
     # *same* slot, so the second cannot reserve a second tee time and collide
     # with the one-round-per-day rule; the worst case is that the club grants the
     # same hold twice.
-    walden_reserve_pipeline_opening_pair: bool = True
+    #
+    # Off by default, deliberately, and not because it is thought wrong.
+    #
+    # Two reasons. Serially the ladder now asks at roughly +1030, +1770 and
+    # +2510ms from the stated window - every one of them past all seven refusals
+    # on record, and the last two past every grant - so pipelining buys an ask at
+    # +1280 instead of +1770 and only pays on a morning where the hypothesis is
+    # wrong *and* the slot is contested.
+    #
+    # Against that, it is untested against the club, and the sequence it creates
+    # - a Reserve granted while a second one for the same slot is already in
+    # flight - has never been observed. That was an occasional case when the
+    # first rung was a guess. Now that rung 0 is the hypothesis, a right
+    # hypothesis means rung 0 wins every morning, which makes the untested
+    # sequence the daily case rather than the rare one.
+    #
+    # And the morning it would first run is the morning testing whether the sheet
+    # opens at 06:30:01. Two new variables at once makes a failure unreadable.
+    # Exercise this with an ad-hoc booking - same timed path, nothing at stake,
+    # and rung 0 always wins there - before letting it near the race.
+    walden_reserve_pipeline_opening_pair: bool = False
 
     # Write the per-attempt race ledger to the debug artifacts bucket.
     #

--- a/app/config.py
+++ b/app/config.py
@@ -130,76 +130,80 @@ class Settings(BaseSettings):
     # a Reserve whose outcome is unknown is never sent twice.
     walden_adhoc_untimed_retry: bool = True
 
-    # Milliseconds past 06:30:00 to ask for the target slot at, before any
-    # fallback tee time is tried. Comma-separated; see walden_sweep_offsets_ms().
+    # When the tee sheet actually opens, as milliseconds past the club's stated
+    # 06:30:00. This is a claim about the club, and the one tomorrow tests.
     #
-    # The club refuses for roughly the first second past the window, and its
-    # refusal reads "This slot is blocked by another user" regardless of why. On
-    # 2026-08-08 a byte-identical request - same slot, same component id, same
-    # ViewState - was refused at 0ms, refused at 812ms and accepted at 1291ms;
-    # 08-12 repeated it at 0/817/1239ms on a 5:00 PM nobody else wanted, with
-    # every slot still open on the sheet an hour later. Firing once on the
-    # instant therefore asks the one question most likely to be answered no.
+    # Every refusal on record arrived under +1000ms (-60, -14, -7, 0, 0, 812,
+    # 817) and every grant over +1200ms (1239, 1240, 1291). On 2026-08-15 the
+    # refusal carried a Date header stamped inside the 06:30:00 second and the
+    # grant one inside 06:30:01, and the clock probe agreed with the application
+    # server to within that header's one-second resolution. So the club is not
+    # running on a clock we misread: it refuses while its own clock still reads
+    # 06:30:00, and the sheet is open from 06:30:01.
     #
-    # Each rung is also a measurement. The ledger records which offsets were
-    # refused and which was granted, so a morning narrows the boundary to the
-    # rung spacing whether or not it wins. Once the boundary is known this
-    # collapses to a single well-chosen offset.
+    # Everything is timed from here. The sweep offsets below are past *this*
+    # instant, not past 06:30:00 - so a run aims at the moment we believe the
+    # sheet opens and retries from there, rather than searching for it.
+    #
+    # Reporting deliberately stays in the 06:30:00 frame: the ledger's
+    # sentMsPastWindow and serverMsPastWindow are still measured from the club's
+    # stated window, so tomorrow's numbers line up with the ten data points above
+    # rather than starting a second, incompatible scale.
+    #
+    # 0 restores the historical behaviour of treating 06:30:00 as the open.
+    walden_window_opens_offset_ms: int = 1000
+
+    # Slack added to the aim, for measurement error rather than for the club.
+    #
+    # Kept separate from the offset above because the two are tuned for different
+    # reasons: that one is what we believe about the club, this one is how much we
+    # distrust our own clock probe. The probe pins the club's second tick to
+    # roughly +-15ms, and arriving 15ms early lands back inside the second that
+    # has never once been granted - so the primary shot is aimed just past it.
+    # Folding these into one number would leave a refusal at the aim point
+    # ambiguous between "move the belief" and "widen the slack".
+    walden_reserve_aim_margin_ms: int = 30
+
+    # Milliseconds past the open (above) to ask for the target slot at, before
+    # any fallback tee time is tried. Comma-separated; see
+    # walden_sweep_offsets_ms().
+    #
+    # These are retries now, not a search. 0 is the aim point - the instant we
+    # believe the sheet opens - and the rest exist to catch the hypothesis being
+    # wrong. A grant at 0 confirms it; a grant at 250 or 1000 says the boundary
+    # is later than the tick and the offset above should move.
+    #
+    # 250 is fired without waiting for 0's answer (see
+    # walden_reserve_pipeline_opening_pair), which puts it near +1280ms in the
+    # old frame - close to the +1239/1240/1291 that have actually been granted.
+    # So a wrong hypothesis costs a rung rather than the morning.
+    #
+    # 1000 is the last ask before the fallback list. It lands around +2030ms in
+    # the old frame, past every grant on record.
     #
     # Spacing is bounded by how fast the club answers, not by what is written
-    # here. Rungs are slept to as absolute instants, so any rung whose moment has
-    # already passed when the previous response lands is skipped - and a Reserve
-    # round trip has measured 593ms and 647ms on the two lost mornings and 828ms
-    # on an uncontested ad-hoc booking. The previous 150/300/500/750 rungs
-    # therefore never once fired: attempt 1's answer arrived at ~860ms, past all
-    # four. A ladder written at that spacing reads like nine attempts and
-    # delivers three.
+    # here: a rung is reached only once the previous answer lands, and a Reserve
+    # round trip has measured 593-828ms. A rung our own latency has just
+    # overshot still fires - see _RUNG_LATE_GRACE_MS - but one spaced tighter
+    # than a round trip will not fire at the instant it names.
     #
-    # The first rung is the aim point, and as of 2026-08-15 it is no longer 0.
-    # Every refusal on record arrived under +1000ms (-60, -14, -7, 0, 0, 812,
-    # 817) and every grant over +1200ms (1239, 1240, 1291), and the club stamped
-    # its refusals inside the 06:30:00 second and its grant inside 06:30:01. The
-    # boundary that fits all of it is the club's own second tick: it refuses
-    # while its clock still reads 06:30:00. Firing at 0ms therefore spends the
-    # first request on a certain no, which is what every morning has done.
-    #
-    # 1030 arrives 30ms past that tick. Rungs are offsets of *arrival* on the
-    # club's clock - the lead subtracts the measured offset and flight time - so
-    # this is 30ms of margin against the tick measurement, which the tightened
-    # clock probe pins to roughly +-15ms.
-    #
-    # 1250 is kept as the second rung because it is where the club has actually
-    # granted three times. It is fired without waiting for 1030's answer (see
-    # walden_reserve_pipeline_opening_pair), so aiming earlier cannot cost the
-    # offset that has been winning.
-    #
-    # Each rung is also a measurement. The ledger records which offsets were
-    # refused and which was granted, so a morning narrows the boundary whether or
-    # not it wins - and a grant at 1030 is the first evidence that the boundary
-    # is the tick rather than something later.
-    #
-    # Spacing past the pair is bounded by how fast the club answers, not by what
-    # is written here. Rungs are slept to as absolute instants, so any rung whose
-    # moment has passed when the previous response lands is skipped - and a
-    # Reserve round trip has measured 593-828ms.
-    #
-    # "0" restores the historical one-shot behaviour.
-    walden_reserve_sweep_offsets_ms: str = "1030,1250,2000,3000,4500"
+    # "0" restores the historical single ask.
+    walden_reserve_sweep_offsets_ms: str = "0,250,1000"
 
     # Fire the first two rungs without waiting for the first one's answer.
     #
     # Serialised, the ladder cannot ask twice inside one round trip: 08-15 fired
     # at -60ms, got its refusal back at +940ms, and by then the 900 rung was gone
-    # so the next question went at +1240ms. Aiming the first rung at the tick
-    # (1030) without this would make the second rung ~1780ms - later than the
-    # offset that has won three times - so a mis-measured tick would cost the
-    # morning rather than one rung.
+    # so the next question went at +1240ms. Aiming at the open without this would
+    # put the retry near +1780ms in the old frame - later than the offset that has
+    # won three times - so a wrong hypothesis would cost the morning rather than
+    # one rung.
     #
-    # Pipelined, the pair brackets the boundary in one round trip and the run is
-    # no worse off than a serial 1250 even if 1030 is refused. Both requests are
-    # for the *same* slot, so the second cannot reserve a second tee time and
-    # collide with the one-round-per-day rule; the worst case is that the club
-    # grants the same hold twice.
+    # Pipelined, the pair brackets the open in one round trip and the run is no
+    # worse off than the +1240ms that has been winning. Both requests are for the
+    # *same* slot, so the second cannot reserve a second tee time and collide
+    # with the one-round-per-day rule; the worst case is that the club grants the
+    # same hold twice.
     walden_reserve_pipeline_opening_pair: bool = True
 
     # Write the per-attempt race ledger to the debug artifacts bucket.

--- a/app/providers/walden_http.py
+++ b/app/providers/walden_http.py
@@ -108,11 +108,24 @@ _SPIN_WINDOW_MS = 3
 # second of resolution, so a single sample says nothing better than "somewhere
 # in this second". What is readable is the *transition*: probe faster than the
 # second ticks, and the local time at which the header increments is a server
-# second boundary observed directly. Spacing bounds the error (+-40 ms here);
-# the count has to span more than a second so at least one transition is
-# guaranteed to fall inside the run.
-_SKEW_PROBE_COUNT = 16
-_SKEW_PROBE_SPACING_S = 0.08
+# second boundary observed directly. Spacing bounds the error; the run has to
+# span more than a second so at least one transition falls inside it.
+#
+# Sized for the boundary, not just the lead. Until 2026-08-15 this was 16 probes
+# at 80ms, which spans 1.3s and yields one transition bracketed to +-105ms - fine
+# for arriving "about when the window opens", useless for aiming at the club's
+# second tick, which is what the refusal boundary turns out to be keyed to (see
+# _OPENING_OFFSET_MS in walden_http_booker). Tighter spacing over a longer run
+# gives several transitions instead of one, and the median of them is what makes
+# the estimate better than any single bracket.
+#
+# Budget-bounded rather than count-bounded: the probe target has answered in
+# 26-131ms across mornings, and a count that is 5s of probing on a quiet day
+# would be 40s on a slow one - inside the ~70s before the window, but spending
+# the staging margin on a measurement is not a trade worth making silently.
+_SKEW_PROBE_SPACING_S = 0.02
+_SKEW_PROBE_BUDGET_S = 5.0
+_SKEW_PROBE_MAX = 300
 # A probe is only usable if its own round trip is short enough that the header
 # was stamped near the midpoint we ascribe to it. A stalled probe is dropped
 # rather than allowed to drag the estimate.
@@ -146,12 +159,19 @@ class ClockSkew:
     ``offset_ms`` is the club's clock minus ours: positive means the club gets
     to 06:30:00 before we do. ``one_way_ms`` is the outbound flight time. Their
     sum is how early a request has to leave to arrive as the window opens.
+
+    ``tick_bracket_ms`` is how tightly the server's second boundary was pinned -
+    the median gap between the two probes that straddled a transition. It bounds
+    the error on ``offset_ms``, and so on any aim taken relative to the club's
+    own second tick. Reported rather than acted on: a wide bracket is a reason
+    to distrust a tight aim, and the log is where that gets noticed.
     """
 
     offset_ms: float
     one_way_ms: float
     probes: int
     transitions: int
+    tick_bracket_ms: float = 0.0
 
     @property
     def lead_ms(self) -> float:
@@ -930,9 +950,14 @@ class PrimeFacesSession:
         probe_url = self._resolve_probe_url()
         samples: list[tuple[float, int]] = []
         round_trips: list[float] = []
-        for probe in range(_SKEW_PROBE_COUNT):
+        deadline = time_module.monotonic() + _SKEW_PROBE_BUDGET_S
+        attempted = 0
+        for probe in range(_SKEW_PROBE_MAX):
             if probe:
+                if time_module.monotonic() >= deadline:
+                    break
                 time_module.sleep(_SKEW_PROBE_SPACING_S)
+            attempted += 1
             sent = time_module.time()
             try:
                 response = self._client.head(probe_url)
@@ -958,17 +983,20 @@ class PrimeFacesSession:
                 "DIRECT_HTTP: Clock skew unmeasurable - %d usable probe(s) of %d against %s "
                 "(round trips over %.1fs are dropped)",
                 len(samples),
-                _SKEW_PROBE_COUNT,
+                attempted,
                 probe_url,
                 _SKEW_MAX_PROBE_RTT_S,
             )
             return None
 
-        offsets = [
+        # Each transition gives one estimate of the offset and one bracket that
+        # bounds it. Kept paired so the reported uncertainty belongs to the same
+        # transitions the median was taken over.
+        transitions = [
             # The increment happened between these two probes, so the server's
             # own second boundary sits at their midpoint by our clock. Its
             # distance from the whole second the server reported is the offset.
-            later_second - (earlier_mid + later_mid) / 2
+            (later_second - (earlier_mid + later_mid) / 2, later_mid - earlier_mid)
             for (earlier_mid, earlier_second), (later_mid, later_second) in zip(
                 samples, samples[1:]
             )
@@ -976,15 +1004,16 @@ class PrimeFacesSession:
             # to say where inside it the boundary was.
             if later_second - earlier_second == 1
         ]
-        if not offsets:
+        if not transitions:
             logger.warning(
                 "DIRECT_HTTP: Clock skew unmeasurable - the Date header never advanced "
                 "across %d probes spanning %.1fs (cached?)",
                 len(samples),
-                _SKEW_PROBE_COUNT * _SKEW_PROBE_SPACING_S,
+                samples[-1][0] - samples[0][0],
             )
             return None
 
+        offsets = [offset for offset, _bracket in transitions]
         skew = ClockSkew(
             offset_ms=_median(offsets) * 1000,
             # Halved on the usual assumption that the two legs are symmetric.
@@ -992,15 +1021,25 @@ class PrimeFacesSession:
             # journey back happens after the club has already acted.
             one_way_ms=_median(round_trips) * 1000 / 2,
             probes=len(samples),
-            transitions=len(offsets),
+            transitions=len(transitions),
+            tick_bracket_ms=_median([bracket for _offset, bracket in transitions]) * 1000,
         )
         logger.info(
             "DIRECT_HTTP: Clock skew measured - club is %+.0fms from us, one-way %.0fms "
-            "(%d probes, %d transitions)",
+            "(%d probes, %d transitions, tick pinned to +-%.0fms)",
             skew.offset_ms,
             skew.one_way_ms,
             skew.probes,
             skew.transitions,
+            skew.tick_bracket_ms / 2,
+        )
+        # Stated in our own clock because that is the frame every rung is slept
+        # to. The club's second boundary is the thing the refusal boundary has
+        # tracked on every morning measured, so where it falls is worth its own
+        # line rather than being left implicit in the offset.
+        logger.info(
+            "DIRECT_HTTP: The club's second ticks at %+.0fms against our own whole second",
+            -skew.offset_ms,
         )
         self.clock_skew = skew
         return skew
@@ -1022,6 +1061,30 @@ class PrimeFacesSession:
                 session default is sized for a chain step that must not be
                 abandoned; a request made *during* the race needs to give up
                 far sooner than that and try something else.
+        """
+        response = self.send_detached(config, body=body, timeout_s=timeout_s)
+        self.adopt(response)
+        return response
+
+    def send_detached(
+        self,
+        config: AbConfig,
+        *,
+        body: bytes | None = None,
+        timeout_s: float | None = None,
+    ) -> PartialResponse:
+        """Send one request and return its response without touching session state.
+
+        :meth:`post` is this plus :meth:`adopt`. They are separable because the
+        opening pair of Reserves is fired concurrently: ``adopt`` rebuilds
+        ``form_state`` from the returned markup, so two in-flight requests
+        folding themselves in would race over the fields and ViewState the rest
+        of the chain is built from. Both are sent detached and only the response
+        actually carried forward is adopted.
+
+        The caller owns that choice, and must adopt exactly one response before
+        continuing the chain - otherwise the next step serializes the pre-window
+        form against a view the club has already moved past.
         """
         payload = body if body is not None else self.build_body(config)
         sent_at_ms = int(time_module.time() * 1000)
@@ -1073,8 +1136,15 @@ class PrimeFacesSession:
                 f"Server redirected {config.source} to {response.redirect_url}; "
                 "the adopted session is no longer valid"
             )
-        self._apply(response)
         return response
+
+    def adopt(self, response: PartialResponse) -> None:
+        """Fold a detached response into the session state.
+
+        The other half of :meth:`send_detached`. Call this on the one response
+        the chain carries forward, and only that one.
+        """
+        self._apply(response)
 
     def _apply(self, response: PartialResponse) -> None:
         """Fold a partial response into the session state.

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -205,6 +205,16 @@ _RESERVE_DEADLINE_MS = 10000
 # deadline below.
 _RESERVE_TIMEOUT_S = 3.0
 
+# How far past its instant a ladder rung is still worth firing at once.
+#
+# Rungs are reached only after the previous answer lands, so a rung spaced closer
+# to its predecessor than one round trip is already gone by the time it is
+# considered. Sized above the slowest Reserve round trip measured (828ms) so that
+# our own latency never silently costs a rung, and far below the minutes by which
+# a later booking in a batch overshoots its shared target - which is the case
+# _next_future_rung exists to drop.
+_RUNG_LATE_GRACE_MS = 2000
+
 # Marks a chain result as this path's. The provider handles both this and the JS
 # chain's results through the same branches, but only this one leaves the browser
 # DOM untouched, so only this one needs the outcome resolved against the site.
@@ -337,6 +347,9 @@ class DirectHttpBooker:
         # trip between them. Off here so the historical one-shot default stays
         # exactly that; prepare() turns it on.
         self._pipeline_opening_pair: bool = False
+        # The frame every reported offset is measured from - the club's stated
+        # 06:30:00, which the aim may sit past. book() sets it.
+        self._window_timestamp_ms: int | None = None
 
     # -- staging ----------------------------------------------------------
 
@@ -533,6 +546,7 @@ class DirectHttpBooker:
         num_players: int,
         *,
         target_timestamp_ms: int | None = None,
+        window_timestamp_ms: int | None = None,
     ) -> DirectBookingResult:
         """Run the full chain, firing Reserve at ``target_timestamp_ms``.
 
@@ -546,11 +560,23 @@ class DirectHttpBooker:
             target_timestamp_ms: Epoch ms to send the Reserve POST at. None
                 fires immediately (later bookings in a batch, window already
                 open).
+            window_timestamp_ms: The club's stated window, when the aim above has
+                been moved off it. Every offset reported - the ledger's
+                ``sentMsPastWindow`` and ``serverMsPastWindow``, and the timing
+                summary - is measured from here, so moving the aim does not put
+                a morning on a different scale from the ones before it. Defaults
+                to the target, which is what it was before the two diverged.
 
         Returns:
             The outcome; never raises for an ordinary booking failure.
         """
         result = DirectBookingResult()
+        # Held on the instance so the observation calls deep in the ladder do not
+        # each need it threaded down. Set before any early return so a misuse
+        # result carries a coherent frame too.
+        self._window_timestamp_ms = (
+            window_timestamp_ms if window_timestamp_ms is not None else target_timestamp_ms
+        )
 
         # Misuse, not a booking outcome - but reported as a PHASE_INIT result
         # rather than raised, because nothing has been sent and the caller's
@@ -752,6 +778,14 @@ class DirectHttpBooker:
         started = time_module.perf_counter()
         slot_time = self._slot_time
         remaining = list(self._fallback_times)
+        # Every *reported* offset is measured from the club's stated window; every
+        # instant slept to is measured from the aim. Keeping the two apart is what
+        # lets the aim move to 06:30:01 without the ledger changing scale.
+        window_frame_ms = (
+            self._window_timestamp_ms
+            if self._window_timestamp_ms is not None
+            else target_timestamp_ms
+        )
         # Latches on the first timeout and never clears; see the docstring.
         timed_out = False
         # Untimed bookings have no window to sweep around; the first rung is
@@ -773,13 +807,16 @@ class DirectHttpBooker:
             if slot_time is not None:
                 result.attempted_times.append(slot_time)
 
-            if target_timestamp_ms is not None and attempt == 1:
+            if window_frame_ms is not None and attempt == 1:
                 # First attempt only. Later ones are paced by the ladder, and
                 # reporting each against the window would bury the number that
                 # says whether we were on time.
-                result.timing["reserveSentAtMs"] = (
-                    int(time_module.time() * 1000) - target_timestamp_ms
-                )
+                #
+                # Measured from the club's stated window rather than from where
+                # we aimed, so this stays the same number the mornings before
+                # this one reported - "1030ms past the window", not "0ms past
+                # the thing we decided to aim at".
+                result.timing["reserveSentAtMs"] = int(time_module.time() * 1000) - window_frame_ms
             logger.info(
                 "DIRECT_HTTP: Firing Reserve %d/%d for %s - source=%s, viewState=%s, "
                 "%sms past the window",
@@ -805,8 +842,8 @@ class DirectHttpBooker:
             # line and fingerprint between the two reads are real work, and the
             # closer read is the honest one for the ledger.
             sent_ms_past_window = (
-                int(time_module.time() * 1000) - target_timestamp_ms
-                if target_timestamp_ms is not None
+                int(time_module.time() * 1000) - window_frame_ms
+                if window_frame_ms is not None
                 else None
             )
             if paired_rung_ms is not None and attempt == 1:
@@ -815,6 +852,7 @@ class DirectHttpBooker:
                     config,
                     body,
                     target_timestamp_ms=target_timestamp_ms,
+                    window_frame_ms=window_frame_ms,
                     second_rung_ms=paired_rung_ms,
                     slot_time=slot_time,
                     view_state=view_state,
@@ -892,7 +930,7 @@ class DirectHttpBooker:
                 response, document, observation, stalled = self._fire_single_reserve(
                     config,
                     body,
-                    target_timestamp_ms=target_timestamp_ms,
+                    window_frame_ms=window_frame_ms,
                     slot_time=slot_time,
                     view_state=view_state,
                     sent_ms_past_window=sent_ms_past_window,
@@ -1039,7 +1077,7 @@ class DirectHttpBooker:
         config: AbConfig,
         body: bytes,
         *,
-        target_timestamp_ms: int | None,
+        window_frame_ms: int | None,
         slot_time: time | None,
         view_state: str,
         sent_ms_past_window: int | None,
@@ -1047,6 +1085,10 @@ class DirectHttpBooker:
         result: DirectBookingResult,
     ) -> "tuple[PartialResponse | None, Node | None, ReserveObservation | None, str | None]":
         """Send one Reserve and observe the answer.
+
+        ``window_frame_ms`` is the club's stated window, which every offset in
+        the observation is measured from. Nothing here sleeps, so the aim does
+        not reach this far.
 
         Extracted from :meth:`_reserve_until_accepted` when the opening pair grew
         a second way of sending, so both paths hand the loop the same three
@@ -1099,7 +1141,7 @@ class DirectHttpBooker:
             response=response,
             document=document,
             markup=response.markup,
-            target_timestamp_ms=target_timestamp_ms,
+            target_timestamp_ms=window_frame_ms,
         )
         result.attempt_log.append(observation)
         _log_reserve_observation(observation)
@@ -1111,6 +1153,7 @@ class DirectHttpBooker:
         body: bytes,
         *,
         target_timestamp_ms: int,
+        window_frame_ms: int | None,
         second_rung_ms: int,
         slot_time: time | None,
         view_state: str,
@@ -1137,13 +1180,17 @@ class DirectHttpBooker:
         adopts exactly one.
         """
         lead_ms = int(round(self._lead_ms))
+        frame_ms = window_frame_ms if window_frame_ms is not None else target_timestamp_ms
 
         def send(
             rung_ms: int, wait: bool
         ) -> tuple[int, int, PartialResponse | None, Exception | None]:
+            # Slept to against the aim, reported against the club's stated
+            # window. The two differ by the offset at which we believe the sheet
+            # actually opens.
             if wait:
                 sleep_until(target_timestamp_ms + rung_ms - lead_ms)
-            sent_ms = int(time_module.time() * 1000) - target_timestamp_ms
+            sent_ms = int(time_module.time() * 1000) - frame_ms
             try:
                 sent = self.session.send_detached(config, body=body, timeout_s=_RESERVE_TIMEOUT_S)
             except (DirectHttpError, ViewExpiredError) as exc:
@@ -1198,7 +1245,7 @@ class DirectHttpBooker:
                 response=response,
                 document=document,
                 markup=response.markup,
-                target_timestamp_ms=target_timestamp_ms,
+                target_timestamp_ms=frame_ms,
             )
             pair.observations.append(observation)
             if observation.verdict != RESERVE_REFUSED and pair.accepted is None:
@@ -2030,7 +2077,7 @@ def _find_blocked_message(response: PartialResponse) -> str | None:
 
 
 def _next_future_rung(rungs: list[int], target_timestamp_ms: int | None) -> int | None:
-    """Pop the next ladder rung still ahead of us, discarding any already past.
+    """Pop the next ladder rung not yet meaningfully past, discarding stale ones.
 
     Every booking in a batch carries the same target timestamp - deliberately,
     so the batch's 6:30 gate does not depend on booking 1 reaching its wait - and
@@ -2040,19 +2087,27 @@ def _next_future_rung(rungs: list[int], target_timestamp_ms: int | None) -> int 
     the socket allows: a burst of identical Reserves, which is the opposite of
     what spacing them out is for.
 
-    A rung only means something while the instant it names is still ahead. Once
-    the window is minutes old there is no boundary left to find, a refusal is
-    much more likely to be a slot genuinely held, and the fallback list is the
+    Once the window is minutes old there is no boundary left to find, a refusal
+    is much more likely to be a slot genuinely held, and the fallback list is the
     right next move.
 
-    Consumes ``rungs`` as it goes. Returns None when none are left in the future.
+    But "still ahead" was too strict once the ladder became retries rather than a
+    search over offsets. A rung is reached only after the previous answer lands,
+    so our own round trip - 593-828ms measured - eats whatever rung falls inside
+    it. With the opening pair resolving around aim+1000ms, a 1000ms rung would
+    fire on a fast morning and be silently dropped on a slow one, sending the run
+    to the fallback list while the tee time we wanted had one ask left. The grace
+    below is what separates "our round trip ate this rung" from "this booking is
+    minutes past its window".
+
+    Consumes ``rungs`` as it goes. Returns None when only stale ones are left.
     """
     if target_timestamp_ms is None:
         return None
     now_ms = int(time_module.time() * 1000)
     while rungs:
         rung = rungs.pop(0)
-        if target_timestamp_ms + rung > now_ms:
+        if target_timestamp_ms + rung + _RUNG_LATE_GRACE_MS > now_ms:
             return rung
     return None
 

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -43,6 +43,7 @@ caller treats as "fall back to the Selenium chain". Nothing here is trusted
 enough to be the only path to a booking.
 """
 
+import concurrent.futures
 import hashlib
 import logging
 import re
@@ -332,6 +333,10 @@ class DirectHttpBooker:
         # Offsets past the window to ask for the staged slot at, first to last.
         # The single 0 is the historical behaviour: one shot, on the instant.
         self._sweep_offsets_ms: tuple[int, ...] = (0,)
+        # Fire the first two rungs concurrently rather than waiting out a round
+        # trip between them. Off here so the historical one-shot default stays
+        # exactly that; prepare() turns it on.
+        self._pipeline_opening_pair: bool = False
 
     # -- staging ----------------------------------------------------------
 
@@ -344,6 +349,7 @@ class DirectHttpBooker:
         measure_skew: bool = False,
         refresh_at_window: bool = False,
         sweep_offsets_ms: Sequence[int] = (0,),
+        pipeline_opening_pair: bool = False,
     ) -> None:
         """Resolve and pre-serialize the Reserve request, and warm the socket.
 
@@ -362,7 +368,7 @@ class DirectHttpBooker:
                 which times are spoken for by the rest of the batch.
             measure_skew: Probe the club's clock so the Reserve can be timed to
                 *arrive* as the window opens rather than to leave then. Timed
-                bookings only - it costs ~1.3s of probing, and an immediate
+                bookings only - it costs ~5s of probing, and an immediate
                 booking has no instant to hit.
             refresh_at_window: Re-render the tee sheet at the target instant and
                 fire Reserve against that render. Off by default; see
@@ -371,6 +377,10 @@ class DirectHttpBooker:
                 at, first to last, before any fallback is tried. Timed bookings
                 only. ``(0,)`` is one shot on the instant, which is what every
                 lost morning did. See :meth:`_reserve_until_accepted`.
+            pipeline_opening_pair: Fire the first two offsets without waiting for
+                the first one's answer, so the pair brackets the refusal boundary
+                inside a single round trip. Needs at least two offsets and a
+                timed booking; ignored otherwise.
         """
         document = parse_html(page_html)
         button = document.find_by_id(reserve_button_id)
@@ -397,9 +407,13 @@ class DirectHttpBooker:
         # is slept to absolutely, so an unordered list would sleep backwards
         # (returning instantly) and quietly collapse the sweep into a burst.
         self._sweep_offsets_ms = tuple(sorted(dict.fromkeys(sweep_offsets_ms))) or (0,)
+        # Needs a pair to pipeline. A single-rung ladder is the one-shot case,
+        # where there is nothing to overlap and a worker thread would only add a
+        # handoff to the one request that has to be fast.
+        self._pipeline_opening_pair = pipeline_opening_pair and len(self._sweep_offsets_ms) >= 2
         logger.info(
             "DIRECT_HTTP: Reserve request staged - source=%s, slot=%s, %d body bytes, "
-            "viewState=%s, sweep=%s, fallbacks=%s",
+            "viewState=%s, sweep=%s%s, fallbacks=%s",
             config.source,
             self._slot_time.strftime("%I:%M %p") if self._slot_time else "unreadable",
             len(self._reserve_body),
@@ -408,6 +422,7 @@ class DirectHttpBooker:
             # from the one staged here.
             _view_state_fingerprint(self.session),
             "+".join(str(offset) for offset in self._sweep_offsets_ms) + "ms",
+            " (first two pipelined)" if self._pipeline_opening_pair else "",
             ", ".join(t.strftime("%I:%M %p") for t in self._fallback_times) or "none",
         )
         if refresh_at_window:
@@ -587,11 +602,19 @@ class DirectHttpBooker:
             result.phase = PHASE_PRECISION_WAIT
             result.timing["msUntilTarget"] = target_timestamp_ms - int(time_module.time() * 1000)
             result.timing["arrivalLeadMs"] = round(self._lead_ms)
-            # Led, so that the request *arrives* as the window opens. The drift
-            # is still reported against the lead-adjusted instant, which is the
-            # one the wait was actually aiming at.
+            # The first rung is the aim point, and it is no longer 0: the club
+            # refuses while its own clock still reads 06:30:00, so arriving on
+            # the instant asks a question that has never once been answered yes.
+            # Slept to here rather than inside the ladder because this is the
+            # wait that has to be precise - everything after it is paced by how
+            # fast the club answers.
+            opening_offset_ms = self._sweep_offsets_ms[0]
+            result.timing["openingOffsetMs"] = opening_offset_ms
+            # Led, so that the request *arrives* at the aimed-at offset. The
+            # drift is still reported against the lead-adjusted instant, which is
+            # the one the wait was actually aiming at.
             result.timing["clickDriftMs"] = sleep_until(
-                target_timestamp_ms - int(round(self._lead_ms))
+                target_timestamp_ms + opening_offset_ms - int(round(self._lead_ms))
             )
 
             # After the wait, not before: a sheet re-rendered while the window
@@ -734,6 +757,12 @@ class DirectHttpBooker:
         # Untimed bookings have no window to sweep around; the first rung is
         # already spent by the precision wait in _run_chain.
         rungs = list(self._sweep_offsets_ms[1:]) if target_timestamp_ms is not None else []
+        # The second rung leaves the ladder when it is pipelined: it is fired
+        # alongside the first rather than after it, so the loop must not also
+        # walk to it.
+        paired_rung_ms: int | None = None
+        if self._pipeline_opening_pair and target_timestamp_ms is not None and rungs:
+            paired_rung_ms = rungs.pop(0)
         max_attempts = _RESERVE_MAX_ATTEMPTS + len(rungs)
         last_reason: str | None = None
         attempt = 0
@@ -780,98 +809,136 @@ class DirectHttpBooker:
                 if target_timestamp_ms is not None
                 else None
             )
-            try:
-                response = self.session.post(config, body=body, timeout_s=_RESERVE_TIMEOUT_S)
-            except DirectHttpConnectionError:
-                # The phase was advanced before the call because a request on the
-                # socket cannot be told from one that was answered and lost. This
-                # is the one case where it can: no connection was established, so
-                # nothing was submitted. Rolling the phase back is what keeps the
-                # browser chain available - past PRE_SUBMIT_PHASES the provider
-                # treats a retry as racing our own booking and reports instead.
-                result.phase = PHASE_RESERVE_STAGED
-                raise
-            except DirectHttpTimeoutError as exc:
-                timed_out = True
-                last_reason = str(exc)
-                # Recorded like any other attempt. The ledger previously lost the
-                # attempt that decided both mornings, so a run whose ladder was
-                # cut short read as "1 attempt, every attempt refused".
-                observation = ReserveObservation(
-                    attempt=attempt,
+            if paired_rung_ms is not None and attempt == 1:
+                assert target_timestamp_ms is not None  # paired only when timed
+                pair = self._fire_opening_pair(
+                    config,
+                    body,
+                    target_timestamp_ms=target_timestamp_ms,
+                    second_rung_ms=paired_rung_ms,
                     slot_time=slot_time,
-                    source=config.source,
                     view_state=view_state,
-                    verdict=RESERVE_TIMEDOUT,
-                    reason=str(exc),
-                    sent_ms_past_window=sent_ms_past_window,
-                    round_trip_ms=int(_RESERVE_TIMEOUT_S * 1000),
+                    first_sent_ms_past_window=sent_ms_past_window,
                 )
-                result.attempt_log.append(observation)
-                _log_reserve_observation(observation)
+                # Both requests are one iteration to the loop but two questions
+                # to the club, and the ledger is the record of which offsets were
+                # asked. Counting them here keeps "attempts" honest.
+                if pair.never_connected:
+                    # Neither half reached the socket, so nothing was submitted.
+                    # Same reasoning as the single-send path: rolling the phase
+                    # back is what keeps the browser chain a safe retry, and a
+                    # 6:30 that cannot open a socket can still be won by it.
+                    result.phase = PHASE_RESERVE_STAGED
+                    raise DirectHttpConnectionError(
+                        f"Neither opening Reserve for {config.source} connected: {pair.reason}"
+                    )
+                result.attempt_log.extend(pair.observations)
+                for pair_observation in pair.observations:
+                    _log_reserve_observation(pair_observation)
+                if slot_time is not None and len(pair.observations) > 1:
+                    result.attempted_times.append(slot_time)
+                attempt += len(pair.observations) - 1
+                result.timing["reserveAttempts"] = attempt
+                timed_out = timed_out or pair.timed_out
 
-                # Checked here as well as after a refusal: the refusal path is
-                # `continue`d past, and without this a run that only ever timed
-                # out would spend a full _RESERVE_TIMEOUT_S per remaining rung.
-                spent_ms = (time_module.perf_counter() - started) * 1000
-                if spent_ms >= _RESERVE_DEADLINE_MS or target_timestamp_ms is None:
-                    logger.warning(
-                        "DIRECT_HTTP: Reserve %d never answered and %dms is spent; stopping "
-                        "rather than asking for a different tee time",
+                if pair.accepted is not None:
+                    result.final_markup = pair.accepted.markup
+                    self.session.adopt(pair.accepted)
+                    result.booked_slot_time = slot_time
+                    logger.info(
+                        "DIRECT_HTTP: Reserve accepted for %s from the opening pair at +%dms "
+                        "after %dms (%s)",
+                        slot_time.strftime("%I:%M %p") if slot_time else "the staged slot",
+                        pair.accepted_rung_ms or 0,
+                        int((time_module.perf_counter() - started) * 1000),
+                        pair.accepted_reason or "",
+                    )
+                    return pair.accepted
+
+                if pair.carried is None:
+                    # Neither half answered. Same situation as a serial stall,
+                    # and handled the same way: the ladder's schedule is moot but
+                    # its length is still the budget for asking again.
+                    last_reason = pair.reason
+                    spent_ms = (time_module.perf_counter() - started) * 1000
+                    if spent_ms >= _RESERVE_DEADLINE_MS or not rungs:
+                        logger.warning(
+                            "DIRECT_HTTP: Neither opening Reserve answered after %dms; stopping "
+                            "rather than asking for a different tee time",
+                            int(spent_ms),
+                        )
+                        break
+                    stall_rung_ms = rungs.pop(0)
+                    logger.info(
+                        "DIRECT_HTTP: Neither opening Reserve answered after %dms; asking again "
+                        "for %s at +%dms (same slot only - the club may already be holding it)",
+                        int(spent_ms),
+                        slot_time.strftime("%I:%M %p") if slot_time else "the staged slot",
+                        stall_rung_ms,
+                    )
+                    sleep_until(target_timestamp_ms + stall_rung_ms - int(round(self._lead_ms)))
+                    continue
+
+                # Refused, both times. Carry the later response forward: it is
+                # the freshest view of the sheet, which is what any fallback has
+                # to be relocated in.
+                self.session.adopt(pair.carried)
+                result.final_markup = pair.carried.markup
+                response = pair.carried
+                document = pair.carried_document
+                observation = pair.carried_observation
+                assert document is not None and observation is not None
+            else:
+                response, document, observation, stalled = self._fire_single_reserve(
+                    config,
+                    body,
+                    target_timestamp_ms=target_timestamp_ms,
+                    slot_time=slot_time,
+                    view_state=view_state,
+                    sent_ms_past_window=sent_ms_past_window,
+                    attempt=attempt,
+                    result=result,
+                )
+                if stalled is not None:
+                    timed_out = True
+                    last_reason = stalled
+                    spent_ms = (time_module.perf_counter() - started) * 1000
+                    if spent_ms >= _RESERVE_DEADLINE_MS or target_timestamp_ms is None:
+                        logger.warning(
+                            "DIRECT_HTTP: Reserve %d never answered and %dms is spent; stopping "
+                            "rather than asking for a different tee time",
+                            attempt,
+                            int(spent_ms),
+                        )
+                        break
+                    # Deliberately not _next_future_rung. A stall of seconds has
+                    # already carried us past every offset the ladder was there
+                    # to explore, so its *schedule* is moot - but its length is
+                    # still the budget for how many more times to ask. Take the
+                    # next rung whether or not its instant has passed;
+                    # sleep_until no-ops on one already gone, which fires the
+                    # retry at once. That is the right move anyway: the club
+                    # granted at ~1.24s on 08-08 and 08-12, and a stall leaves us
+                    # well past that.
+                    if not rungs:
+                        logger.warning(
+                            "DIRECT_HTTP: Reserve %d never answered and the ladder is spent; "
+                            "stopping rather than asking for a different tee time",
+                            attempt,
+                        )
+                        break
+                    stall_rung_ms = rungs.pop(0)
+                    logger.info(
+                        "DIRECT_HTTP: Reserve %d never answered after %dms; asking again for %s "
+                        "at +%dms (same slot only - the club may already be holding it)",
                         attempt,
                         int(spent_ms),
+                        slot_time.strftime("%I:%M %p") if slot_time else "the staged slot",
+                        stall_rung_ms,
                     )
-                    break
-
-                # Deliberately not _next_future_rung. A stall of seconds has
-                # already carried us past every offset the ladder was there to
-                # explore, so its *schedule* is moot - but its length is still
-                # the budget for how many more times to ask. Take the next rung
-                # whether or not its instant has passed; sleep_until no-ops on
-                # one already gone, which fires the retry at once. That is the
-                # right move anyway: the club granted at ~1.24s on 08-08 and
-                # 08-12, and a stall leaves us well past that.
-                if not rungs:
-                    logger.warning(
-                        "DIRECT_HTTP: Reserve %d never answered and the ladder is spent; "
-                        "stopping rather than asking for a different tee time",
-                        attempt,
-                    )
-                    break
-                stall_rung_ms = rungs.pop(0)
-                # Re-staged from nothing: there is no response to relocate the
-                # button in, so the previously staged config and body are sent
-                # again unchanged. Same slot, same ViewState - which is exactly
-                # the request 08-08 and 08-12 had accepted a rung later.
-                logger.info(
-                    "DIRECT_HTTP: Reserve %d never answered after %dms; asking again for %s "
-                    "at +%dms (same slot only - the club may already be holding it)",
-                    attempt,
-                    int(spent_ms),
-                    slot_time.strftime("%I:%M %p") if slot_time else "the staged slot",
-                    stall_rung_ms,
-                )
-                sleep_until(target_timestamp_ms + stall_rung_ms - int(round(self._lead_ms)))
-                continue
-            result.final_markup = response.markup
-
-            # One parse, three questions now. At ~190ms for a 500KB sheet this
-            # is the largest single cost in the loop, and the verdict, the
-            # ledger row and the next candidate's handler all come out of it.
-            document = parse_html(response.markup)
-            observation = observe_reserve_response(
-                attempt=attempt,
-                slot_time=slot_time,
-                source=config.source,
-                view_state=view_state,
-                response=response,
-                document=document,
-                markup=response.markup,
-                target_timestamp_ms=target_timestamp_ms,
-            )
-            result.attempt_log.append(observation)
-            _log_reserve_observation(observation)
-
+                    sleep_until(target_timestamp_ms + stall_rung_ms - int(round(self._lead_ms)))
+                    continue
+                assert response is not None and document is not None and observation is not None
             if observation.verdict != RESERVE_REFUSED:
                 result.booked_slot_time = slot_time
                 if attempt > 1:
@@ -966,6 +1033,199 @@ class DirectHttpBooker:
             "; at least one Reserve never answered, so the outcome is unknown" if timed_out else "",
         )
         return None
+
+    def _fire_single_reserve(
+        self,
+        config: AbConfig,
+        body: bytes,
+        *,
+        target_timestamp_ms: int | None,
+        slot_time: time | None,
+        view_state: str,
+        sent_ms_past_window: int | None,
+        attempt: int,
+        result: DirectBookingResult,
+    ) -> "tuple[PartialResponse | None, Node | None, ReserveObservation | None, str | None]":
+        """Send one Reserve and observe the answer.
+
+        Extracted from :meth:`_reserve_until_accepted` when the opening pair grew
+        a second way of sending, so both paths hand the loop the same three
+        things and the loop keeps one copy of what to do with them.
+
+        Returns:
+            ``(response, document, observation, None)`` when the club answered,
+            or ``(None, None, None, reason)`` when it did not. The stall reason
+            is the caller's signal to walk the ladder rather than the sheet.
+        """
+        try:
+            response = self.session.post(config, body=body, timeout_s=_RESERVE_TIMEOUT_S)
+        except DirectHttpConnectionError:
+            # The phase was advanced before the call because a request on the
+            # socket cannot be told from one that was answered and lost. This is
+            # the one case where it can: no connection was established, so
+            # nothing was submitted. Rolling the phase back is what keeps the
+            # browser chain available - past PRE_SUBMIT_PHASES the provider
+            # treats a retry as racing our own booking and reports instead.
+            result.phase = PHASE_RESERVE_STAGED
+            raise
+        except DirectHttpTimeoutError as exc:
+            # Recorded like any other attempt. The ledger previously lost the
+            # attempt that decided both mornings, so a run whose ladder was cut
+            # short read as "1 attempt, every attempt refused".
+            observation = ReserveObservation(
+                attempt=attempt,
+                slot_time=slot_time,
+                source=config.source,
+                view_state=view_state,
+                verdict=RESERVE_TIMEDOUT,
+                reason=str(exc),
+                sent_ms_past_window=sent_ms_past_window,
+                round_trip_ms=int(_RESERVE_TIMEOUT_S * 1000),
+            )
+            result.attempt_log.append(observation)
+            _log_reserve_observation(observation)
+            return None, None, None, str(exc)
+
+        result.final_markup = response.markup
+        # One parse, three questions now. At ~190ms for a 500KB sheet this is the
+        # largest single cost in the loop, and the verdict, the ledger row and
+        # the next candidate's handler all come out of it.
+        document = parse_html(response.markup)
+        observation = observe_reserve_response(
+            attempt=attempt,
+            slot_time=slot_time,
+            source=config.source,
+            view_state=view_state,
+            response=response,
+            document=document,
+            markup=response.markup,
+            target_timestamp_ms=target_timestamp_ms,
+        )
+        result.attempt_log.append(observation)
+        _log_reserve_observation(observation)
+        return response, document, observation, None
+
+    def _fire_opening_pair(
+        self,
+        config: AbConfig,
+        body: bytes,
+        *,
+        target_timestamp_ms: int,
+        second_rung_ms: int,
+        slot_time: time | None,
+        view_state: str,
+        first_sent_ms_past_window: int | None,
+    ) -> "_OpeningPair":
+        """Ask for the same slot at the first two offsets without waiting between.
+
+        Serially the ladder cannot ask twice inside one round trip. On 2026-08-15
+        the first Reserve went at -60ms and its refusal landed at +940ms, by
+        which point the +900 rung was gone and the next question could not go
+        until +1240ms. That is fine when the first rung is 0 and expected to
+        fail, but the first rung is now aimed at the club's second tick - and
+        aiming there serially would push the follow-up to ~+1780ms, later than
+        the +1240ms that has been granted three times. Overlapping them means a
+        mis-measured tick costs one rung rather than the morning.
+
+        Both requests are for the *same* slot, so neither can reserve a second
+        tee time and collide with the one-round-per-day rule; the worst case is
+        that the club grants the same hold twice and the later grant is dropped.
+
+        Sent detached, because :meth:`PrimeFacesSession.post` folds the response
+        into the session's form state and two in-flight requests doing that would
+        race over the fields the rest of the chain is built from. The caller
+        adopts exactly one.
+        """
+        lead_ms = int(round(self._lead_ms))
+
+        def send(
+            rung_ms: int, wait: bool
+        ) -> tuple[int, int, PartialResponse | None, Exception | None]:
+            if wait:
+                sleep_until(target_timestamp_ms + rung_ms - lead_ms)
+            sent_ms = int(time_module.time() * 1000) - target_timestamp_ms
+            try:
+                sent = self.session.send_detached(config, body=body, timeout_s=_RESERVE_TIMEOUT_S)
+            except (DirectHttpError, ViewExpiredError) as exc:
+                return rung_ms, sent_ms, None, exc
+            return rung_ms, sent_ms, sent, None
+
+        # The first request goes on this thread: it is the one the whole morning
+        # is timed around, and handing it to a pool would put a scheduling hop in
+        # front of the only send that has to be exact. The worker takes the later
+        # rung, where a hundred microseconds does not matter.
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="reserve-pair"
+        ) as pool:
+            deferred = pool.submit(send, second_rung_ms, True)
+            first = send(self._sweep_offsets_ms[0], False)
+            second = deferred.result()
+
+        pair = _OpeningPair(observations=[])
+        # Only counts when *nothing* was sent. A read or write timeout may have
+        # landed at the club, and treating that as "never happened" is what would
+        # let the run book a second tee time on top of a hold it cannot see.
+        never_connected = True
+        for index, (rung_ms, sent_ms, response, exc) in enumerate((first, second)):
+            attempt_number = index + 1
+            if exc is not None:
+                if not isinstance(exc, DirectHttpConnectionError):
+                    never_connected = False
+                    pair.timed_out = True
+                pair.reason = str(exc)
+                pair.observations.append(
+                    ReserveObservation(
+                        attempt=attempt_number,
+                        slot_time=slot_time,
+                        source=config.source,
+                        view_state=view_state,
+                        verdict=RESERVE_TIMEDOUT,
+                        reason=str(exc),
+                        sent_ms_past_window=sent_ms,
+                        round_trip_ms=int(_RESERVE_TIMEOUT_S * 1000),
+                    )
+                )
+                continue
+
+            never_connected = False
+            assert response is not None
+            document = parse_html(response.markup)
+            observation = observe_reserve_response(
+                attempt=attempt_number,
+                slot_time=slot_time,
+                source=config.source,
+                view_state=view_state,
+                response=response,
+                document=document,
+                markup=response.markup,
+                target_timestamp_ms=target_timestamp_ms,
+            )
+            pair.observations.append(observation)
+            if observation.verdict != RESERVE_REFUSED and pair.accepted is None:
+                # First grant in rung order wins. A second grant for the same
+                # slot is the same hold said twice, and adopting the later one
+                # would only throw away the earlier view for nothing.
+                pair.accepted = response
+                pair.accepted_rung_ms = rung_ms
+                pair.accepted_reason = observation.reason
+            elif observation.verdict == RESERVE_REFUSED:
+                pair.reason = observation.reason
+                # Latest refusal wins as the one carried forward: it is the
+                # freshest sheet, and a fallback has to be relocated in it.
+                pair.carried = response
+                pair.carried_document = document
+                pair.carried_observation = observation
+
+        pair.never_connected = never_connected
+        # first_sent_ms_past_window is read for the log line only; the ledger
+        # takes each request's own send time from the exchange above.
+        logger.info(
+            "DIRECT_HTTP: Opening pair fired at +%dms and +%dms (aimed from %sms)",
+            first[0],
+            second[0],
+            first_sent_ms_past_window if first_sent_ms_past_window is not None else "?",
+        )
+        return pair
 
     def _next_candidate(
         self,
@@ -1674,6 +1934,36 @@ class ReserveObservation:
             "evalText": self.eval_text[:2000],
             "callbackArgs": self.callback_args,
         }
+
+
+@dataclass
+class _OpeningPair:
+    """What the two overlapped opening Reserves came back with.
+
+    ``accepted`` is the first grant in rung order; ``carried`` is the latest
+    refusal, which is the response the chain continues against when neither was
+    granted - it holds the freshest sheet for relocating a fallback in. Both are
+    detached: exactly one must be adopted before the chain goes on.
+
+    Defined here rather than beside :class:`DirectHttpBooker` because it names
+    :class:`ReserveObservation`, which the module resolves at class-creation
+    time.
+    """
+
+    observations: list[ReserveObservation]
+    accepted: PartialResponse | None = None
+    accepted_rung_ms: int | None = None
+    accepted_reason: str | None = None
+    carried: PartialResponse | None = None
+    carried_document: Node | None = None
+    carried_observation: ReserveObservation | None = None
+    # A read or write timeout, which may have reached the club. Closes the
+    # fallback list for the rest of the run.
+    timed_out: bool = False
+    # Every request failed before a byte left, so nothing was submitted and the
+    # browser chain is still a safe retry.
+    never_connected: bool = False
+    reason: str | None = None
 
 
 def observe_reserve_response(

--- a/app/providers/walden_http_booker.py
+++ b/app/providers/walden_http_booker.py
@@ -927,7 +927,13 @@ class DirectHttpBooker:
                 observation = pair.carried_observation
                 assert document is not None and observation is not None
             else:
-                response, document, observation, stalled = self._fire_single_reserve(
+                # Bound to their own names and only widened into the loop's
+                # variables past the stall check below. Assigning straight into
+                # `response` would give it an optional type on this branch and a
+                # non-optional one on the paired branch above, which is a real
+                # ambiguity rather than a typing nuisance: the two branches have
+                # to hand the shared tail the same thing.
+                sent, sent_document, sent_observation, stalled = self._fire_single_reserve(
                     config,
                     body,
                     window_frame_ms=window_frame_ms,
@@ -976,7 +982,10 @@ class DirectHttpBooker:
                     )
                     sleep_until(target_timestamp_ms + stall_rung_ms - int(round(self._lead_ms)))
                     continue
-                assert response is not None and document is not None and observation is not None
+                assert (
+                    sent is not None and sent_document is not None and sent_observation is not None
+                )
+                response, document, observation = sent, sent_document, sent_observation
             if observation.verdict != RESERVE_REFUSED:
                 result.booked_slot_time = slot_time
                 if attempt > 1:

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -3315,6 +3315,28 @@ class WaldenGolfProvider(ReservationProvider):
                     page_text, "direct HTTP response"
                 )
                 if confirmed:
+                    # Checked even though the response said yes. "Confirmed" here
+                    # is a phrase match on a PrimeFaces partial update - 08-15
+                    # returned success on the word "thank you" - and the one
+                    # failure class that looks exactly like a win in the logs is
+                    # a chain that completed against no reservation. The check
+                    # costs a page load after the race is over, and its answer is
+                    # the only thing that separates the two.
+                    #
+                    # Reported, not enforced: a text-confirmed booking is not
+                    # thrown away because the reservations page was slow to load,
+                    # and _reservation_exists returns None rather than False when
+                    # it could not read the page at all.
+                    held = self._reservation_exists(driver, target_date, booked_time)
+                    if held is False:
+                        logger.error(
+                            "RESERVATION_CHECK: The response confirmed the booking (%s) but "
+                            "the tee time is not on the member's reservations page",
+                            verdict_detail,
+                        )
+                        self._capture_response_artifact(
+                            "direct_http_confirmed_not_listed", direct_markup
+                        )
                     return BookingResult(
                         success=True,
                         booked_time=booked_time,
@@ -4147,6 +4169,12 @@ class WaldenGolfProvider(ReservationProvider):
                     settings.walden_sweep_offsets_ms()
                     if execute_at_timestamp_ms is not None
                     else (0,)
+                ),
+                # Same reasoning: overlapping the first two rungs only means
+                # anything when there is a window to bracket.
+                pipeline_opening_pair=(
+                    settings.walden_reserve_pipeline_opening_pair
+                    and execute_at_timestamp_ms is not None
                 ),
             )
         except Exception as e:  # noqa: BLE001 - opt-in path must never break booking

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -1342,11 +1342,19 @@ class WaldenGolfProvider(ReservationProvider):
                     # batch back and it would race a still-locked tee sheet.
                     # Wait in Python instead: coarser, but a kill switch that
                     # silently drops the window gate is worse than a slow one.
+                    #
+                    # Shifted by the same offset as the other two chains. This
+                    # path reads execute_at rather than execute_at_timestamp_ms,
+                    # so without this it would be the one route still firing at
+                    # the stated window - the arrival the offset exists to avoid,
+                    # and a silent disagreement about when the window opens
+                    # sitting behind a kill switch nobody exercises.
                     logger.info(
                         "BATCH_BOOKING: Fast chain disabled - waiting for the booking "
-                        "window in Python before the Selenium flow"
+                        "window (+%dms) in Python before the Selenium flow",
+                        aim_offset_ms,
                     )
-                    self._precision_wait_until(execute_at)
+                    self._precision_wait_until(execute_at + timedelta(milliseconds=aim_offset_ms))
 
             # Track times that have been successfully booked to avoid conflicts
             # When a booking succeeds, we add its booked_time to this set

--- a/app/providers/walden_provider.py
+++ b/app/providers/walden_provider.py
@@ -1296,6 +1296,10 @@ class WaldenGolfProvider(ReservationProvider):
             # Instead of Python waiting then calling JS, we inject JS that self-triggers
             # at the exact timestamp. This eliminates Python→Selenium→JS handoff latency.
             execute_at_timestamp_ms: int | None = None
+            # The club's stated window, kept unshifted. Every offset in the race
+            # ledger is measured from here, so the numbers stay on one scale
+            # across the aim moving - ten mornings of evidence are in this frame.
+            window_timestamp_ms: int | None = None
             if execute_at:
                 # Normalize to naive CT first (execute_at may be aware or naive),
                 # then convert via relative delta to avoid host-timezone interpretation.
@@ -1303,12 +1307,32 @@ class WaldenGolfProvider(ReservationProvider):
                 execute_at_ct = CTDateTime.to_naive_ct(execute_at)
                 now_ct = CTDateTime.to_naive_ct(CTDateTime.now())
                 delay_ms = max(0, int((execute_at_ct - now_ct).total_seconds() * 1000))
-                execute_at_timestamp_ms = int(time_module.time() * 1000) + delay_ms
+                window_timestamp_ms = int(time_module.time() * 1000) + delay_ms
+                # The sheet does not open when the club says it does. Applied
+                # here rather than inside the direct booker so both chains agree
+                # on when the window opens - the JS chain reads the same target
+                # and would otherwise click into the one arrival that has never
+                # been granted.
+                aim_offset_ms = max(
+                    0,
+                    settings.walden_window_opens_offset_ms + settings.walden_reserve_aim_margin_ms,
+                )
+                execute_at_timestamp_ms = window_timestamp_ms + aim_offset_ms
                 logger.info(
                     f"BATCH_BOOKING: Step 7 - Timed booking mode, "
                     f"target timestamp: {execute_at_timestamp_ms} "
-                    f"({execute_at_ct.strftime('%H:%M:%S.%f')} CT, delay={delay_ms}ms)"
+                    f"({execute_at_ct.strftime('%H:%M:%S.%f')} CT +{aim_offset_ms}ms, "
+                    f"delay={delay_ms + aim_offset_ms}ms)"
                 )
+                if aim_offset_ms:
+                    logger.info(
+                        "BATCH_BOOKING: Aiming %dms past the stated window - the club opens "
+                        "at +%dms and %dms is margin on the clock probe. Ledger offsets "
+                        "stay measured from the stated window.",
+                        aim_offset_ms,
+                        settings.walden_window_opens_offset_ms,
+                        settings.walden_reserve_aim_margin_ms,
+                    )
 
                 if not use_fast_booking:
                     # The 6:30 gate lives inside the fast chain - the JS
@@ -1379,6 +1403,7 @@ class WaldenGolfProvider(ReservationProvider):
                         use_fast_js=use_fast_booking,
                         prelocated_slot=prelocated_slots.get(req.booking_id),
                         execute_at_timestamp_ms=use_timed_for_this_booking,
+                        window_timestamp_ms=window_timestamp_ms,
                         target_date=target_date,
                     )
 
@@ -2939,6 +2964,7 @@ class WaldenGolfProvider(ReservationProvider):
         use_fast_js: bool = False,
         prelocated_slot: dict[str, Any] | None = None,
         execute_at_timestamp_ms: int | None = None,
+        window_timestamp_ms: int | None = None,
         target_date: date | None = None,
     ) -> BookingResult:
         """
@@ -2977,6 +3003,10 @@ class WaldenGolfProvider(ReservationProvider):
                             Used to skip DOM re-scanning when the slot was located before
                             the booking window opened.
             execute_at_timestamp_ms: Optional Unix timestamp in milliseconds for timed booking.
+            window_timestamp_ms: The club's stated 06:30:00, when it differs from
+                the instant above. Reporting only: every offset in the race
+                ledger is measured from here, so the aim can move without
+                starting a second scale alongside the mornings already recorded.
                             When provided, uses _stage_timed_booking_chain_js which busy-waits
                             in JavaScript until the exact timestamp before clicking Reserve.
                             This eliminates Python→Selenium→JS handoff latency at 6:30 AM.
@@ -3116,6 +3146,7 @@ class WaldenGolfProvider(ReservationProvider):
                 num_players,
                 execute_at_timestamp_ms,
                 fallback_times=fallback_times,
+                window_timestamp_ms=window_timestamp_ms,
             )
 
             if chain_result is None:
@@ -4111,6 +4142,7 @@ class WaldenGolfProvider(ReservationProvider):
         num_players: int,
         execute_at_timestamp_ms: int | None,
         fallback_times: Sequence[time] = (),
+        window_timestamp_ms: int | None = None,
     ) -> dict[str, Any] | None:
         """
         Attempt the booking chain over direct HTTP instead of browser clicks.
@@ -4125,6 +4157,8 @@ class WaldenGolfProvider(ReservationProvider):
             slot_info: Slot dict from _find_target_slot_js; needs 'reserveId'
             num_players: Number of players (1-4)
             execute_at_timestamp_ms: Epoch ms to fire Reserve at, or None for now
+            window_timestamp_ms: The club's stated window, for reporting offsets
+                from. Defaults to the instant above when they are the same.
             fallback_times: Tee times to try, best first, when the club refuses
                 the slot above as held by another member
 
@@ -4193,7 +4227,11 @@ class WaldenGolfProvider(ReservationProvider):
             return None
 
         try:
-            result = booker.book(num_players, target_timestamp_ms=execute_at_timestamp_ms)
+            result = booker.book(
+                num_players,
+                target_timestamp_ms=execute_at_timestamp_ms,
+                window_timestamp_ms=window_timestamp_ms,
+            )
         except Exception as e:  # noqa: BLE001 - see above
             # book() turns its own failures into results, so anything raised
             # here is a bug. Reserve may already have been sent, so report it
@@ -4213,7 +4251,12 @@ class WaldenGolfProvider(ReservationProvider):
         # the record of what the club did, and a morning that *won* is exactly
         # as informative about where the boundary sits as one that lost.
         if settings.walden_capture_race_ledger and execute_at_timestamp_ms is not None:
-            self._capture_race_ledger(result, execute_at_timestamp_ms)
+            # The stated window, not the aim: the ledger's offsets have to stay
+            # on the scale the mornings before this one were recorded on.
+            self._capture_race_ledger(
+                result,
+                window_timestamp_ms if window_timestamp_ms is not None else execute_at_timestamp_ms,
+            )
 
         # The one line a post-mortem starts from, so everything that decides a
         # morning has to be readable in it without going back through the run.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -244,6 +244,11 @@ resource "google_cloud_run_v2_service" "teetime" {
       }
 
       env {
+        name  = "WALDEN_RESERVE_PIPELINE_OPENING_PAIR"
+        value = tostring(var.walden_reserve_pipeline_opening_pair)
+      }
+
+      env {
         name  = "WALDEN_CAPTURE_RACE_LEDGER"
         value = tostring(var.walden_capture_race_ledger)
       }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -239,6 +239,16 @@ resource "google_cloud_run_v2_service" "teetime" {
       }
 
       env {
+        name  = "WALDEN_WINDOW_OPENS_OFFSET_MS"
+        value = tostring(var.walden_window_opens_offset_ms)
+      }
+
+      env {
+        name  = "WALDEN_RESERVE_AIM_MARGIN_MS"
+        value = tostring(var.walden_reserve_aim_margin_ms)
+      }
+
+      env {
         name  = "WALDEN_RESERVE_SWEEP_OFFSETS_MS"
         value = var.walden_reserve_sweep_offsets_ms
       }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -346,16 +346,27 @@ variable "walden_reserve_pipeline_opening_pair" {
     the follow-up to ~+1780ms, later than the +1240ms that has been granted three
     times.
 
-    Pipelined, the pair brackets the boundary inside one round trip and the run
-    is no worse off than a serial 1250 even when the tick estimate is wrong. Both
-    requests are for the same slot, so neither can reserve a second tee time and
-    collide with the club's one-round-per-day rule; the worst case is the club
-    granting the same hold twice.
+    Pipelined, the pair brackets the open inside one round trip. Both requests
+    are for the same slot, so neither can reserve a second tee time and collide
+    with the club's one-round-per-day rule; the worst case is the club granting
+    the same hold twice.
+
+    Off by default, and not because it is thought wrong. Serially the ladder now
+    asks at roughly +1030, +1770 and +2510ms from the stated window - all past
+    every refusal on record, the last two past every grant - so this buys an ask
+    at +1280 instead of +1770, which only pays when the hypothesis is wrong and
+    the slot is contested.
+
+    Against that it is untested against the club, and the sequence it creates - a
+    Reserve granted while a second for the same slot is already in flight - has
+    never been observed. With rung 0 now being the hypothesis rather than a
+    guess, a right hypothesis makes that sequence the daily case, not the rare
+    one. Exercise it with an ad-hoc booking before letting it near the race.
 
     Needs at least two offsets and a timed booking; ignored otherwise.
   EOT
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "walden_capture_race_ledger" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -258,23 +258,34 @@ variable "walden_reserve_sweep_offsets_ms" {
     still open an hour later. Asking once on the instant is therefore the single
     worst-timed question we can ask.
 
-    Each rung doubles as a measurement - the race ledger records which offsets
-    were refused and which was granted - so a morning narrows the boundary to the
-    rung spacing whether or not it wins. Once it is known, collapse this to one
-    well-chosen offset.
+    The first offset is the aim point, and as of 2026-08-15 it is no longer 0.
+    Every refusal on record arrived under +1000ms (-60, -14, -7, 0, 0, 812, 817)
+    and every grant over +1200ms (1239, 1240, 1291), and the club stamped its
+    refusals inside the 06:30:00 second and its one grant inside 06:30:01. The
+    boundary that fits all of it is the club's own second tick: it refuses while
+    its clock still reads 06:30:00. 1030 arrives 30ms past that tick, which is
+    margin against a tick measurement good to roughly +-15ms.
 
-    Spacing is bounded by how fast the club answers, not by what is set here.
-    Rungs are slept to as absolute instants, so one whose moment has already
-    passed when the previous response lands is skipped - and a Reserve round trip
-    has measured 593ms and 647ms on the two lost mornings and 828ms on an
-    uncontested ad-hoc booking. The previous 150/300/500/750 rungs never once
-    fired: attempt 1's answer arrived ~860ms in, past all four. Rungs spaced
-    tighter than a round trip make the ladder read longer than it runs.
+    1250 is kept as the second offset because it is where the club has actually
+    granted three times, and walden_reserve_pipeline_opening_pair fires it
+    without waiting for 1030's answer - so aiming earlier cannot cost the offset
+    that has been winning.
+
+    Each rung doubles as a measurement - the race ledger records which offsets
+    were refused and which was granted - so a morning narrows the boundary
+    whether or not it wins. A grant at 1030 is the first evidence that the
+    boundary is the tick rather than something later.
+
+    Spacing past the pair is bounded by how fast the club answers, not by what is
+    set here. Rungs are slept to as absolute instants, so one whose moment has
+    already passed when the previous response lands is skipped - and a Reserve
+    round trip has measured 593-828ms. Rungs spaced tighter than a round trip
+    make the ladder read longer than it runs.
 
     "0" restores the historical single shot on the instant.
   EOT
   type        = string
-  default     = "0,900,1300,2000,3000,4500"
+  default     = "1030,1250,2000,3000,4500"
 
   validation {
     # Whitespace is tolerated because the parser in app/config.py strips it, and
@@ -286,6 +297,30 @@ variable "walden_reserve_sweep_offsets_ms" {
     condition     = can(regex("^[0-9]+( *, *[0-9]+)*$", var.walden_reserve_sweep_offsets_ms))
     error_message = "Must be non-negative whole milliseconds, comma-separated, e.g. \"0,150,300\"."
   }
+}
+
+variable "walden_reserve_pipeline_opening_pair" {
+  description = <<-EOT
+    Fire the first two sweep offsets without waiting for the first one's answer.
+
+    Serialised, the ladder cannot ask twice inside one round trip. On 2026-08-15
+    the first Reserve went at -60ms, its refusal landed at +940ms, and by then
+    the +900 rung was gone - so the next question could not go until +1240ms.
+    That is harmless when the first rung is 0 and expected to fail, but the first
+    rung now aims at the club's second tick, and aiming there serially would push
+    the follow-up to ~+1780ms, later than the +1240ms that has been granted three
+    times.
+
+    Pipelined, the pair brackets the boundary inside one round trip and the run
+    is no worse off than a serial 1250 even when the tick estimate is wrong. Both
+    requests are for the same slot, so neither can reserve a second tee time and
+    collide with the club's one-round-per-day rule; the worst case is the club
+    granting the same hold twice.
+
+    Needs at least two offsets and a timed booking; ignored otherwise.
+  EOT
+  type        = bool
+  default     = true
 }
 
 variable "walden_capture_race_ledger" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -245,47 +245,82 @@ variable "walden_measure_clock_skew" {
   default     = true
 }
 
+variable "walden_window_opens_offset_ms" {
+  description = <<-EOT
+    When the tee sheet actually opens, as milliseconds past the club's stated
+    06:30:00. A claim about the club, and the one being tested.
+
+    Every refusal on record arrived under +1000ms (-60, -14, -7, 0, 0, 812, 817)
+    and every grant over +1200ms (1239, 1240, 1291). On 2026-08-15 the refusal
+    carried a Date header stamped inside the 06:30:00 second and the grant one
+    inside 06:30:01, and the clock probe agreed with the application server to
+    within that header's one-second resolution. The club is not running on a
+    clock we misread: it refuses while its own clock still reads 06:30:00.
+
+    Everything is timed from here - walden_reserve_sweep_offsets_ms are offsets
+    past this instant, not past 06:30:00. Reporting deliberately is not: the race
+    ledger still measures from the stated window, so a morning's numbers stay
+    comparable with the ten data points above.
+
+    0 restores the historical behaviour of treating 06:30:00 as the open.
+  EOT
+  type        = number
+  default     = 1000
+
+  validation {
+    condition     = var.walden_window_opens_offset_ms == floor(var.walden_window_opens_offset_ms) && var.walden_window_opens_offset_ms >= 0 && var.walden_window_opens_offset_ms <= 10000
+    error_message = "walden_window_opens_offset_ms must be a whole number of milliseconds between 0 and 10000."
+  }
+}
+
+variable "walden_reserve_aim_margin_ms" {
+  description = <<-EOT
+    Slack added to the aim, for measurement error rather than for the club.
+
+    Kept separate from walden_window_opens_offset_ms because the two are tuned
+    for different reasons: that one is what we believe about the club, this is how
+    far we distrust our own clock probe. The probe pins the club's second tick to
+    roughly +-15ms, and arriving 15ms early lands back inside the second that has
+    never once been granted. Folding them into one number would leave a refusal
+    at the aim point ambiguous between "move the belief" and "widen the slack".
+  EOT
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.walden_reserve_aim_margin_ms == floor(var.walden_reserve_aim_margin_ms) && var.walden_reserve_aim_margin_ms >= 0 && var.walden_reserve_aim_margin_ms <= 1000
+    error_message = "walden_reserve_aim_margin_ms must be a whole number of milliseconds between 0 and 1000."
+  }
+}
+
 variable "walden_reserve_sweep_offsets_ms" {
   description = <<-EOT
-    Milliseconds past 06:30:00 to ask for the target slot at, comma-separated,
-    before any fallback tee time is tried.
+    Milliseconds past the open (walden_window_opens_offset_ms) to ask for the
+    target slot at, comma-separated, before any fallback tee time is tried.
 
-    The club refuses for roughly the first second past the window, wording every
-    refusal "This slot is blocked by another user". On 2026-08-08 a byte-identical
-    request - same slot, same component id, same ViewState - was refused at 0ms,
-    refused at 812ms and accepted at 1291ms. 2026-08-12 repeated the pattern at
-    0/817/1239ms, on a 5:00 PM slot no other member wanted: the whole sheet was
-    still open an hour later. Asking once on the instant is therefore the single
-    worst-timed question we can ask.
+    These are retries, not a search. 0 is the aim point - the instant we believe
+    the sheet opens - and the rest exist to catch that belief being wrong. A grant
+    at 0 confirms it; a grant at 250 or 1000 says the boundary is later than the
+    club's second tick and walden_window_opens_offset_ms should move.
 
-    The first offset is the aim point, and as of 2026-08-15 it is no longer 0.
-    Every refusal on record arrived under +1000ms (-60, -14, -7, 0, 0, 812, 817)
-    and every grant over +1200ms (1239, 1240, 1291), and the club stamped its
-    refusals inside the 06:30:00 second and its one grant inside 06:30:01. The
-    boundary that fits all of it is the club's own second tick: it refuses while
-    its clock still reads 06:30:00. 1030 arrives 30ms past that tick, which is
-    margin against a tick measurement good to roughly +-15ms.
+    250 is fired without waiting for 0's answer (see
+    walden_reserve_pipeline_opening_pair), which puts it near +1280ms measured
+    from the stated window - close to the +1239/1240/1291 that have actually been
+    granted. So a wrong hypothesis costs a rung rather than the morning.
 
-    1250 is kept as the second offset because it is where the club has actually
-    granted three times, and walden_reserve_pipeline_opening_pair fires it
-    without waiting for 1030's answer - so aiming earlier cannot cost the offset
-    that has been winning.
+    1000 is the last ask before the fallback list, landing near +2030ms from the
+    stated window, past every grant on record.
 
-    Each rung doubles as a measurement - the race ledger records which offsets
-    were refused and which was granted - so a morning narrows the boundary
-    whether or not it wins. A grant at 1030 is the first evidence that the
-    boundary is the tick rather than something later.
+    Spacing is bounded by how fast the club answers, not by what is set here: a
+    rung is reached only once the previous answer lands, and a Reserve round trip
+    has measured 593-828ms. A rung our own latency has just overshot still fires
+    (see _RUNG_LATE_GRACE_MS in walden_http_booker.py), but one spaced tighter
+    than a round trip will not fire at the instant it names.
 
-    Spacing past the pair is bounded by how fast the club answers, not by what is
-    set here. Rungs are slept to as absolute instants, so one whose moment has
-    already passed when the previous response lands is skipped - and a Reserve
-    round trip has measured 593-828ms. Rungs spaced tighter than a round trip
-    make the ladder read longer than it runs.
-
-    "0" restores the historical single shot on the instant.
+    "0" restores the historical single ask.
   EOT
   type        = string
-  default     = "1030,1250,2000,3000,4500"
+  default     = "0,250,1000"
 
   validation {
     # Whitespace is tolerated because the parser in app/config.py strips it, and

--- a/tests/test_reserve_verdict.py
+++ b/tests/test_reserve_verdict.py
@@ -140,31 +140,55 @@ class TestStaleMessagesLaterInTheChain:
 class TestSweepLadder:
     """The offsets the Reserve is asked at, parsed from configuration."""
 
-    def test_the_default_ladder_aims_past_the_clubs_second_tick(
+    def test_the_aim_clears_every_refusal_on_record(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The sheet is believed to open at 06:30:01, and that is where we aim.
+
+        Every refusal on record arrived under +1000ms (-60, -14, -7, 0, 0, 812,
+        817) and every grant over +1200ms, with the club stamping refusals inside
+        the 06:30:00 second and its grant inside 06:30:01. An aim that did not
+        clear the last refusal would be spending the primary shot on a question
+        already answered no seven times.
+
+        Isolated from the environment: terraform sets these on the deployed
+        service, so a shell mirroring the deployment would make this assert what
+        is configured rather than what ships.
+        """
+        monkeypatch.delenv("WALDEN_WINDOW_OPENS_OFFSET_MS", raising=False)
+        monkeypatch.delenv("WALDEN_RESERVE_AIM_MARGIN_MS", raising=False)
+        config = Settings(_env_file=None)
+
+        aim_ms = config.walden_window_opens_offset_ms + config.walden_reserve_aim_margin_ms
+
+        assert config.walden_window_opens_offset_ms >= 1000
+        # Strictly past, not equal: landing exactly on the tick is the case the
+        # margin exists for, since the probe pins it to only about +-15ms.
+        assert aim_ms > 1000
+
+    def test_the_default_ladder_is_retries_from_the_aim(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The first rung clears +1000ms, and the ladder still reaches the grants.
+        """Rungs are offsets past the open now, so the first one is 0.
 
-        Every refusal on record arrived under +1000ms and every grant over
-        +1200ms, with the club stamping refusals inside the 06:30:00 second and
-        its grant inside 06:30:01. Aiming the first question at 0ms spent it on a
-        certain no; this pins that it is no longer aimed there.
-
-        Isolated from the environment: terraform sets this variable on the
-        deployed service, so a shell mirroring the deployment would make this
-        assert what is configured rather than what ships. The tests below need no
-        such care - an explicit init argument outranks both sources.
+        The ladder stopped being a search over offsets once the open was named:
+        rung 0 *is* the hypothesis, and the rest are there to catch it being
+        wrong. One of them still has to reach the offsets the club has actually
+        granted at, or a wrong hypothesis costs the morning rather than a rung.
         """
         monkeypatch.delenv("WALDEN_RESERVE_SWEEP_OFFSETS_MS", raising=False)
-        ladder = Settings(_env_file=None).walden_sweep_offsets_ms()
+        monkeypatch.delenv("WALDEN_WINDOW_OPENS_OFFSET_MS", raising=False)
+        monkeypatch.delenv("WALDEN_RESERVE_AIM_MARGIN_MS", raising=False)
+        config = Settings(_env_file=None)
+        ladder = config.walden_sweep_offsets_ms()
+        aim_ms = config.walden_window_opens_offset_ms + config.walden_reserve_aim_margin_ms
 
-        assert ladder[0] > 1000
+        assert ladder[0] == 0
         assert list(ladder) == sorted(ladder)
-        # 08-08 was granted at +1291ms, 08-12 at +1239ms and 08-15 at +1240ms, so
-        # a ladder that stopped short of those would give up the offset that has
-        # actually been winning while the new aim point is still unproven.
-        assert ladder[1] >= 1239
-        assert ladder[-1] >= 1300
+        # 08-08 was granted at +1291ms, 08-12 at +1239ms and 08-15 at +1240ms,
+        # measured from the stated window. A rung has to land out there.
+        assert any(aim_ms + rung >= 1239 for rung in ladder)
+        # And the ladder has to be short. It is retries now; a long one is the
+        # search it replaced.
+        assert len(ladder) <= 4
 
     def test_a_malformed_ladder_degrades_to_one_shot(self) -> None:
         """A bad value must not stop a morning."""

--- a/tests/test_reserve_verdict.py
+++ b/tests/test_reserve_verdict.py
@@ -140,23 +140,30 @@ class TestStaleMessagesLaterInTheChain:
 class TestSweepLadder:
     """The offsets the Reserve is asked at, parsed from configuration."""
 
-    def test_the_default_ladder_starts_on_the_instant_and_climbs(
+    def test_the_default_ladder_aims_past_the_clubs_second_tick(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """0ms is still asked first - the sweep adds rungs, it does not delay.
+        """The first rung clears +1000ms, and the ladder still reaches the grants.
+
+        Every refusal on record arrived under +1000ms and every grant over
+        +1200ms, with the club stamping refusals inside the 06:30:00 second and
+        its grant inside 06:30:01. Aiming the first question at 0ms spent it on a
+        certain no; this pins that it is no longer aimed there.
 
         Isolated from the environment: terraform sets this variable on the
         deployed service, so a shell mirroring the deployment would make this
-        assert what is configured rather than what ships. The two tests below
-        need no such care - an explicit init argument outranks both sources.
+        assert what is configured rather than what ships. The tests below need no
+        such care - an explicit init argument outranks both sources.
         """
         monkeypatch.delenv("WALDEN_RESERVE_SWEEP_OFFSETS_MS", raising=False)
         ladder = Settings(_env_file=None).walden_sweep_offsets_ms()
 
-        assert ladder[0] == 0
+        assert ladder[0] > 1000
         assert list(ladder) == sorted(ladder)
-        # 08-08 was granted at +1291ms and 08-12 at +1239ms, so a ladder that
-        # stopped short of those would have measured nothing on either morning.
+        # 08-08 was granted at +1291ms, 08-12 at +1239ms and 08-15 at +1240ms, so
+        # a ladder that stopped short of those would give up the offset that has
+        # actually been winning while the new aim point is still unproven.
+        assert ladder[1] >= 1239
         assert ladder[-1] >= 1300
 
     def test_a_malformed_ladder_degrades_to_one_shot(self) -> None:

--- a/tests/test_reserve_verdict.py
+++ b/tests/test_reserve_verdict.py
@@ -190,6 +190,25 @@ class TestSweepLadder:
         # search it replaced.
         assert len(ladder) <= 4
 
+    def test_the_opening_pair_is_off_until_it_has_been_exercised(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Untested concurrency does not get its first run in the race.
+
+        Firing rungs 0 and 250 together has never run against the club, and the
+        sequence it creates - a Reserve granted while a second for the same slot
+        is already in flight - has never been observed. With rung 0 now being the
+        hypothesis rather than a guess, a right hypothesis makes that sequence
+        the daily case rather than the rare one.
+
+        Serially the ladder still asks at roughly +1030, +1770 and +2510ms from
+        the stated window, all past every refusal on record, so the cost of
+        leaving this off is an ask at +1770 instead of +1280.
+        """
+        monkeypatch.delenv("WALDEN_RESERVE_PIPELINE_OPENING_PAIR", raising=False)
+
+        assert Settings(_env_file=None).walden_reserve_pipeline_opening_pair is False
+
     def test_a_malformed_ladder_degrades_to_one_shot(self) -> None:
         """A bad value must not stop a morning."""
         assert Settings(walden_reserve_sweep_offsets_ms="nonsense").walden_sweep_offsets_ms() == (

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -2167,6 +2167,80 @@ class TestOpeningPairIsFiredTogether:
         assert result.distinct_attempted_times() == [RESERVE_SLOT_TIME]
 
 
+class TestReportingStaysInTheStatedWindowFrame:
+    """The aim moved to 06:30:01; the scale everything is reported on did not.
+
+    Ten mornings of evidence are recorded as milliseconds past the club's stated
+    06:30:00 - refusals at -60, -14, -7, 0, 0, 812, 817 and grants at 1239, 1240,
+    1291. If moving the aim also moved the frame, tomorrow's ledger would read
+    "sent 0ms, accepted" and could not be compared with any of it.
+    """
+
+    def test_offsets_are_measured_from_the_window_not_the_aim(self) -> None:
+        """A run aimed 1030ms late reports 1030, not 0."""
+        recorder = PairRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        aim = window_about_to_open(20)
+        result = sweep_booker(recorder, 0).book(
+            1, target_timestamp_ms=aim, window_timestamp_ms=aim - 1030
+        )
+
+        assert result.success, result.error
+        sent = result.attempt_log[0].sent_ms_past_window
+        assert sent is not None
+        # Wide, because the wait may overshoot; the point is the ~1030 offset is
+        # present at all rather than having been zeroed out by the reframing.
+        assert 950 < sent < 1500
+        assert result.timing["reserveSentAtMs"] > 950
+
+    def test_without_a_separate_window_the_frame_is_the_target(self) -> None:
+        """The pre-existing behaviour, for every caller that passes one instant."""
+        recorder = PairRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        result = sweep_booker(recorder, 0).book(1, target_timestamp_ms=window_about_to_open(20))
+
+        assert result.success, result.error
+        sent = result.attempt_log[0].sent_ms_past_window
+        assert sent is not None
+        assert -50 < sent < 500
+
+
+class TestARungOurOwnLatencyOvershotStillFires:
+    """A rung reached late is still asked, unless the whole window is stale.
+
+    Rungs are reached only once the previous answer lands, so a round trip of
+    593-828ms eats whatever rung falls inside it. With the opening pair resolving
+    around aim+1000ms, the 1000 rung would fire on a fast morning and be dropped
+    on a slow one - sending the run to the fallback list with an ask still owed
+    to the tee time we actually wanted.
+
+    The grace has to stay well short of the minutes by which a later booking in a
+    batch overshoots its shared target, which is the case the discard exists for.
+    """
+
+    def test_a_rung_just_overshot_is_still_taken(self) -> None:
+        """Our own round trip must not cost a retry."""
+        from app.providers.walden_http_booker import _next_future_rung
+
+        target = int(time_module.time() * 1000) - 1500
+
+        assert _next_future_rung([1000], target) == 1000
+
+    def test_a_rung_from_a_stale_window_is_dropped(self) -> None:
+        """A later booking in a batch has no boundary left to find."""
+        from app.providers.walden_http_booker import _next_future_rung
+
+        target = int(time_module.time() * 1000) - 60_000
+
+        assert _next_future_rung([0, 250, 1000], target) is None
+
+    def test_a_rung_still_ahead_is_taken_unchanged(self) -> None:
+        """The ordinary case the grace must not disturb."""
+        from app.providers.walden_http_booker import _next_future_rung
+
+        target = int(time_module.time() * 1000) + 500
+
+        assert _next_future_rung([250, 1000], target) == 250
+
+
 class TestTheAimPointIsTheFirstRung:
     """The precision wait sleeps to the first rung, not to the window.
 

--- a/tests/test_walden_http.py
+++ b/tests/test_walden_http.py
@@ -7,6 +7,7 @@ expects - not one derived from a hand-written mock.
 """
 
 import email.utils
+import threading
 import time as time_module
 import urllib.parse
 from collections.abc import Callable
@@ -1992,6 +1993,247 @@ class TestReserveTimeoutKeepsTheLadderWalking:
         assert recorder.sources[:2] == [RESERVE_ID, RESERVE_ID]
 
 
+class PairRecorder(ChainRecorder):
+    """Serves pages by *request* order, optionally answering some of them late.
+
+    Request order rather than answer order: the opening pair is in flight
+    together, so the sequence the club answers in is not the sequence it was
+    asked in, and indexing on replies would hand a response to whichever request
+    happened to be served first.
+    """
+
+    def __init__(
+        self,
+        pages: list[str],
+        *,
+        delay_on: set[int] | None = None,
+        delay_s: float = 0.0,
+    ) -> None:
+        """``delay_on`` holds 1-based request numbers answered after ``delay_s``."""
+        super().__init__(pages)
+        self.delay_on = delay_on or set()
+        self.delay_s = delay_s
+        self.sent_at_ms: list[int] = []
+        self._lock = threading.Lock()
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        """Answer the ``index``-th request with the ``index``-th canned page."""
+        params = dict(urllib.parse.parse_qsl(request.content.decode()))
+        with self._lock:
+            self.requests.append(params)
+            self.sources.append(params.get("javax.faces.source", ""))
+            index = len(self.sources)
+            self.sent_at_ms.append(int(time_module.time() * 1000))
+        if index in self.delay_on:
+            time_module.sleep(self.delay_s)
+        page = self.pages[min(index - 1, len(self.pages) - 1)]
+        return httpx.Response(200, text=partial_response(page, f"vs-{index}"))
+
+
+def paired_booker(recorder: ChainRecorder, *offsets: int) -> DirectHttpBooker:
+    """A sweep booker whose first two rungs are fired together."""
+    booker = sweep_booker(recorder, *offsets)
+    booker._pipeline_opening_pair = True
+    return booker
+
+
+class TestOpeningPairIsFiredTogether:
+    """The first two rungs overlap, so the ladder can ask twice in one round trip.
+
+    Serially the ladder cannot: on 2026-08-15 the first Reserve went at -60ms and
+    its refusal did not land until +940ms, by which point the +900 rung had gone
+    and the next question could not go until +1240ms. That was tolerable while
+    the first rung was 0 and expected to fail. It is not now that the first rung
+    aims at the club's second tick - serially, a mis-measured tick would push the
+    follow-up past the offset that has actually been winning.
+    """
+
+    def test_the_second_goes_before_the_first_is_answered(self) -> None:
+        """The whole point: the pair overlaps rather than queueing."""
+        recorder = PairRecorder(
+            [blocked_sheet(*ALL_THREE), PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE],
+            delay_on={1},
+            delay_s=0.4,
+        )
+        result = paired_booker(recorder, 0, 120).book(1, target_timestamp_ms=window_about_to_open())
+
+        assert result.success, result.error
+        # Serialised, the second could not have left until the first was
+        # answered 400ms later. The margin is wide because only the order of
+        # magnitude is the claim.
+        assert recorder.sent_at_ms[1] - recorder.sent_at_ms[0] < 300
+
+    def test_a_grant_on_the_later_rung_is_taken(self) -> None:
+        """A refused aim point costs a rung, not the morning."""
+        recorder = PairRecorder([blocked_sheet(*ALL_THREE), PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        result = paired_booker(recorder, 1030, 1250).book(
+            1, target_timestamp_ms=window_about_to_open()
+        )
+
+        assert result.success, result.error
+        assert result.booked_slot_time == RESERVE_SLOT_TIME
+        assert recorder.sources[:2] == [RESERVE_ID, RESERVE_ID]
+
+    def test_a_grant_on_the_aim_point_is_taken(self) -> None:
+        """The rung the change exists to win on."""
+        recorder = PairRecorder([PLAYER_PAGE, blocked_sheet(*ALL_THREE), ROWS_PAGE, BOOKED_PAGE])
+        result = paired_booker(recorder, 1030, 1250).book(
+            1, target_timestamp_ms=window_about_to_open()
+        )
+
+        assert result.success, result.error
+        assert result.booked_slot_time == RESERVE_SLOT_TIME
+        # The chain carried on from the granting response, not the refusal that
+        # came back beside it - the player count is the step after Reserve.
+        assert recorder.sources[2] == "playerGroup"
+
+    def test_both_halves_ask_only_for_the_staged_slot(self) -> None:
+        """Two requests, one tee time - the club cannot grant two holds."""
+        recorder = PairRecorder([blocked_sheet(*ALL_THREE), blocked_sheet(*ALL_THREE)])
+        paired_booker(recorder, 1030, 1250).book(1, target_timestamp_ms=window_about_to_open())
+
+        assert recorder.sources[:2] == [RESERVE_ID, RESERVE_ID]
+
+    def test_both_refused_still_reaches_the_fallback_list(self) -> None:
+        """The pair replaces two rungs, it does not replace the ladder."""
+        recorder = PairRecorder(
+            [
+                blocked_sheet(*ALL_THREE),
+                blocked_sheet(
+                    slot_block(RESERVE_ID, "04:34 PM"),
+                    slot_block(SLOT_B_ID, "04:42 PM"),
+                    slot_block(SLOT_C_ID, "04:50 PM"),
+                ),
+                PLAYER_PAGE,
+                ROWS_PAGE,
+                BOOKED_PAGE,
+            ]
+        )
+        result = paired_booker(recorder, 0, 60).book(1, target_timestamp_ms=window_about_to_open())
+
+        assert result.success, result.error
+        # Both halves asked for the staged slot, then the run moved on to the
+        # best fallback the freshest sheet still offered.
+        assert recorder.sources[:3] == [RESERVE_ID, RESERVE_ID, SLOT_B_ID]
+
+    def test_both_refused_are_both_in_the_ledger(self) -> None:
+        """Two questions asked is two rows, or a post-mortem reads one."""
+        recorder = PairRecorder([blocked_sheet(*ALL_THREE), blocked_sheet(*ALL_THREE)])
+        result = paired_booker(recorder, 1030, 1250).book(
+            1, target_timestamp_ms=window_about_to_open()
+        )
+
+        assert not result.success
+        assert len(result.attempt_log) >= 2
+        assert result.timing["reserveAttempts"] >= 2
+
+    def test_neither_connecting_leaves_the_browser_chain_available(self) -> None:
+        """Nothing was submitted, so a Selenium retry cannot race our own booking.
+
+        The single-send path rolls the phase back for exactly this case, and the
+        pair has to as well: past PRE_SUBMIT_PHASES the provider stops retrying,
+        so a 6:30 that cannot open a socket would be lost outright rather than
+        handed to the chain that can still win it.
+        """
+        recorder = StallingRecorder([PLAYER_PAGE], stall_on={1, 2}, error=httpx.ConnectError)
+        booker = paired_booker(recorder, 1030, 1250)
+
+        result = booker.book(1, target_timestamp_ms=window_about_to_open())
+
+        assert not result.success
+        assert result.phase == PHASE_RESERVE_STAGED
+        # Both halves were fired before the rollback. Serialised, the first
+        # failure would have raised on its own and this would read 1 - which is
+        # the reading that would let the pair path skip the rollback unnoticed.
+        assert len(recorder.sources) == 2
+
+    def test_one_half_landing_closes_the_fallback_list(self) -> None:
+        """A read timeout may have reached the club, so no *other* slot is asked.
+
+        The asymmetry that keeps the one-round-per-day rule: a request that never
+        connected cannot be holding anything, but one that timed out mid-flight
+        might be, and booking a second tee time on top of an invisible hold is
+        worse than losing the morning.
+        """
+        recorder = StallingRecorder([PLAYER_PAGE], stall_on={1, 2}, error=httpx.ReadTimeout)
+        booker = paired_booker(recorder, 1030, 1250)
+
+        result = booker.book(1, target_timestamp_ms=window_about_to_open())
+
+        assert not result.success
+        # Not "blocked": the club never said no, so the member is not told
+        # another member took it, and the untimed retry stays shut.
+        assert not result.blocked
+        assert result.distinct_attempted_times() == [RESERVE_SLOT_TIME]
+
+
+class TestTheAimPointIsTheFirstRung:
+    """The precision wait sleeps to the first rung, not to the window.
+
+    Every refusal on record arrived under +1000ms and every grant over +1200ms,
+    with the club stamping its refusals inside the 06:30:00 second. Firing on the
+    instant asks the one question that has never been answered yes.
+    """
+
+    def test_the_wait_targets_the_first_rung(self) -> None:
+        """A first rung past the window delays the first request by that much."""
+        recorder = PairRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        target = window_about_to_open(10)
+        result = sweep_booker(recorder, 250, 400).book(1, target_timestamp_ms=target)
+
+        assert result.success, result.error
+        assert result.timing["openingOffsetMs"] == 250
+        # Slack below the rung only: the wait may overshoot, never undershoot by
+        # more than the spin window.
+        assert recorder.sent_at_ms[0] - target > 200
+
+    def test_a_zero_first_rung_still_fires_on_the_instant(self) -> None:
+        """The historical behaviour stays reachable by configuration."""
+        recorder = PairRecorder([PLAYER_PAGE, ROWS_PAGE, BOOKED_PAGE])
+        target = window_about_to_open(10)
+        result = sweep_booker(recorder, 0, 300).book(1, target_timestamp_ms=target)
+
+        assert result.success, result.error
+        assert result.timing["openingOffsetMs"] == 0
+        # Generous, because this direction is bounded by the test runner rather
+        # than by the code: sleep_until cannot fire early, but a loaded machine
+        # can delay the send arbitrarily. Still far below the 1030ms default,
+        # which is the value it has to be distinguishable from.
+        assert recorder.sent_at_ms[0] - target < 500
+
+
+class TestDetachedSendLeavesStateAlone:
+    """Sending and adopting are separable, which is what makes the pair safe.
+
+    ``post`` folds the response into the session's form state. Two in-flight
+    requests doing that would race over the fields and ViewState the rest of the
+    chain is built from, so the pair sends detached and adopts exactly one.
+    """
+
+    def test_a_detached_send_does_not_change_the_view_state(self) -> None:
+        """The whole hazard, in one assertion."""
+        recorder = ChainRecorder([PLAYER_PAGE])
+        session = make_session(FormState.from_html(TEE_SHEET), recorder)
+        config = AbConfig(source=RESERVE_ID, form=FORM_ID, update=FORM_ID)
+        before = dict(session.form_state.fields)
+
+        response = session.send_detached(config, body=session.build_body(config))
+
+        assert response.markup
+        assert dict(session.form_state.fields) == before
+
+    def test_adopting_applies_what_the_detached_send_returned(self) -> None:
+        """And the other half: nothing is lost by deferring it."""
+        recorder = ChainRecorder([PLAYER_PAGE])
+        session = make_session(FormState.from_html(TEE_SHEET), recorder)
+        config = AbConfig(source=RESERVE_ID, form=FORM_ID, update=FORM_ID)
+        response = session.send_detached(config, body=session.build_body(config))
+
+        session.adopt(response)
+
+        assert dict(session.form_state.fields) != {}
+
+
 class TestStagingTheLadder:
     """The ladder as it arrives through the public staging path."""
 
@@ -2237,6 +2479,24 @@ class TestClockSkew:
         from app.providers.walden_http import ClockSkew
 
         assert ClockSkew(offset_ms=250, one_way_ms=200, probes=9, transitions=2).lead_ms == 450
+
+    def test_the_tick_is_pinned_tightly_enough_to_aim_at(self) -> None:
+        """The bracket bounds the offset, and so any aim taken from it.
+
+        The first sweep rung is now aimed 30ms past the club's second tick, so a
+        measurement that only located the tick to +-105ms - which 16 probes at
+        80ms did - would not be good enough to aim with. The bracket is reported
+        so that a morning where it comes out wide is legible as one.
+        """
+        session = make_session(FormState.from_html(TEE_SHEET), clock_handler(0.4))
+
+        skew = session.measure_clock_skew()
+
+        assert skew is not None
+        # Several transitions rather than the single one the old spacing yielded:
+        # the median of them is what makes the estimate better than one bracket.
+        assert skew.transitions >= 3
+        assert 0 < skew.tick_bracket_ms < 60
 
 
 class TestArrivalLead:

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -3455,6 +3455,47 @@ class TestUnconfirmedBookingResolution:
         assert result.error_message is not None
         assert "could not be checked" in result.error_message
 
+    def test_a_confirmed_response_is_still_checked_against_the_page(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ "Confirmed" is a phrase match, and the logs must not stop there.
+
+        2026-08-15 returned success on the word "thank you" in a PrimeFaces
+        partial update and never looked at the reservations page, so a run that
+        completed against no reservation - the one failure class that reads as a
+        win - would have been indistinguishable from the morning it won.
+        """
+        result, reservation_check = self._book(
+            provider,
+            monkeypatch,
+            self._completed_chain("<div><p>Thank you, your tee time is booked.</p></div>"),
+            reservation_exists=True,
+        )
+
+        assert result.success is True
+        reservation_check.assert_called_once_with(ANY, self.TARGET_DATE, time(8, 42))
+
+    def test_a_confirmed_response_the_page_does_not_list_still_reports_success(
+        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reported, not enforced - and deliberately so.
+
+        The member dashboard can lag a booking by seconds, and flipping a
+        text-confirmed win to a failure would feed the untimed retry, which is
+        how a second tee time gets stacked on a hold that does exist. The
+        discrepancy is loud in the logs and keeps an artifact; it does not change
+        the outcome.
+        """
+        result, reservation_check = self._book(
+            provider,
+            monkeypatch,
+            self._completed_chain("<div><p>Thank you, your tee time is booked.</p></div>"),
+            reservation_exists=False,
+        )
+
+        assert result.success is True
+        reservation_check.assert_called_once_with(ANY, self.TARGET_DATE, time(8, 42))
+
     def test_refusal_wording_is_carried_into_the_error(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -3505,20 +3546,6 @@ class TestUnconfirmedBookingResolution:
         assert result.error_message is not None
         assert result.error_message.startswith("Restriction: Member: Sample, Member")
         assert "could not be checked" in result.error_message
-
-    def test_a_confirmed_response_never_reaches_the_reservations_page(
-        self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """The check costs the tee sheet, so it only runs when it is needed."""
-        result, reservation_check = self._book(
-            provider,
-            monkeypatch,
-            self._completed_chain("<div><h2>Your tee time is booked</h2></div>"),
-            reservation_exists=False,
-        )
-
-        assert result.success is True
-        reservation_check.assert_not_called()
 
     def test_failure_after_reserve_was_sent_checks_the_reservations_page(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -3088,7 +3088,9 @@ class TestDirectHttpBookingWiring:
         assert chain_result is not None
         assert chain_result["success"] is True
         assert chain_result["phase"] == "complete"
-        booker.book.assert_called_once_with(4, target_timestamp_ms=1770000000000)
+        booker.book.assert_called_once_with(
+            4, target_timestamp_ms=1770000000000, window_timestamp_ms=None
+        )
         session.close.assert_called_once()
 
     def test_blocked_is_honored_not_retried(
@@ -4144,7 +4146,7 @@ class TestImmediateBookingFastPath:
         assert result.confirmation_number == "12345"
         assert result.booked_time == time(8, 42)
         # Untimed: Reserve fires as soon as it is staged, no target to wait for.
-        booker.book.assert_called_once_with(4, target_timestamp_ms=None)
+        booker.book.assert_called_once_with(4, target_timestamp_ms=None, window_timestamp_ms=None)
         fast_chain.assert_not_called()
 
     def test_immediate_booking_uses_the_js_chain_when_direct_http_is_off(

--- a/tests/test_walden_provider.py
+++ b/tests/test_walden_provider.py
@@ -2871,7 +2871,16 @@ class TestBatchBookingPreparation:
         # The 6:30 gate lives in the fast chain's JS/HTTP precision wait. With
         # the chain off, Python has to hold the window itself or the batch races
         # a locked tee sheet - the bug #122 fixed, re-entering by the back door.
-        precision_wait.assert_called_once_with(datetime(2026, 2, 19, 6, 30, 0))
+        #
+        # Shifted, where this used to assert the stated 06:30:00. That assertion
+        # encoded a time we now know the club refuses: this path reads execute_at
+        # rather than execute_at_timestamp_ms, so it was the one route still
+        # firing at the stated window while the other two aimed at the open.
+        aim = timedelta(
+            milliseconds=settings.walden_window_opens_offset_ms
+            + settings.walden_reserve_aim_margin_ms
+        )
+        precision_wait.assert_called_once_with(datetime(2026, 2, 19, 6, 30, 0) + aim)
 
     def test_untimed_batch_uses_the_fast_chain(
         self, provider: WaldenGolfProvider, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## The hypothesis

Every refusal on record arrived under +1000ms and every grant over +1200ms:

| Sent (ms past stated window) | Verdict |
|---|---|
| -60, -14, -7, 0, 0, 812, 817 | refused |
| 1239, 1240, 1291 | **accepted** |

On 2026-08-15 the refusal carried a `Date` header stamped inside the **06:30:00** second and the grant one inside **06:30:01**, with the clock probe agreeing with the application server to within that header's resolution. So this is not a clock we misread — **the sheet opens at 06:30:01.**

This PR times the race from there and tests that tomorrow. **One new variable, deliberately.**

## What ships

```
pipeline_opening_pair = False
aim  = stated window +1030ms   (1000 open + 30 margin)
rungs past aim = [0, 250, 1000]

asks, in ms past the club's stated window:
  RTT 593ms -> [1030, 1623, 2216]
  RTT 741ms -> [1030, 1771, 2512]
  RTT 828ms -> [1030, 1858, 2686]
```

Every ask is past all seven refusals on record; the last two are past every grant.

**The target moves.** `walden_window_opens_offset_ms` (1000) names when the club opens; `walden_reserve_aim_margin_ms` (30) is slack for a clock probe good to ~±15ms. Separate, so a refusal at the aim point reads as either "move the belief" or "widen the slack" rather than being ambiguous. Applied at `execute_at_timestamp_ms`, so both chains agree on when the window opens.

**The ladder becomes retries.** `0,250,1000` — offsets past the open, not a search for it. Rung 0 *is* the hypothesis; the others catch it being wrong. A grant at 250 or 1000 says the boundary is later than the tick and the offset should move.

**The clock probe is tightened.** 16 HEADs at 80ms pinned the tick to one transition bracketed to ±105ms — useless for aiming at it. Now budget-bounded at 5s with 20ms spacing, several transitions, median of them. The bracket is carried on `ClockSkew` and logged.

**Text-confirmed bookings are checked against the reservations page.** 08-15 returned success on the word "thank you" and never looked, making "chain completed against no reservation" indistinguishable in the logs from the morning it won.

## The opening pair is built, tested, and switched off

Firing rungs 0 and 250 together is implemented behind `walden_reserve_pipeline_opening_pair`, defaulting **false**.

It has never run against the club, and the sequence it creates — a Reserve granted while a second for the same slot is already in flight — has never been observed. That was an occasional case when the first rung was a guess; now that rung 0 is the hypothesis, a *right* hypothesis makes it the daily case.

The argument for it also weakened. It was proposed when aiming at the tick serially would push the follow-up to ~+1780ms, past the offsets the club has granted at. With rungs reckoned from the open and the rung-grace fix below, serial already asks at +1030/+1770/+2510. Pipelining buys +1280 instead of +1770 — it pays only when the hypothesis is wrong *and* the slot is contested.

And the morning it would first run is the one testing the hypothesis. Two new variables makes a failure unreadable. An ad-hoc booking takes the same timed path with nothing at stake, and is where this gets its first look.

## Reporting stays on the old scale

Ten mornings are recorded as ms past the club's stated 06:30:00. A ledger that reset to the new aim would read `sent 0ms, accepted` and be comparable with none of them.

`window_timestamp_ms` is threaded alongside the target purely as the frame for `sentMsPastWindow`, `serverMsPastWindow`, `reserveSentAtMs` and the race ledger.

## A rung that would have been silently dropped

Rungs are reached only once the previous answer lands, and `_next_future_rung` discarded any whose instant had passed — so the last ask before the fallback list would have been dropped on exactly the mornings the club is slowest, walking off the target slot with a retry still owed. A rung overshot by less than `_RUNG_LATE_GRACE_MS` (2000ms) now fires at once. That stays far short of the minutes by which a later booking in a batch overshoots its shared target, which is the case the discard exists for and is still dropped.

## Budgets

Worst case all three rungs answered is +3686ms from the stated window, 2656ms of the 10s attempt deadline. Three consecutive stalls at the 3s per-request timeout is 9s, still inside it. Max attempts 7.

## Safety

- `PrimeFacesSession.post` is split into `send_detached` + `adopt`, because `post` folds the response into the session's form state and two in-flight requests doing that would race over the ViewState the chain is built from. Exactly one response is adopted. (Only reachable with the pair enabled.)
- Both halves of the pair ask for the **same slot**, so neither can reserve a second tee time and collide with the one-round-per-day rule.
- Neither half connected → phase rolls back and raises, so the Selenium chain stays a safe retry.
- Either half timed out mid-flight → timeout latches, closing the fallback list, because that request may be holding the slot.
- The reservations-page discrepancy is **reported, not enforced**: the dashboard can lag, and flipping a text-confirmed win to a failure would feed the untimed retry — which is how a second tee time gets stacked on a hold that does exist.

## Testing

928 passed, 3 skipped. New coverage: the reporting frame surviving the aim moving, the rung grace (overshot fires, stale window still drops, ahead unchanged), the pair defaulting off, the pair overlapping rather than queueing (verified to fail with the flag off), grants on either rung, both-refused reaching the fallback list and landing two ledger rows, the never-connected rollback, the timed-out fallback closure, detached sends leaving state alone, and the tick bracket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable opening offsets, reserve timing margins, retry schedules, and optional concurrent opening attempts.
  * Reserve booking now targets the configured opening window more precisely and supports late grace-period retries.
* **Bug Fixes**
  * Improved handling of delayed responses, timeouts, connection failures, and retry attempts.
  * Confirmed bookings are now checked against the reservations page, including delayed listing scenarios.
* **Reliability**
  * Enhanced clock-skew measurement, timing diagnostics, and concurrent request handling for more accurate booking decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->