### PR TITLE
fix: report why a cold remote setup failed, and correct the ladder in the skill

### DIFF
--- a/.claude/skills/booking-postmortem/SKILL.md
+++ b/.claude/skills/booking-postmortem/SKILL.md
@@ -173,7 +173,7 @@ The run has a fixed shape. Walk it and note where it diverges:
 | Clock | `Clock skew measured` | probes, transitions, offset, one-way |
 | Lead | `Reserve will be sent Nms early` | Should be tens of ms, not hundreds |
 | Fire | `Firing Reserve k/N ... Nms past the window` | Attempt 1 should land on the first rung — **≈ +1030ms** since #150, not ≈ 0ms |
-| Each answer | `Reserve k -> <verdict>` | Verdict, club clock, bytes, sheet rows, form slot |
+| Each answer | `Reserve k -> <verdict>` | Verdict, club clock, bytes, sheet rows, form slot, and **`round trip`** against the 3.0s budget (§7b) |
 | Boundary | `RACE_LEDGER: club granted ... at +Nms` | Which rung won, and the last that lost |
 | Outcome | `Chain finished - phase=..., success=..., blocked=...` | Phase says how far it got |
 
@@ -399,10 +399,21 @@ the split holds across every morning on record: refused at −60, −14, −7, 0
 812, 817; granted at 1239, 1240, 1291. The sheet opens at 06:30:01, so every
 first Reserve ever sent at ~0ms was spent on a certain no.
 
-#150 acted on this: the first rung is now 1030ms rather than 0, the ladder is
-`1030,1250,2000,3000,4500`, the precision wait sleeps to the first rung rather
-than to the window, and the clock probe is budget-bounded at 5s with 20ms
-spacing so the tick is bracketed tightly enough to aim 30ms past it.
+#150 acted on this: the first rung is now 1030ms rather than 0, the precision
+wait sleeps to the first rung rather than to the window, and the clock probe is
+budget-bounded at 5s with 20ms spacing so the tick is bracketed tightly enough
+to aim 30ms past it.
+
+The ladder itself is configured as offsets past that **aim point**, not past the
+stated window: `walden_reserve_sweep_offsets_ms` defaults to `0,250,1000`, which
+the staging line logs as `sweep=0+250+1000ms` and which lands at +1030, +1280 and
++2030ms in the frame the ledger reports. Read the two frames apart before calling
+a rung missed. Spacing is also a floor rather than a schedule — a rung is reached
+only once the previous answer lands, so served serially the three asks fall
+nearer +1030, +1770 and +2510ms. `walden_reserve_pipeline_opening_pair` would
+fire the first two together and is **off by default**, deliberately; a run whose
+staging line lacks `(first two pipelined)` is behaving as configured, not
+misfiring.
 
 **Read `serverMsPastWindow` as ±1s, not as a millisecond figure.** The HTTP
 `Date` header is whole-second resolution and the parser multiplies seconds by
@@ -432,6 +443,39 @@ certain no.
 What is still open is narrower: whether the 06:30:01 boundary is fixed or drifts
 morning to morning. The ladder brackets it either way, and `serverMsPastWindow`
 on the granted row records which second won.
+
+## 7b. The margin 08-16 spent, and what to watch
+
+The same 2935ms that blurred the boundary is a risk in its own right, and it is
+the one thing worth checking on every future race. `_RESERVE_TIMEOUT_S` is
+**3.0s**, so the winning Reserve came back with 65ms to spare. Round trips on
+record, from the ledgers:
+
+| morning | kind | roundTripMs |
+|---|---|---|
+| 08-13 | race | 593 |
+| 08-14 | race | 647 |
+| 08-14 | ad-hoc | 956 |
+| 08-15 | race | 741 / 754 |
+| 08-15 | ad-hoc | 942 |
+| **08-16** | **race** | **2935** |
+
+3.1x the previous worst on record and 3.9x the previous *race* worst. The
+timeout was sized at "~3.6x a quiet-day round trip" against a 593–828ms sample,
+and 08-16 is outside the sample that sized it. Note also that the club stamped
+its answer at 06:30:03 for a request sent at 06:30:01.022, so most of the delay
+was on the club's side rather than the return leg — consistent with race-morning
+load, and therefore likely to recur on exactly the mornings that matter.
+
+Had it crossed 3.0s the run would have abandoned a Reserve the club had already
+granted, and per the ladder's own rule a timeout closes the fallback list for the
+rest of the run. So the failure this nearly produced is the `success=True` /
+no-reservation class in §6 — the one that reads like a win.
+
+**So read `roundTripMs` on every race ledger, not just when the boundary is in
+question.** A second morning near 3s makes raising `_RESERVE_TIMEOUT_S` the
+cheapest fix; a single one does not, and one data point is not a trend. This
+needs no morning to test — it is a number already in the ledger.
 
 ## 8. Report
 

