### PR TITLE
fix: make a post-mortem runnable from a remote session

### DIFF
--- a/.claude/skills/booking-postmortem/SKILL.md
+++ b/.claude/skills/booking-postmortem/SKILL.md
@@ -162,7 +162,7 @@ The run has a fixed shape. Walk it and note where it diverges:
 | Pre-locate | `JS slot finder found slot` | `exact=True`, and **how many fallbacks** it kept |
 | Clock | `Clock skew measured` | probes, transitions, offset, one-way |
 | Lead | `Reserve will be sent Nms early` | Should be tens of ms, not hundreds |
-| Fire | `Firing Reserve k/N ... Nms past the window` | Attempt 1 should be ≈ 0ms or slightly negative |
+| Fire | `Firing Reserve k/N ... Nms past the window` | Attempt 1 should land on the first rung — **≈ +1030ms** since #150, not ≈ 0ms |
 | Each answer | `Reserve k -> <verdict>` | Verdict, club clock, bytes, sheet rows, form slot |
 | Boundary | `RACE_LEDGER: club granted ... at +Nms` | Which rung won, and the last that lost |
 | Outcome | `Chain finished - phase=..., success=..., blocked=...` | Phase says how far it got |
@@ -323,13 +323,18 @@ a past morning can be answered there without touching GCS or a booking.
 
 ## 6. Classify
 
-- **Lost on the clock** — attempt 1 fired hundreds of ms past the window, or
-  `Clock skew unmeasurable`. Look at the probe target and RTTs.
+- **Lost on the clock** — attempt 1 did not land on its rung. Since #150 the aim
+  point is +1030ms, i.e. 30ms past the club's 06:30:01 tick, so "early" now means
+  *near zero* and not the other way round. Read `Clock skew measured` for the
+  tick bracket: a wide one (the probe is budget-bounded at 5s with 20ms spacing
+  and should yield several transitions) means the 30ms of margin was aimed with
+  a ruler that could not see it. `Clock skew unmeasurable` is the same class.
 - **Lost on the slot list** — few or zero fallbacks kept, or the scan dropped
   everything. Check the `dropped course=/window=` split.
-- **Refused at Reserve inside the first second** — every rung of the sweep so
-  far past the window was refused. This is the standing failure, and it is a
-  *boundary*, not contention: see below.
+- **Refused at Reserve inside the first second** — was the standing failure
+  before #150, when attempt 1 went at ~0ms and was spent on a certain no. It is
+  a *boundary*, not contention (§7a). A run that still shows this after #150 is
+  not aiming where it thinks it is: check the rung offsets, not the club.
 - **Refused at Reserve all the way out** — refusals continue past ~2s. That
   would be new, and is the first evidence that would make contention real.
 - **Granted, then lost later** — `ledger.jsonl` has an `accepted` row but the

--- a/.claude/skills/booking-postmortem/SKILL.md
+++ b/.claude/skills/booking-postmortem/SKILL.md
@@ -410,6 +410,25 @@ spacing so the tick is bracketed tightly enough to aim 30ms past it.
 second", not "1ms past". It is precise enough to say which second the club was
 in — which is the whole question — and not precise enough for anything finer.
 
+**And read it against `roundTripMs`, because it is stamped when the club
+*answers*, not when it receives.** The two are near enough to interchange at a
+700ms round trip and not at a slow one. 2026-08-16 fired at +1023ms and the row
+says `serverMsPastWindow: 3001` — which is not three seconds of lateness and not
+a two-second clock difference, but a `2935ms` round trip putting the answer at
+06:30:03 for a request sent at 06:30:01.022. The club's receipt is only bounded
+to `[sent, sent+roundTripMs]`; when that span is seconds wide, the row cannot
+place the boundary at all. This is why 08-15 could carry the boundary argument
+and 08-16 cannot: 08-15's 741ms round trip bracketed the refusal inside the
+06:30:00 second, and a 2935ms one brackets nothing. Check the round trip before
+reading anything into the second.
+
+**#150 works.** 2026-08-16 was the first race on it: one Reserve, fired at
++1023ms with a tick pinned to ±23ms, accepted first try, and
+`RESERVATION_CHECK` found `08/23/2026 08:00 AM RESERVED` on the member's page —
+a prime Sunday-morning slot, and the first morning with no refusal in the ledger
+at all. Every earlier win came from a later rung after attempt 1 was spent on a
+certain no.
+
 What is still open is narrower: whether the 06:30:01 boundary is fixed or drifts
 morning to morning. The ladder brackets it either way, and `serverMsPastWindow`
 on the granted row records which second won.

--- a/.claude/skills/booking-postmortem/SKILL.md
+++ b/.claude/skills/booking-postmortem/SKILL.md
@@ -7,8 +7,9 @@ description: Diagnose why the morning's TeeTime booking run failed. Use when the
 
 The booking job fires at 06:28 CT. The window nominally opens at 06:30:00 CT,
 but the club's sheet actually opens at 06:30:01 — see §7a, which is why the run
-no longer aims at 06:30:00.000. Every morning it loses, the question is the
-same: did we lose the race, or did we refuse ourselves? This skill is the
+no longer aims at 06:30:00.000. The bot first won the race on 2026-08-15, so
+losing is no longer the default — but when a morning does lose, the question is
+the same: did we lose the race, or did we refuse ourselves? This skill is the
 repeatable path to that answer.
 
 ## 0. Set the session up
@@ -19,11 +20,20 @@ idempotent, and takes about 16 seconds cold:
 
 ```bash
 bash scripts/setup_remote_env.sh
-gcloud storage ls gs://gen-lang-client-0822973627-teetime-debug-artifacts/walden/race/
 ```
 
-A listing means every command in this skill works. Point the environment's
-setup-script setting at that file and it happens before you are asked anything.
+Its last line is the answer: `READY` means both access paths work, `PARTIAL`
+names the one that does, and `NOT READY` means neither and the warnings above
+it say why. Point the environment's setup-script setting at that file and this
+happens before you are asked anything.
+
+Check whichever path you are about to use, because they fail independently —
+a `gcloud` listing says nothing about whether the venv installed:
+
+```bash
+gcloud storage ls gs://gen-lang-client-0822973627-teetime-debug-artifacts/walden/race/
+poetry run python scripts/fetch_debug_artifacts.py list --date "$(date -u +%Y%m%d)"
+```
 
 Two things worth knowing, because the earlier version of this skill got both
 wrong and cost a post-mortem each:
@@ -307,6 +317,7 @@ a refusal comes back `unknown` — the failure is silent and reads like a findin
 Unwrap it first, which also gives you the `<eval>` scripts:
 
 ```python
+from pathlib import Path
 from app.providers.walden_http import parse_html, parse_partial_response
 from app.providers.walden_http_booker import classify_reserve_response
 response = parse_partial_response(Path("attempt_01_refused.xml").read_text(errors="replace"))

--- a/.claude/skills/booking-postmortem/SKILL.md
+++ b/.claude/skills/booking-postmortem/SKILL.md
@@ -5,9 +5,48 @@ description: Diagnose why the morning's TeeTime booking run failed. Use when the
 
 # Morning booking post-mortem
 
-The booking job fires at 06:28 CT and the window opens at 06:30:00 CT. Every
-morning it loses, the question is the same: did we lose the race, or did we
-refuse ourselves? This skill is the repeatable path to that answer.
+The booking job fires at 06:28 CT. The window nominally opens at 06:30:00 CT,
+but the club's sheet actually opens at 06:30:01 — see §7a, which is why the run
+no longer aims at 06:30:00.000. Every morning it loses, the question is the
+same: did we lose the race, or did we refuse ourselves? This skill is the
+repeatable path to that answer.
+
+## 0. Set the session up
+
+A fresh remote container (Claude Code on the web) has neither `gcloud` nor a
+usable credential nor an installed venv. One script fixes all three, is
+idempotent, and takes about 16 seconds cold:
+
+```bash
+bash scripts/setup_remote_env.sh
+gcloud storage ls gs://gen-lang-client-0822973627-teetime-debug-artifacts/walden/race/
+```
+
+A listing means every command in this skill works. Point the environment's
+setup-script setting at that file and it happens before you are asked anything.
+
+Two things worth knowing, because the earlier version of this skill got both
+wrong and cost a post-mortem each:
+
+**`gcloud` does install here.** The egress policy refuses `dl.google.com` and
+`packages.cloud.google.com`, which is why installing the CLI the documented way
+fails — but `dl.google.com` is only a CDN in front of the `cloud-sdk-release`
+bucket, and `storage.googleapis.com` is reachable because it is the same host
+the debug artifacts come from. `curl` the tarball out of the bucket and you get
+a complete SDK, `gsutil` and `bq` included, with its own bundled Python.
+Established 2026-08-15; the setup script does exactly this.
+
+**The key file exists and is empty.** The environment sets `GCP_KEY_B64` and
+points `GOOGLE_APPLICATION_CREDENTIALS` at `/tmp/gcp-key.json`, but nothing
+decodes one into the other, so a test for the file's *existence* passes and
+everything downstream fails with an ADC error that names nothing. Test `-s`, not
+`-f`. See `docs/debug-artifact-access.md` for the service account and its
+grant — read-only, one bucket and the project's logs.
+
+If for some reason the CLI is unavailable, nothing here is blocked:
+`scripts/fetch_debug_artifacts.py` reads the same logs and the same bucket over
+the JSON APIs with `google.auth` + `httpx`, and every step below gives both
+forms.
 
 ## 1. Get to latest first
 
@@ -29,17 +68,54 @@ gcloud run revisions list --service=teetime --region=us-central1 --project=gen-l
 If a deploy landed between the run and now, read the code at that revision's
 commit (`git show <sha>:<path>`, or a worktree) rather than at `main`.
 
+**That command fails for the post-mortem service account** — it needs
+`run.revisions.list`, and the grant is deliberately only storage + logging. It
+is an IAM gap, not a tooling one; `roles/run.viewer` on the account would close
+it. Until then, the logs name the revision themselves:
+
+```bash
+gcloud logging read "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"teetime\" AND timestamp>=\"2026-08-15T11:28:00Z\" AND timestamp<=\"2026-08-15T11:31:00Z\"" --project=gen-lang-client-0822973627 --format="value(resource.labels.revision_name)" --limit=200 | sort -u
+```
+
+That gives the revision that served the run (`teetime-00063-779` on 2026-08-15)
+but not its commit. Bound that from commit timestamps and confirm against the
+run's own behaviour:
+
+```bash
+git log --format="%h %ad %s" --date=iso -8
+```
+
+Any commit dated after the run was not in it. Confirm rather than assume: the
+run logs what the deployed code did, so a field the newest commit introduced —
+or a constant it changed — settles which side of the deploy you are on. On
+2026-08-15 the ledger's `targetTimestampMs` decoded to 06:29:59.999 CT and no
+`RESERVATION_CHECK` line appeared, both of which place the morning run before
+#150 (merged 16:32 CT the same day) without ever listing a revision.
+
 ## 2. Pull the run
 
 Project `gen-lang-client-0822973627`, Cloud Run service `teetime`, region
 `us-central1`. The job fires at 06:28 CT and the window opens at 06:30 CT —
 11:30 UTC during CDT, 12:30 UTC during CST.
 
+**The short form, and the only one that works without `gcloud`.** It takes CT
+wall-clock times and does the UTC conversion, the DST offset and the
+`discord.gateway` exclusion itself:
+
+```bash
+poetry run python scripts/fetch_debug_artifacts.py logs \
+  --date 2026-08-15 --from 06:20 --to 06:40 --out run.txt
+```
+
+Widen `--to` to `08:00` when the question is about what happened *after* the
+race — a later manual booking, or the SMS the member got.
+
 **Use the Bash tool, not PowerShell** — PowerShell mangles the quoting inside
 the filter and gcloud rejects it with "Unparseable filter".
 
-Set the date once and derive the UTC bounds from it, so the same command works
-for any morning and picks the right offset either side of a DST change:
+The `gcloud` form, for a machine that has it. Set the date once and derive the
+UTC bounds from it, so the same command works for any morning and picks the
+right offset either side of a DST change:
 
 ```bash
 DAY=2026-08-09
@@ -95,9 +171,20 @@ The sweep means a run now fires several Reserves for the **same** slot before it
 touches the fallback list. A refused attempt 1 is expected and is not the story;
 which rung was granted is.
 
-`phase=complete, success=True` is **not** proof of a booking — the provider
-verifies against the member's reservations page afterwards
-(`RESERVATION_CHECK:`). Read that line before declaring a win.
+`phase=complete, success=True` is **not** proof of a booking. Success is a
+phrase match on a PrimeFaces partial update — 2026-08-15 returned it on the
+words "thank you" — and the one failure class that looks exactly like a win in
+the logs is a chain that completed against no reservation. As of #150 the
+provider checks the member's reservations page even when the response said yes,
+and logs `RESERVATION_CHECK:`. Read that line before declaring a win.
+
+Its **absence** means different things either side of that commit: in a run
+after #150 the check should be there, and in a run before it a text-confirmed
+booking returned without ever looking. 08-15's morning run has no such line for
+that reason, not because anything went wrong. Failing the check is reported,
+not enforced — a confirmed booking is not discarded because the page was slow,
+so `RESERVATION_CHECK: ... not on the member's reservations page` is an
+`ERROR` line in an otherwise successful-looking run.
 
 ## 4. Pull the artifacts
 
@@ -105,8 +192,31 @@ Failures upload to `gs://gen-lang-client-0822973627-teetime-debug-artifacts/`.
 The log lines print the exact paths; the naming is
 `walden/<reason>/<YYYYMMDD_HHMMSS>/<file>`.
 
-**Use `gcloud storage cp`, not `gsutil`** — gsutil is broken in this
-environment (`python3.13: command not found`).
+List what a morning left, then pull it. This works with or without `gcloud`, and
+summarizes any ledger it downloads:
+
+```bash
+poetry run python scripts/fetch_debug_artifacts.py list  --date 20260815
+poetry run python scripts/fetch_debug_artifacts.py fetch --date 20260815 --out ./artifacts
+```
+
+Artifact object names come from `datetime.now()` inside Cloud Run with no `TZ`
+set, so **they are stamped UTC**. A 06:30 CT run lands under the same date
+either way; an evening run does not.
+
+**Pick the morning's directory, not just the day's.** Ad-hoc bookings write
+race ledgers into the same bucket, so a date often has two — `20260815_113004`
+is the 06:30 race, `20260815_224814` is a 17:48 CT ad-hoc run. Do not read an
+evening ledger as evidence about the boundary: there is no queue outside the
+race and the club accepts immediately, so 08-14's evening run was granted at
+**−25ms** and 08-15's on the first rung it tried. Neither says anything about
+what happens at 06:30. The race is the one whose first Reserve fires near the
+window.
+
+To copy by hand, `gcloud storage cp` and `gcloud storage ls` both work. Prefer
+them to `gsutil` out of habit — gsutil is broken on the maintainer's local
+machine (`python3.13: command not found`), though it does work in a remote
+session, where the SDK tarball brings its own Python.
 
 **Start with the race ledger** — `walden/race/<YYYYMMDD_HHMMSS>/`. It is the
 whole run rather than its last frame:
@@ -143,16 +253,33 @@ matching it to the pre-window sheet's `Booking Starts In : 00:0X:XX` — on
 2026-08-09 both read 70s. It is logged, never branched on. Don't re-derive
 "the window wasn't open" from it.
 
