### PR TITLE
fix: name the package Poetry installs for the root project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 description = "Golf tee time reservation application with SMS interface and LLM-powered natural language understanding"
 authors = ["Devin AI <devin@cognition.ai>"]
 readme = "README.md"
+# The project is named teetime but the code lives in app/, so Poetry has no
+# package to install for the root project. Poetry 1.7.1 - what the Dockerfile
+# and CI pin - treats that as a warning and exits 0, which is the only reason
+# `poetry install` in the CI "Install project" step passes today. Poetry 1.8+
+# makes it a hard error, so without this line CI turns red on every PR the
+# moment the pin moves, with a message about packaging rather than the bump.
+# Naming the real package fixes it on both: verified exit 0 on 1.7.1 and 2.3.3.
+packages = [{ include = "app" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
One line in `pyproject.toml`. `pyproject` declares the project as `teetime`, but the code lives in `app/` and there is no `teetime/` directory, so Poetry has no package to install for the root project.

## Why this is latent rather than harmless

CI's "Install project" step runs a bare `poetry install`. It passes today **only** because the pinned Poetry 1.7.1 treats the missing package as a warning:

| | `poetry install` exit |
|---|---|
| Poetry 1.7.1 (Dockerfile + CI pin) | **0** — warning only |
| Poetry 2.3.3 (the dev container ships this) | **1** — hard error |

So the moment the pin moves, CI turns red on every PR — and the error talks about packaging, not about the bump that caused it. That is an unpleasant thing to debug from a failing unrelated PR, which is roughly how it surfaced here.

## Why `packages` and not `package-mode = false`

`package-mode = false` is what Poetry 2.x's own error message suggests, but it is a 1.8+ key and **1.7.1 rejects the file outright** with `The Poetry configuration is invalid`. It cannot land before a version bump. Naming the real package works on both, so this is safe to merge now and still correct afterwards.

## Verification

- `poetry install` exits **0** on 2.3.3, where it exited 1 on this tree before.
- `poetry check` passes on a clean **1.7.1** install — the version CI actually uses.
- `import app` still resolves to `/home/user/teetime/app/__init__.py`, the working tree, not a copy in `site-packages`. This was the one risk worth checking: the root project installs editable, so tests are not at risk of importing a stale copy.
- Full suite unchanged: **921 passed, 10 skipped**.
- `ruff format --check`: 54 files already formatted.

Production is untouched — the Dockerfile installs with `--no-root --only main`, so the root project is never installed there. This only affects `poetry install` in CI and in a dev environment.

Found while setting up a remote session for #151; kept separate so that PR's diff stays docs-and-tooling only. The underlying version-pin question (1.7.1 dates from 2023) is filed separately rather than decided here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnCr6eTgAReKmHtGFyGurB)_