--- a/scripts/setup_remote_env.sh
+++ b/scripts/setup_remote_env.sh
@@ -179,12 +179,33 @@ if command -v poetry > /dev/null 2>&1; then
     have_python=yes
   else
     log "installing python dependencies (this takes a few minutes on a cold container)"
-    if poetry install --no-root --no-interaction > /dev/null 2>&1 \
-       && poetry run python -c "import google.auth, httpx" > /dev/null 2>&1; then
-      log "dependencies installed"
-      have_python=yes
-    else
-      log "WARNING: poetry install did not produce a usable venv; run it by hand"
+    # Twice, and kept rather than discarded.
+    #
+    # On 2026-08-16 the cold install failed here and the session reported
+    # PARTIAL; a plain `poetry install` run by hand immediately afterwards
+    # succeeded with one package left to fetch, which is a transient download
+    # rather than a broken lock file. One retry covers that.
+    #
+    # The output went to /dev/null, so the warning below named nothing and the
+    # cause had to be guessed - the same failure mode this script exists to fix
+    # for the key file (see the header). Keep it on disk and say where.
+    install_log="${TMPDIR:-/tmp}/poetry-install.log"
+    for attempt in 1 2; do
+      if poetry install --no-root --no-interaction > "$install_log" 2>&1 \
+         && poetry run python -c "import google.auth, httpx" > /dev/null 2>&1; then
+        log "dependencies installed"
+        have_python=yes
+        break
+      fi
+      if [ "$attempt" = 1 ]; then
+        log "poetry install failed; retrying once"
+      fi
+    done
+    if [ "$have_python" != yes ]; then
+      log "WARNING: poetry install did not produce a usable venv; see $install_log"
+      tail -n 5 "$install_log" 2>/dev/null | while IFS= read -r line; do
+        log "  | $line"
+      done
     fi
   fi
 else

--- a/scripts/setup_remote_env.sh
+++ b/scripts/setup_remote_env.sh
@@ -58,6 +58,21 @@ KEY_FILE="${GOOGLE_APPLICATION_CREDENTIALS:-/tmp/gcp-key.json}"
 
 log() { printf '[setup] %s\n' "$*"; }
 