-**The blocked popup is not a verdict.** `teeSheetValidationErrorPopup` and the
-text "This slot is blocked by another user" appear in *every* Reserve response —
-all five saved from 2026-08-06 to 08-12, including the two where the club had
-just granted a tee time. It is emitted as inert markup: no `visible:true`, no
-`.show()` anywhere in the payload, `ui-hidden-container` and no `aria-hidden`.
-Reading it as a refusal discarded a held slot on 08-08 and again on 08-12.
+**The popup's markup is not a verdict.** `teeSheetValidationErrorPopup` and the
+text "This slot is blocked by another user" are carried by Reserve responses
+that *accepted* — all five saved from 2026-08-06 to 08-12 and both of 08-15's
+morning attempts have it, including the three where the club had just granted a
+tee time. In the re-rendered markup it is inert: `ui-hidden-container`, no
+`aria-hidden`, no `visible:true`. Reading it as a refusal discarded a held slot
+on 08-08 and again on 08-12. `ledger.jsonl` records it as `popupPresent`, which
+is `True` on accepted rows too — a presence flag, not an outcome.
+
+It is not in literally every response: 08-15's evening ad-hoc booking was
+accepted with `popupPresent=False`. So its *absence* carries no information
+either. Neither direction of that flag is a verdict; stop reading it as one.
 
 Its absence from the pre-window sheet proves only that the club renders it in
 responses, not in sheets. That is not the same as showing it, and the 08-09
 inference built on it does not generalize.
+
+**What does show it is the `<eval>`, and that is a verdict.** Corrected
+2026-08-15, the first morning whose raw envelopes were kept: the refused attempt
+carried `PF('teeSheetValidationErrorPopupVar').show();;` and the accepted one
+carried `executeHoldTimeTimer('300');;stopSheetTimers();;` and no `.show()` at
+all. The earlier "no `.show()` anywhere in the payload" was true of what had been
+saved, not of what the club sent — the parser dropped `<eval>` before 08-12. So
+the popup on a refusal is genuinely displayed to the member, and `evalText` in
+the ledger is a second, independent read on the verdict. Do not go back to
+matching the popup's *markup*; that is the trap this replaces, not a reprieve
+from it.
 
 **What separates them is which view came back:**
 
@@ -172,6 +299,23 @@ from app.providers.walden_http import parse_html
 from app.providers.walden_http_booker import classify_reserve_response
 verdict, reason = classify_reserve_response(parse_html(markup), markup)
 ```
+
+**`markup` there means the extracted markup, not the file you downloaded.** The
+`attempt_NN_*.xml` artifacts are the raw `<partial-response>` envelope, and the
+classifier reads the re-rendered form inside its CDATA. Hand it the envelope and
+a refusal comes back `unknown` — the failure is silent and reads like a finding.
+Unwrap it first, which also gives you the `<eval>` scripts:
+
+```python
+from app.providers.walden_http import parse_html, parse_partial_response
+from app.providers.walden_http_booker import classify_reserve_response
+response = parse_partial_response(Path("attempt_01_refused.xml").read_text(errors="replace"))
+verdict, reason = classify_reserve_response(parse_html(response.markup), response.markup)
+```
+
+Reproduced both of 2026-08-15's verdicts exactly. The older
+`direct_http_response.html` artifacts are already-extracted markup and take the
+first form.
 
 It is pinned by `tests/test_reserve_verdict.py` against all five real responses,
 kept gzipped in `tests/fixtures/reserve_responses/`. A structural question about
@@ -220,21 +364,39 @@ Don't re-litigate these; each was established from artifacts, not reasoning:
   own screenshot at 7:46 showed every slot from 4:23 to 6:00 PM still Available.
   The club words *every* early refusal "blocked by another user".
 
-## 7a. The open question
+## 7a. The question that was open, and its answer
 
-The club refuses for roughly the first second past the window and then accepts.
-Two readings remain, and one morning's ledger separates them:
+**Settled 2026-08-15, the morning the bot first won.** The club refused for
+roughly the first second past the window and then accepted, and two readings
+were live: a clock difference (the skew probe measures a *static asset host*,
+which need not share a clock with the application server) or a deliberate
+boundary. 08-15's ledger separates them:
 
-- **A clock difference.** The skew probe measures a *static asset host*, which
-  need not share a clock with the application server that decides bookings.
-  `serverMsPastWindow` in the ledger reads the `Date` header off the Reserve
-  POST itself. If it says ~−1000ms when we sent at our 06:30:00.000, we are
-  simply early and the probe target is wrong.
-- **A server-side grace period.** If the club's own clock reads 06:30:00 and it
-  refuses anyway, the boundary is deliberate and the answer is to aim past it.
+| attempt | sent | club `Date` | verdict |
+|---|---|---|---|
+| 1 | −60ms | inside the 06:30:00 second | refused |
+| 2 | +1240ms | inside the 06:30:01 second | accepted |
 
-Either way the sweep records which offsets were refused and which was granted,
-so the boundary narrows to the rung spacing every morning it runs.
+The club refused while its **own** clock read 06:30:00. That is the boundary
+reading, not the clock reading — the probe was not measuring the wrong host, and
+the split holds across every morning on record: refused at −60, −14, −7, 0, 0,
+812, 817; granted at 1239, 1240, 1291. The sheet opens at 06:30:01, so every
+first Reserve ever sent at ~0ms was spent on a certain no.
+
+#150 acted on this: the first rung is now 1030ms rather than 0, the ladder is
+`1030,1250,2000,3000,4500`, the precision wait sleeps to the first rung rather
+than to the window, and the clock probe is budget-bounded at 5s with 20ms
+spacing so the tick is bracketed tightly enough to aim 30ms past it.
+
+**Read `serverMsPastWindow` as ±1s, not as a millisecond figure.** The HTTP
+`Date` header is whole-second resolution and the parser multiplies seconds by
+1000 (`walden_http.py`), so a row reading `1` means "somewhere in the 06:30:00
+second", not "1ms past". It is precise enough to say which second the club was
+in — which is the whole question — and not precise enough for anything finer.
+
+What is still open is narrower: whether the 06:30:01 boundary is fixed or drifts
+morning to morning. The ladder brackets it either way, and `serverMsPastWindow`
+on the granted row records which second won.
 
 ## 8. Report
 

--- a/docs/debug-artifact-access.md
+++ b/docs/debug-artifact-access.md
@@ -10,18 +10,64 @@ project's logs.
 
 ## What is not needed
 
-- **The `gcloud` CLI.** `WaldenProvider._upload_bytes_to_gcs` already does GCS
-  I/O with `google.auth` + `httpx` against the JSON API, with no
-  `google-cloud-storage` dependency. `scripts/fetch_debug_artifacts.py` reads
-  them back the same way, with read-only scopes. Both libraries are already in
-  the venv.
 - **A network policy change.** `storage.googleapis.com`,
   `logging.googleapis.com` and `oauth2.googleapis.com` are all reachable from a
   remote session today; an unauthenticated bucket request returns a genuine GCS
-  `401`, not a proxy block. (`dl.google.com` *is* refused, which is why
-  installing the CLI fails — but the CLI is not the path.)
+  `401`, not a proxy block.
+- **The `gcloud` CLI**, for the artifacts themselves.
+  `WaldenProvider._upload_bytes_to_gcs` already does GCS I/O with `google.auth`
+  + `httpx` against the JSON API, with no `google-cloud-storage` dependency.
+  `scripts/fetch_debug_artifacts.py` reads them back the same way, with
+  read-only scopes. Both libraries are already in the venv.
 
 The only missing piece is a credential.
+
+## The CLI, which turns out to be installable after all
+
+This document originally said the CLI could not be installed in a remote
+session, because the egress policy refuses `dl.google.com`. It does refuse it,
+and `packages.cloud.google.com` as well — but that was the wrong conclusion.
+`dl.google.com` is a CDN in front of the `cloud-sdk-release` GCS bucket, and
+`storage.googleapis.com` is reachable, being the same host the debug artifacts
+come from. Pulling the tarball from the bucket installs a complete SDK — `bq`
+and `gsutil` included, with its own bundled Python, so the
+`python3.13: command not found` that breaks gsutil locally does not apply:
+
+```bash
+curl -sS -o /tmp/gcloud.tar.gz \
+  https://storage.googleapis.com/cloud-sdk-release/google-cloud-cli-linux-x86_64.tar.gz
+tar -xzf /tmp/gcloud.tar.gz -C /opt
+ln -sf /opt/google-cloud-sdk/bin/{gcloud,gsutil,bq} /usr/local/bin/
+gcloud config set component_manager/disable_update_check true
+gcloud auth activate-service-account --key-file=/tmp/gcp-key.json
+```
+
+Verified 2026-08-15: `gcloud storage ls` and `gcloud logging read` both work
+against this project, cold install to working command in about 16 seconds.
+
+Two details that matter. Set `component_manager/disable_update_check` — every
+invocation otherwise reaches for `dl.google.com` and prints a `ProxyError`
+traceback that reads like the command itself failed, when it has not. And
+symlink into `/usr/local/bin` rather than exporting `PATH`: the agent's shell
+does not inherit a setup script's exports.
+
+`scripts/setup_remote_env.sh` does all of the above plus the key and the venv,
+and is idempotent. Point the environment's setup-script setting at it.
+
+### What the CLI still cannot do here
+
+`gcloud run revisions list` — the step a post-mortem wants for "which code
+actually ran" — fails with `Permission 'run.revisions.list' denied`. That is
+this account's IAM, not the network: the grant below is storage and logging
+only. Adding `roles/run.viewer` would close it:
+
+```bash
+gcloud projects add-iam-policy-binding $PROJECT \
+  --member=serviceAccount:$SA --role=roles/run.viewer
+```
+
+Without it, the logs still name the revision that served a run, in
+`resource.labels.revision_name`.
 
 ## Setting it up
 
@@ -66,8 +112,18 @@ docs](https://code.claude.com/docs/en/claude-code-on-the-web)):
 
 ### 3. Setup script
 
+Point the environment's setup-script setting at `scripts/setup_remote_env.sh`.
+It decodes the key, installs the CLI, authenticates, and installs the venv;
+it is idempotent, so a warm container re-runs it in about a second.
+
+**Setting the two environment variables is not sufficient on its own.** Without
+the script nothing decodes `GCP_KEY_B64` into `/tmp/gcp-key.json`, and on
+2026-08-15 the target file existed and was zero bytes — so a check for the
+file's existence passed while every read failed with an ADC error that named
+nothing. If you are doing it by hand, test `-s`, not `-f`:
+
 ```bash
-echo "$GCP_KEY_B64" | base64 -d > /tmp/gcp-key.json
+[ -s /tmp/gcp-key.json ] || printf '%s' "$GCP_KEY_B64" | base64 -d > /tmp/gcp-key.json
 chmod 600 /tmp/gcp-key.json
 ```
 
@@ -79,10 +135,13 @@ script's exports, but environment-level variables are present on every call.
 
 ```bash
 poetry run python scripts/fetch_debug_artifacts.py list --date 20260813
+gcloud storage ls gs://gen-lang-client-0822973627-teetime-debug-artifacts/walden/race/
 ```
 
 A listing means it works. A `403` names the missing role; a credentials error
-means ADC never found the key file.
+means ADC never found the key file. Note that the venv starts empty on a fresh
+container — a `ModuleNotFoundError: No module named 'google'` means
+`poetry install --no-root` has not run, not that anything is misconfigured.
 
 ## Using it
 

--- a/docs/debug-artifact-access.md
+++ b/docs/debug-artifact-access.md
@@ -56,18 +56,50 @@ and is idempotent. Point the environment's setup-script setting at it.
 
 ### What the CLI still cannot do here
 
-`gcloud run revisions list` — the step a post-mortem wants for "which code
-actually ran" — fails with `Permission 'run.revisions.list' denied`. That is
-this account's IAM, not the network: the grant below is storage and logging
-only. Adding `roles/run.viewer` would close it:
+`gcloud run revisions list` — the step §1 of the post-mortem skill wants for
+"which code actually ran" — fails with `Permission 'run.revisions.list' denied`.
+That is this account's IAM, not the network: the grant above is storage and
+logging only, and Cloud Run's admin API is neither.
+
+Adding `roles/run.viewer` closes it. **Run this on your own machine**, like
+steps 1 and 2 — the post-mortem account cannot grant itself a role:
 
 ```bash
+PROJECT=gen-lang-client-0822973627
+SA=teetime-artifact-reader@$PROJECT.iam.gserviceaccount.com
+
 gcloud projects add-iam-policy-binding $PROJECT \
   --member=serviceAccount:$SA --role=roles/run.viewer
 ```
 
-Without it, the logs still name the revision that served a run, in
-`resource.labels.revision_name`.
+Then, from a session, `gcloud run revisions list --service=teetime
+--region=us-central1 --limit=5` should list revisions instead of erroring.
+
+**What that grant exposes.** `roles/run.viewer` is read-only over Cloud Run —
+it cannot deploy, update traffic, or delete — but it does read service
+*configuration*, which includes the environment block. That would matter if
+secrets were set as literal env values. They are not: every secret in
+`terraform/main.tf` is injected through `value_source.secret_key_ref`, so the
+service config carries secret *names* and versions while the values stay in
+Secret Manager, behind `roles/secretmanager.secretAccessor` that this account
+does not have. The plain `env` entries are booking flags and timezone. So the
+grant adds revision and service metadata and no credential material.
+
+If you would rather grant the single permission than the role, a custom role
+does it:
+
+```bash
+gcloud iam roles create teetimeRevisionReader --project=$PROJECT \
+  --title="List Cloud Run revisions for post-mortems" \
+  --permissions=run.revisions.list,run.revisions.get
+gcloud projects add-iam-policy-binding $PROJECT \
+  --member=serviceAccount:$SA --role=projects/$PROJECT/roles/teetimeRevisionReader
+```
+
+None of this is load-bearing: without it the logs still name the revision that
+served a run, in `resource.labels.revision_name`, and commit timestamps plus the
+run's own logged behaviour bound which code was deployed. It saves a step in §1
+rather than enabling anything new.
 
 ## Setting it up
 

--- a/docs/debug-artifact-access.md
+++ b/docs/debug-artifact-access.md
@@ -155,9 +155,13 @@ file's existence passed while every read failed with an ADC error that named
 nothing. If you are doing it by hand, test `-s`, not `-f`:
 
 ```bash
-[ -s /tmp/gcp-key.json ] || printf '%s' "$GCP_KEY_B64" | base64 -d > /tmp/gcp-key.json
+[ -s /tmp/gcp-key.json ] || (umask 077; printf '%s' "$GCP_KEY_B64" | base64 -d > /tmp/gcp-key.json)
 chmod 600 /tmp/gcp-key.json
 ```
+
+The `umask` matters when the target does not already exist: a redirect creates
+the file under the caller's umask, so the plain `> file; chmod 600 file` form
+leaves a private key world-readable for the width of the decode.
 
 Set `GOOGLE_APPLICATION_CREDENTIALS` as an environment variable rather than
 exporting it from the setup script. The agent's shell does not inherit the

--- a/docs/debug-artifact-access.md
+++ b/docs/debug-artifact-access.md
@@ -34,13 +34,31 @@ and `gsutil` included, with its own bundled Python, so the
 `python3.13: command not found` that breaks gsutil locally does not apply:
 
 ```bash