+# Anchor to the repository root rather than trusting the caller's directory.
+#
+# The setup-script setting does not promise a working directory, and step 3
+# below runs `poetry install`, which resolves pyproject.toml from the cwd. Run
+# from anywhere else that step fails with "could not find a pyproject.toml file",
+# which reads like a broken checkout rather than the wrong directory - and the
+# summary would report PARTIAL for a reason that has nothing to do with the
+# venv. Anchoring here means the setting can be a bare path to this file.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2> /dev/null && pwd)"
+if [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/pyproject.toml" ]; then
+  cd "$REPO_ROOT" || log "WARNING: could not enter $REPO_ROOT; running from $PWD"
+else
+  log "WARNING: no pyproject.toml above this script; running from $PWD"
+fi
+
 # mktemp rather than a fixed /tmp name: these are world-writable paths and a
 # predictable one is pre-creatable as a symlink by anything else on the box.
 SCRATCH=""


### PR DESCRIPTION
Ran the 2026-08-16 post-mortem end to end from a fresh Claude Code on the web session, which was the point of the exercise. The morning itself was a clean win and needs no fix; this is what testing the path turned up.

## The run (no action needed)

One Reserve, fired at +1023ms, accepted first try, `RESERVATION_CHECK` found `08/23/2026 08:00 AM RESERVED`. Verified independently rather than taken from the log: `classify_reserve_response` on the raw envelope returns `accepted`, and every structural marker is on the accepted side of §5's table (79,247 bytes, 0 `teeTimeSlots:` rows, 0 `reserve_button`, `reservationsTable` present, `Reservation at` populated, and the eval scripts carrying `executeHoldTimeTimer('300')` with no `.show()`). No failure artifacts were written anywhere in the bucket today.

## What the session test found

**1. The cold container reported PARTIAL.** `poetry install` failed and its output went to `/dev/null`, so the warning named nothing. A plain `poetry install` by hand immediately afterwards succeeded with one package left to fetch — a transient download, not a broken lock file. Now retried once, with the output kept on disk and the last few lines echoed into the summary. The script's own header says the summary only works "if every failure is actually reported"; this step was the exception.

Both the success and failure paths were exercised — the warm re-run still reports `READY`, and a stubbed failing `poetry` produces:

```
[setup] poetry install failed; retrying once
[setup] WARNING: poetry install did not produce a usable venv; see /tmp/.../poetry-install.log
[setup]   | ConnectionError: failed to fetch aiohttp-retry (2.9.1)
```

**2. The script assumed its caller's working directory.** The venv step runs `poetry install`, which resolves `pyproject.toml` from the cwd, so invoking it by absolute path — or from a wrapper that `cd`s elsewhere first — fails every poetry call with `could not find a pyproject.toml file in / or its parents`. The summary then reports `PARTIAL` blaming the venv when the actual cause is the directory. It now anchors to its own repository root via `BASH_SOURCE`, verified by running it from `/`, where it reports `READY`.

This is what lets `docs/debug-artifact-access.md`'s instruction — point the environment's setup-script setting at `scripts/setup_remote_env.sh` — work as written, with no wrapper. A wrapper that hand-rolls the key decode before calling this script is worse than none: it writes `/tmp/gcp-key.json` under the default umask (world-readable until the following `chmod`), skips the parse-verify step, and leaves the script logging `credentials already present` so its own careful decode never runs.

**3. The skill documented a ladder that does not exist.** §7a said `1030,1250,2000,3000,4500`. The actual config is `walden_reserve_sweep_offsets_ms="0,250,1000"`, measured from the aim point rather than the stated window — landing at +1030/+1280/+2030, and nearer +1030/+1770/+2510 once served serially, since a rung is only reached after the previous answer lands. Corrected, along with a note that `walden_reserve_pipeline_opening_pair` is off by default, so a staging line lacking `(first two pipelined)` is behaving as configured rather than misfiring. This morning's run logged `sweep=0+250+1000ms`, which under the old text would have read as a discrepancy.

**4. The winning Reserve had 65ms of margin.** `roundTripMs` was 2935 against a `_RESERVE_TIMEOUT_S` of 3.0s. Round trips from every ledger on record:

| morning | kind | roundTripMs |
|---|---|---|
| 08-13 | race | 593 |
| 08-14 | race | 647 |
| 08-14 | ad-hoc | 956 |
| 08-15 | race | 741 / 754 |
| 08-15 | ad-hoc | 942 |
| **08-16** | **race** | **2935** |

3.9x the previous race worst, and outside the 593–828ms sample the timeout was sized against. The club stamped its answer at 06:30:03 for a request sent at 06:30:01.022, so most of the delay was club-side rather than the return leg — consistent with race-morning load, and so likely to recur on the mornings that matter. Had it crossed 3.0s the run would have abandoned a Reserve the club had already granted and closed the fallback list for the rest of the run, which is the `success=True` / no-reservation class that reads like a win.

Recorded as §7b rather than acted on. One data point is not a trend, and raising the timeout on a single sample trades against `_RESERVE_DEADLINE_MS` for no established reason. The check costs nothing — the number is already in the ledger — so §3's table now points at it on every run.

## Not included

The reason this session started cold at all is that the environment's setup-script setting was never pointed at `scripts/setup_remote_env.sh` — the two environment variables are set, but nothing ran the script, so the SDK and venv were missing until it was invoked by hand. That is an environment setting rather than a repository change, so it is not fixable here.

## Testing

- `tests/test_reserve_verdict.py` — 22 passed
- `bash -n` on the setup script; warm re-run reports `READY`; failure path exercised with a stubbed `poetry`; invoked from `/` by absolute path to confirm the anchoring
- Config defaults read back from `Settings.model_fields` to confirm the corrected ladder text