-curl -sS -o /tmp/gcloud.tar.gz \
-  https://storage.googleapis.com/cloud-sdk-release/google-cloud-cli-linux-x86_64.tar.gz
-tar -xzf /tmp/gcloud.tar.gz -C /opt
-ln -sf /opt/google-cloud-sdk/bin/{gcloud,gsutil,bq} /usr/local/bin/
+VERSION=580.0.0
+SHA256=e580c04b45dfa2e537b8dc0cf7c828e46a65bc77ef61de69161e1f3a124d7480
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+curl -sS --fail --max-time 600 -o "$TMP/gcloud.tar.gz" \
+  "https://storage.googleapis.com/cloud-sdk-release/google-cloud-cli-$VERSION-linux-x86_64.tar.gz" \
+  && printf '%s  %s\n' "$SHA256" "$TMP/gcloud.tar.gz" | sha256sum -c - \
+  && mkdir -p /opt/google-cloud-sdk \
+  && tar -xzf "$TMP/gcloud.tar.gz" -C /opt/google-cloud-sdk --strip-components=1 \
+  && ln -sf /opt/google-cloud-sdk/bin/{gcloud,gsutil,bq} /usr/local/bin/
+
 gcloud config set component_manager/disable_update_check true
 gcloud auth activate-service-account --key-file=/tmp/gcp-key.json
 ```
+
+Four things in there are load-bearing, and the obvious shorter version has a
+bug in each: `--fail`, because without it curl writes the server's error body
+to the output file and *still exits 0*, so a proxy 403 becomes a 200-byte XML
+document named like an archive; the pinned version and digest, because the
+rolling `google-cloud-cli-linux-x86_64.tar.gz` can change under a URL that
+never does and TLS authenticates the host rather than the object; `mktemp`,
+because a fixed `/tmp` name is pre-creatable as a symlink by anything else on
+the machine; and `&&` throughout, so a failure at any step stops rather than
+extracting an unverified archive. `scripts/setup_remote_env.sh` does all of
+this, and is the path to prefer.
 
 Verified 2026-08-15: `gcloud storage ls` and `gcloud logging read` both work
 against this project, cold install to working command in about 16 seconds.
@@ -155,13 +173,22 @@ file's existence passed while every read failed with an ADC error that named
 nothing. If you are doing it by hand, test `-s`, not `-f`:
 
 ```bash
-[ -s /tmp/gcp-key.json ] || (umask 077; printf '%s' "$GCP_KEY_B64" | base64 -d > /tmp/gcp-key.json)
+if [ ! -s /tmp/gcp-key.json ]; then
+  TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+  (umask 077; printf '%s' "$GCP_KEY_B64" | base64 -d > "$TMP/key.json") \
+    && python3 -c "import json;json.load(open('$TMP/key.json'))['client_email']" \
+    && (umask 077; cat "$TMP/key.json" > /tmp/gcp-key.json)
+fi
 chmod 600 /tmp/gcp-key.json
 ```
 
-The `umask` matters when the target does not already exist: a redirect creates
-the file under the caller's umask, so the plain `> file; chmod 600 file` form
-leaves a private key world-readable for the width of the decode.
+Longer than it looks like it needs to be, for two reasons. The `umask` matters
+when the target does not already exist: a redirect creates the file under the
+caller's umask, so the plain `> file; chmod 600 file` form leaves a private key
+world-readable for the width of the decode. And the decode goes to scratch and
+is *parsed* before being moved into place, because a partial decode otherwise
+leaves a non-empty file that passes the `-s` test on every later run — a
+corrupt key that looks permanently like a present one.
 
 Set `GOOGLE_APPLICATION_CREDENTIALS` as an environment variable rather than
 exporting it from the setup script. The agent's shell does not inherit the

--- a/scripts/setup_remote_env.sh
+++ b/scripts/setup_remote_env.sh
@@ -5,7 +5,7 @@
 # Point the environment's setup-script setting at this file. It is idempotent
 # and safe to re-run; a warm container re-runs it in about a second.
 #
-# Two things a fresh remote container is missing:
+# Three things a fresh remote container is missing:
 #
 #   1. The service-account key. The environment holds it as GCP_KEY_B64 and
 #      points GOOGLE_APPLICATION_CREDENTIALS at /tmp/gcp-key.json, but nothing
@@ -20,6 +20,13 @@
 #      it is the same host the debug artifacts come from. Pulling the tarball
 #      from the bucket directly installs a complete SDK, gsutil and bq
 #      included, with its own bundled Python.
+#
+#   3. The project venv, which starts empty.
+#
+# `set -e` is deliberately absent: a container missing any one of the three
+# should still get the other two, plus a warning naming what it lacks. That
+# only works if every failure is actually reported, so the exit summary below
+# reflects what is genuinely usable rather than the fact that the script ran.
 #
 # See docs/debug-artifact-access.md.
 
@@ -51,80 +58,114 @@ KEY_FILE="${GOOGLE_APPLICATION_CREDENTIALS:-/tmp/gcp-key.json}"
 
 log() { printf '[setup] %s\n' "$*"; }
 
+# mktemp rather than a fixed /tmp name: these are world-writable paths and a
+# predictable one is pre-creatable as a symlink by anything else on the box.
+SCRATCH=""
+cleanup() { [ -n "$SCRATCH" ] && rm -rf "$SCRATCH"; }
+trap cleanup EXIT
+SCRATCH="$(mktemp -d)" || { log "FATAL: could not create a temp directory"; exit 0; }
+
+have_cred=no
+have_gcloud=no
+have_python=no
+
 # --- 1. Credentials ----------------------------------------------------------
 # -s rather than -f: the file is pre-created empty, so "exists" is not "usable".
 if [ -s "$KEY_FILE" ]; then
   log "credentials already present at $KEY_FILE"
+  have_cred=yes
 elif [ -n "${GCP_KEY_B64:-}" ]; then
-  # umask in a subshell, not chmod afterwards. A redirect creates a *new* file
-  # under the caller's umask - 0644 by default - so `> key; chmod 600 key`
-  # leaves a private key world-readable for the width of the decode. It does
-  # not show up in the environment this was written for, because there the
-  # file is pre-created 0600 and a redirect onto an existing file keeps its
-  # mode; it appears the moment GOOGLE_APPLICATION_CREDENTIALS points
-  # somewhere new. The chmod stays for that pre-existing case, where the mode
-  # is whatever someone else set.
-  if (umask 077; printf '%s' "$GCP_KEY_B64" | base64 -d > "$KEY_FILE") 2>/dev/null && [ -s "$KEY_FILE" ]; then
-    chmod 600 "$KEY_FILE"
-    log "decoded GCP_KEY_B64 -> $KEY_FILE"
+  # Decode to scratch and move only once it is known good. Writing straight to
+  # KEY_FILE means a partial decode leaves a non-empty file that passes the -s
+  # test above on the next run, so a corrupt key would look like a present one
+  # forever. Non-empty is not the bar; parsing as a service-account key is.
+  #
+  # umask, not a following chmod: a redirect creates a *new* file under the
+  # caller's umask - 0644 by default - which would leave a private key
+  # world-readable for the width of the decode. It does not reproduce where
+  # the target is pre-created 0600, because a redirect onto an existing file
+  # keeps its mode; it appears the moment the path is new.
+  if (umask 077; printf '%s' "$GCP_KEY_B64" | base64 -d > "$SCRATCH/key.json") 2>/dev/null \
+     && [ -s "$SCRATCH/key.json" ] \
+     && python3 -c "import json,sys; json.load(open(sys.argv[1]))['client_email']" "$SCRATCH/key.json" 2>/dev/null; then
+    if (umask 077; cat "$SCRATCH/key.json" > "$KEY_FILE") 2>/dev/null; then
+      chmod 600 "$KEY_FILE"
+      log "decoded GCP_KEY_B64 -> $KEY_FILE"
+      have_cred=yes
+    else
+      log "WARNING: could not write the decoded key to $KEY_FILE"
+    fi
   else
-    log "WARNING: GCP_KEY_B64 did not decode; artifact and log access will fail"
-    rm -f "$KEY_FILE"
+    log "WARNING: GCP_KEY_B64 did not decode to a service-account key;"
+    log "         artifact and log access will fail. $KEY_FILE left untouched."
   fi
 else
   log "WARNING: no GCP_KEY_B64 set; artifact and log access will fail"
 fi
 
 # --- 2. The gcloud CLI -------------------------------------------------------
-if command -v gcloud > /dev/null 2>&1; then
-  log "gcloud already on PATH"
-elif [ -x "$SDK_ROOT/bin/gcloud" ]; then
-  log "gcloud already installed at $SDK_ROOT"
-else
+if [ ! -x "$SDK_ROOT/bin/gcloud" ] && ! command -v gcloud > /dev/null 2>&1; then
   log "installing the gcloud CLI $SDK_VERSION from the cloud-sdk-release bucket"
   # --fail matters more than it looks. Without it curl writes the server's
   # error body to the output file and still exits 0, so a proxy 403 or a
-  # renamed object lands a 200-byte XML document named gcloud.tar.gz, tar
-  # fails, and the failure is silent - which is the opposite of the degraded
-  # path this script is supposed to provide.
-  if ! curl -sS --fail --max-time 600 -o /tmp/gcloud.tar.gz "$SDK_TARBALL"; then
-    log "WARNING: could not download the SDK $SDK_VERSION; falling back to scripts/fetch_debug_artifacts.py"
-    rm -f /tmp/gcloud.tar.gz
-  elif ! printf '%s  /tmp/gcloud.tar.gz\n' "$SDK_SHA256" | sha256sum -c - > /dev/null 2>&1; then
+  # renamed object lands a 200-byte XML document named like an archive, tar
+  # fails, and the failure is silent - the opposite of the degraded path this
+  # script exists to provide.
+  if ! curl -sS --fail --max-time 600 -o "$SCRATCH/gcloud.tar.gz" "$SDK_TARBALL"; then
+    log "WARNING: could not download the SDK $SDK_VERSION;"
+    log "         falling back to scripts/fetch_debug_artifacts.py"
+  elif ! printf '%s  %s\n' "$SDK_SHA256" "$SCRATCH/gcloud.tar.gz" | sha256sum -c - > /dev/null 2>&1; then
     log "WARNING: SDK checksum mismatch - expected $SDK_SHA256,"
-    log "         got $(sha256sum /tmp/gcloud.tar.gz 2>/dev/null | cut -d' ' -f1). NOT installing."
+    log "         got $(sha256sum "$SCRATCH/gcloud.tar.gz" 2>/dev/null | cut -d' ' -f1). NOT installing."
     log "         If Google published a new $SDK_VERSION build, verify it and update SDK_SHA256."
-    rm -f /tmp/gcloud.tar.gz
   else
-    mkdir -p "$(dirname "$SDK_ROOT")"
-    if tar -xzf /tmp/gcloud.tar.gz -C "$(dirname "$SDK_ROOT")"; then
+    # --strip-components=1 into SDK_ROOT rather than extracting into its
+    # parent. The archive always contains a top-level google-cloud-sdk/, so
+    # extracting to dirname(SDK_ROOT) silently ignores GCLOUD_SDK_ROOT: the
+    # tree lands next to the configured path, every later check misses it, and
+    # the script reports an install that is not where it says it is.
+    mkdir -p "$SDK_ROOT"
+    if tar -xzf "$SCRATCH/gcloud.tar.gz" -C "$SDK_ROOT" --strip-components=1; then
       log "verified and unpacked to $SDK_ROOT"
     else
       log "WARNING: SDK archive downloaded and verified but would not extract"
     fi
-    rm -f /tmp/gcloud.tar.gz
   fi
 fi
 
-# The agent's shell does not inherit exports from this script, so putting the
-# SDK on PATH here would not survive. Symlink into a directory already on it.
+# Whichever gcloud is going to be used is the one that must be configured.
+# Selecting only $SDK_ROOT/bin/gcloud meant a pre-existing gcloud elsewhere on
+# PATH skipped configuration and authentication entirely, and the script still
+# exited 0 with an unusable CLI.
+GCLOUD_BIN=""
 if [ -x "$SDK_ROOT/bin/gcloud" ]; then
-  for tool in gcloud gsutil bq; do
-    [ -x "$SDK_ROOT/bin/$tool" ] && ln -sf "$SDK_ROOT/bin/$tool" "/usr/local/bin/$tool"
-  done
+  GCLOUD_BIN="$SDK_ROOT/bin/gcloud"
+elif command -v gcloud > /dev/null 2>&1; then
+  GCLOUD_BIN="$(command -v gcloud)"
+fi
+
+if [ -n "$GCLOUD_BIN" ]; then
+  # The agent's shell does not inherit exports from this script, so putting the
+  # SDK on PATH here would not survive. Symlink into a directory already on it.
+  if [ -x "$SDK_ROOT/bin/gcloud" ]; then
+    for tool in gcloud gsutil bq; do
+      [ -x "$SDK_ROOT/bin/$tool" ] && ln -sf "$SDK_ROOT/bin/$tool" "/usr/local/bin/$tool"
+    done
+  fi
 
   # Every gcloud invocation otherwise tries dl.google.com for a component
   # update check, which the egress policy refuses - slow, and it prints a
   # traceback that reads like the command itself failed.
-  "$SDK_ROOT/bin/gcloud" config set component_manager/disable_update_check true > /dev/null 2>&1
-  "$SDK_ROOT/bin/gcloud" config set core/disable_usage_reporting true > /dev/null 2>&1
-  "$SDK_ROOT/bin/gcloud" config set project "$PROJECT" > /dev/null 2>&1
+  "$GCLOUD_BIN" config set component_manager/disable_update_check true > /dev/null 2>&1
+  "$GCLOUD_BIN" config set core/disable_usage_reporting true > /dev/null 2>&1
+  "$GCLOUD_BIN" config set project "$PROJECT" > /dev/null 2>&1
 
-  if [ -s "$KEY_FILE" ]; then
-    if "$SDK_ROOT/bin/gcloud" auth activate-service-account --key-file="$KEY_FILE" > /dev/null 2>&1; then
+  if [ "$have_cred" = yes ]; then
+    if "$GCLOUD_BIN" auth activate-service-account --key-file="$KEY_FILE" > /dev/null 2>&1; then
       log "authenticated as $(python3 -c "import json;print(json.load(open('$KEY_FILE'))['client_email'])" 2>/dev/null)"
+      have_gcloud=yes
     else
-      log "WARNING: could not activate the service account"
+      log "WARNING: could not activate the service account for $GCLOUD_BIN"
     fi
   fi
 fi
@@ -135,13 +176,39 @@ fi
 if command -v poetry > /dev/null 2>&1; then
   if poetry run python -c "import google.auth, httpx" > /dev/null 2>&1; then
     log "python dependencies already installed"
+    have_python=yes
   else
     log "installing python dependencies (this takes a few minutes on a cold container)"
-    poetry install --no-root --no-interaction > /dev/null 2>&1 \
-      && log "dependencies installed" \
-      || log "WARNING: poetry install failed; run it by hand"
+    if poetry install --no-root --no-interaction > /dev/null 2>&1 \
+       && poetry run python -c "import google.auth, httpx" > /dev/null 2>&1; then
+      log "dependencies installed"
+      have_python=yes
+    else
+      log "WARNING: poetry install did not produce a usable venv; run it by hand"
+    fi
   fi
+else
+  log "WARNING: poetry not found; scripts/fetch_debug_artifacts.py will not run"
 fi
 
-log "done - verify with: gcloud storage ls gs://${PROJECT}-teetime-debug-artifacts/walden/race/"
+# --- Summary -----------------------------------------------------------------
+# Reported per capability rather than as a single "done", because the two
+# access paths fail independently and a post-mortem only needs one of them.
+# Saying "done" while the session cannot run a single documented command is
+# the failure mode this section exists to prevent.
+if [ "$have_gcloud" = yes ] && [ "$have_python" = yes ]; then
+  log "READY - both paths available"
+  log "  gcloud storage ls gs://${PROJECT}-teetime-debug-artifacts/walden/race/"
+  log "  poetry run python scripts/fetch_debug_artifacts.py list --date \$(date -u +%Y%m%d)"
+elif [ "$have_gcloud" = yes ]; then
+  log "PARTIAL - gcloud works, the python path does not"
+  log "  gcloud storage ls gs://${PROJECT}-teetime-debug-artifacts/walden/race/"
+elif [ "$have_python" = yes ] && [ "$have_cred" = yes ]; then
+  log "PARTIAL - the python path works, gcloud does not"
+  log "  poetry run python scripts/fetch_debug_artifacts.py list --date \$(date -u +%Y%m%d)"
+else
+  log "NOT READY - no working path to the artifacts or logs. See the warnings above."
+  log "  credentials=$have_cred gcloud=$have_gcloud python=$have_python"
+fi
+
 exit 0

--- a/scripts/setup_remote_env.sh
+++ b/scripts/setup_remote_env.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Set up a Claude Code on the web session to run a booking post-mortem.
+#
+# Point the environment's setup-script setting at this file. It is idempotent
+# and safe to re-run; a warm container re-runs it in about a second.
+#
+# Two things a fresh remote container is missing:
+#
+#   1. The service-account key. The environment holds it as GCP_KEY_B64 and
+#      points GOOGLE_APPLICATION_CREDENTIALS at /tmp/gcp-key.json, but nothing
+#      decodes one into the other. On 2026-08-15 the target existed and was
+#      zero bytes, which surfaces as an ADC error several steps into a
+#      post-mortem rather than as anything that names the cause.
+#
+#   2. The gcloud CLI. docs/debug-artifact-access.md used to say installing it
+#      was impossible here because the egress policy refuses dl.google.com. It
+#      refuses dl.google.com, but that host is only a CDN in front of the
+#      cloud-sdk-release bucket, and storage.googleapis.com is reachable -
+#      it is the same host the debug artifacts come from. Pulling the tarball
+#      from the bucket directly installs a complete SDK, gsutil and bq
+#      included, with its own bundled Python.
+#
+# See docs/debug-artifact-access.md.
+
+set -uo pipefail
+
+SDK_ROOT="${GCLOUD_SDK_ROOT:-/opt/google-cloud-sdk}"
+SDK_TARBALL="https://storage.googleapis.com/cloud-sdk-release/google-cloud-cli-linux-x86_64.tar.gz"
+PROJECT="${GCP_PROJECT:-gen-lang-client-0822973627}"
+KEY_FILE="${GOOGLE_APPLICATION_CREDENTIALS:-/tmp/gcp-key.json}"
+
+log() { printf '[setup] %s\n' "$*"; }
+
+# --- 1. Credentials ----------------------------------------------------------
+# -s rather than -f: the file is pre-created empty, so "exists" is not "usable".
+if [ -s "$KEY_FILE" ]; then
+  log "credentials already present at $KEY_FILE"
+elif [ -n "${GCP_KEY_B64:-}" ]; then
+  if printf '%s' "$GCP_KEY_B64" | base64 -d > "$KEY_FILE" 2>/dev/null && [ -s "$KEY_FILE" ]; then
+    chmod 600 "$KEY_FILE"
+    log "decoded GCP_KEY_B64 -> $KEY_FILE"
+  else
+    log "WARNING: GCP_KEY_B64 did not decode; artifact and log access will fail"
+    rm -f "$KEY_FILE"
+  fi
+else
+  log "WARNING: no GCP_KEY_B64 set; artifact and log access will fail"
+fi
+
+# --- 2. The gcloud CLI -------------------------------------------------------
+if command -v gcloud > /dev/null 2>&1; then
+  log "gcloud already on PATH"
+elif [ -x "$SDK_ROOT/bin/gcloud" ]; then
+  log "gcloud already installed at $SDK_ROOT"
+else
+  log "installing the gcloud CLI from the cloud-sdk-release bucket"
+  if curl -sS --max-time 600 -o /tmp/gcloud.tar.gz "$SDK_TARBALL"; then
+    mkdir -p "$(dirname "$SDK_ROOT")"
+    tar -xzf /tmp/gcloud.tar.gz -C "$(dirname "$SDK_ROOT")" && log "unpacked to $SDK_ROOT"
+    rm -f /tmp/gcloud.tar.gz
+  else
+    log "WARNING: could not download the SDK; use scripts/fetch_debug_artifacts.py instead"
+  fi
+fi
+
+# The agent's shell does not inherit exports from this script, so putting the
+# SDK on PATH here would not survive. Symlink into a directory already on it.
+if [ -x "$SDK_ROOT/bin/gcloud" ]; then
+  for tool in gcloud gsutil bq; do
+    [ -x "$SDK_ROOT/bin/$tool" ] && ln -sf "$SDK_ROOT/bin/$tool" "/usr/local/bin/$tool"
+  done
+
+  # Every gcloud invocation otherwise tries dl.google.com for a component
+  # update check, which the egress policy refuses - slow, and it prints a
+  # traceback that reads like the command itself failed.
+  "$SDK_ROOT/bin/gcloud" config set component_manager/disable_update_check true > /dev/null 2>&1
+  "$SDK_ROOT/bin/gcloud" config set core/disable_usage_reporting true > /dev/null 2>&1
+  "$SDK_ROOT/bin/gcloud" config set project "$PROJECT" > /dev/null 2>&1
+
+  if [ -s "$KEY_FILE" ]; then
+    if "$SDK_ROOT/bin/gcloud" auth activate-service-account --key-file="$KEY_FILE" > /dev/null 2>&1; then
+      log "authenticated as $(python3 -c "import json;print(json.load(open('$KEY_FILE'))['client_email'])" 2>/dev/null)"
+    else
+      log "WARNING: could not activate the service account"
+    fi
+  fi
+fi
+
+# --- 3. The venv -------------------------------------------------------------
+# fetch_debug_artifacts.py needs google.auth + httpx, and the classifier needs
+# the app package. Both come from the project venv, which starts empty.
+if command -v poetry > /dev/null 2>&1; then
+  if poetry run python -c "import google.auth, httpx" > /dev/null 2>&1; then
+    log "python dependencies already installed"
+  else
+    log "installing python dependencies (this takes a few minutes on a cold container)"
+    poetry install --no-root --no-interaction > /dev/null 2>&1 \
+      && log "dependencies installed" \
+      || log "WARNING: poetry install failed; run it by hand"
+  fi
+fi
+
+log "done - verify with: gcloud storage ls gs://${PROJECT}-teetime-debug-artifacts/walden/race/"
+exit 0

--- a/scripts/setup_remote_env.sh
+++ b/scripts/setup_remote_env.sh
@@ -37,7 +37,15 @@ log() { printf '[setup] %s\n' "$*"; }
 if [ -s "$KEY_FILE" ]; then
   log "credentials already present at $KEY_FILE"
 elif [ -n "${GCP_KEY_B64:-}" ]; then
-  if printf '%s' "$GCP_KEY_B64" | base64 -d > "$KEY_FILE" 2>/dev/null && [ -s "$KEY_FILE" ]; then
+  # umask in a subshell, not chmod afterwards. A redirect creates a *new* file
+  # under the caller's umask - 0644 by default - so `> key; chmod 600 key`
+  # leaves a private key world-readable for the width of the decode. It does
+  # not show up in the environment this was written for, because there the
+  # file is pre-created 0600 and a redirect onto an existing file keeps its
+  # mode; it appears the moment GOOGLE_APPLICATION_CREDENTIALS points
+  # somewhere new. The chmod stays for that pre-existing case, where the mode
+  # is whatever someone else set.
+  if (umask 077; printf '%s' "$GCP_KEY_B64" | base64 -d > "$KEY_FILE") 2>/dev/null && [ -s "$KEY_FILE" ]; then
     chmod 600 "$KEY_FILE"
     log "decoded GCP_KEY_B64 -> $KEY_FILE"
   else

--- a/scripts/setup_remote_env.sh
+++ b/scripts/setup_remote_env.sh
@@ -26,7 +26,26 @@
 set -uo pipefail
 
 SDK_ROOT="${GCLOUD_SDK_ROOT:-/opt/google-cloud-sdk}"
-SDK_TARBALL="https://storage.googleapis.com/cloud-sdk-release/google-cloud-cli-linux-x86_64.tar.gz"
+
+# Pinned rather than the rolling google-cloud-cli-linux-x86_64.tar.gz, because
+# this script runs unattended, installs executables under /opt and links them
+# into /usr/local/bin. TLS authenticates the host, not the object: on the
+# rolling URL the bytes can change under a URL that never does, and nothing
+# here would notice. A pinned version plus a recorded digest turns that into a
+# loud failure.
+#
+# The digest was taken from the versioned archive and cross-checked three ways
+# before being recorded: the download's size and MD5 match what the GCS JSON
+# API reports for the object server-side, and the extracted tree reports
+# "Google Cloud SDK 580.0.0". That establishes the bytes are the object Google
+# is serving; the value's job from here is to detect it ever changing.
+#
+# The cost is explicit upgrades. To move: bump SDK_VERSION, download the new
+# archive, verify it the same way, and record its sha256 in one reviewed
+# change. Nothing auto-updates it.
+SDK_VERSION="${GCLOUD_SDK_VERSION:-580.0.0}"
+SDK_TARBALL="https://storage.googleapis.com/cloud-sdk-release/google-cloud-cli-${SDK_VERSION}-linux-x86_64.tar.gz"
+SDK_SHA256="${GCLOUD_SDK_SHA256:-e580c04b45dfa2e537b8dc0cf7c828e46a65bc77ef61de69161e1f3a124d7480}"
 PROJECT="${GCP_PROJECT:-gen-lang-client-0822973627}"
 KEY_FILE="${GOOGLE_APPLICATION_CREDENTIALS:-/tmp/gcp-key.json}"
 
@@ -62,13 +81,28 @@ if command -v gcloud > /dev/null 2>&1; then
 elif [ -x "$SDK_ROOT/bin/gcloud" ]; then
   log "gcloud already installed at $SDK_ROOT"
 else
-  log "installing the gcloud CLI from the cloud-sdk-release bucket"
-  if curl -sS --max-time 600 -o /tmp/gcloud.tar.gz "$SDK_TARBALL"; then
-    mkdir -p "$(dirname "$SDK_ROOT")"
-    tar -xzf /tmp/gcloud.tar.gz -C "$(dirname "$SDK_ROOT")" && log "unpacked to $SDK_ROOT"
+  log "installing the gcloud CLI $SDK_VERSION from the cloud-sdk-release bucket"
+  # --fail matters more than it looks. Without it curl writes the server's
+  # error body to the output file and still exits 0, so a proxy 403 or a
+  # renamed object lands a 200-byte XML document named gcloud.tar.gz, tar
+  # fails, and the failure is silent - which is the opposite of the degraded
+  # path this script is supposed to provide.
+  if ! curl -sS --fail --max-time 600 -o /tmp/gcloud.tar.gz "$SDK_TARBALL"; then
+    log "WARNING: could not download the SDK $SDK_VERSION; falling back to scripts/fetch_debug_artifacts.py"
+    rm -f /tmp/gcloud.tar.gz
+  elif ! printf '%s  /tmp/gcloud.tar.gz\n' "$SDK_SHA256" | sha256sum -c - > /dev/null 2>&1; then
+    log "WARNING: SDK checksum mismatch - expected $SDK_SHA256,"
+    log "         got $(sha256sum /tmp/gcloud.tar.gz 2>/dev/null | cut -d' ' -f1). NOT installing."
+    log "         If Google published a new $SDK_VERSION build, verify it and update SDK_SHA256."
     rm -f /tmp/gcloud.tar.gz
   else
-    log "WARNING: could not download the SDK; use scripts/fetch_debug_artifacts.py instead"
+    mkdir -p "$(dirname "$SDK_ROOT")"
+    if tar -xzf /tmp/gcloud.tar.gz -C "$(dirname "$SDK_ROOT")"; then
+      log "verified and unpacked to $SDK_ROOT"
+    else
+      log "WARNING: SDK archive downloaded and verified but would not extract"
+    fi
+    rm -f /tmp/gcloud.tar.gz
   fi
 fi
 


### PR DESCRIPTION
Ran the `booking-postmortem` skill end to end in a Claude Code on the web session to see whether it works there. It did not — every command it gives goes through `gcloud`, which the container does not have. This fixes that and corrects two things the skill got wrong, both found by running it against real artifacts rather than by reading it.

## gcloud does install here

`docs/debug-artifact-access.md` concluded it could not, because the egress policy refuses `dl.google.com`. It does refuse it, and `packages.cloud.google.com` too — but `dl.google.com` is a CDN in front of the `cloud-sdk-release` GCS bucket, and `storage.googleapis.com` is reachable, being the same host the debug artifacts come from. Pulling the tarball out of the bucket installs a complete SDK, `gsutil` and `bq` included, with its own bundled Python. Cold install to a working `gcloud logging read` is about 16 seconds.

`scripts/setup_remote_env.sh` (new) does that, decodes the key, and installs the venv. Idempotent; point the environment's setup-script setting at it.

The key needed decoding at all because setting `GCP_KEY_B64` and `GOOGLE_APPLICATION_CREDENTIALS` is not sufficient on its own — nothing writes one into the other. `/tmp/gcp-key.json` existed and was **zero bytes**, so a test for the file's existence passed while every read failed with an ADC error that named nothing. Test `-s`, not `-f`.

## Two skill corrections

**The §5 classifier recipe silently misreports the new artifacts.** `attempt_NN_*.xml` are the raw `<partial-response>` envelope, and the classifier reads the re-rendered form inside its CDATA. Hand it the envelope and a refusal comes back `unknown` — a wrong answer that reads like a finding. Going through `parse_partial_response` first reproduces both of 08-15's verdicts exactly.

**"No `.show()` anywhere in the payload" was true of what had been saved, not of what the club sent** — the parser dropped `<eval>` before 08-12. 08-15's refusal carried `PF('teeSheetValidationErrorPopupVar').show()`, so the popup on a refusal is genuinely displayed to the member, and `evalText` is a second, independent read on the verdict. The popup's *markup* still is not one, and it is not universal either: the evening ad-hoc booking was accepted with `popupPresent=False`, so its absence carries no information either.

## §7a is no longer open

08-15 refused at −60ms with the club's own `Date` header inside the 06:30:00 second, and accepted at +1240ms inside 06:30:01. That is the boundary reading rather than the clock one, and is what #150 acted on. Recorded here with the caveat that the `Date` header is whole-second resolution (`walden_http.py` multiplies seconds by 1000), so `serverMsPastWindow` is a ±1s figure — precise enough to say which second the club was in, and nothing finer.

## Smaller things

- `gcloud run revisions list` fails for this service account (`run.revisions.list` denied). That is an IAM gap, not a tooling one; `roles/run.viewer` would close it. Meanwhile the logs name the revision in `resource.labels.revision_name` — `teetime-00063-779` served 08-15.
- Ad-hoc bookings write race ledgers into the same bucket as the 06:30 run, so a date often has two directories. They are granted at whatever offset they are sent at (08-14's evening run at −25ms), so they must not be read as evidence about the boundary.
- §3's `RESERVATION_CHECK` note now says what its *absence* means either side of #150.

## Testing

- `tests/test_reserve_verdict.py` — 22 passed, unchanged (docs and a script only; no application code touched).
- `scripts/setup_remote_env.sh` verified on both paths: warm re-run, and cold after `rm -rf /opt/google-cloud-sdk`. Post-install `gcloud storage ls` and `gcloud logging read` both work against the project, and `gcloud` resolves on `PATH` in a fresh shell with no export.
- The whole skill was then re-run against the 08-15 evening ad-hoc booking, which it read cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnCr6eTgAReKmHtGFyGurB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded booking postmortem guidance for remote setup, credential validation, log retrieval, reservation verification, and response classification.
  * Documented timing behavior and updated booking ladder and clock-probe guidance.
  * Added instructions for installing and configuring Google Cloud CLI access, verifying storage access, and handling fresh-environment dependencies.

* **New Features**
  * Added an automated remote-environment setup process with credential validation, Cloud CLI installation, authentication, dependency setup, and artifact verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->